### PR TITLE
Fix bugs

### DIFF
--- a/solana/transaction.py
+++ b/solana/transaction.py
@@ -328,12 +328,13 @@ class Transaction:
         wire_transaction.extend(signature_count)
         # Encode signatures
         for sig_pair in self.signatures:
-            if not sig_pair.signature:
-                wire_transaction.extend(bytearray(64))
-                continue
             if len(sig_pair.signature) != SIG_LENGTH:
                 raise RuntimeError("signature has invalid length", sig_pair.signature)
-            wire_transaction.extend(sig_pair.signature)
+
+            if not sig_pair.signature:
+                wire_transaction.extend(bytearray(SIG_LENGTH))
+            else:
+                wire_transaction.extend(sig_pair.signature)
         # Encode signed data
         wire_transaction.extend(signed_data)
 

--- a/solana/transaction.py
+++ b/solana/transaction.py
@@ -327,7 +327,7 @@ class Transaction:
         wire_transaction.extend(signature_count)
         # Encode signatures
         for sig_pair in self.signatures:
-            if len(sig_pair.signature) != SIG_LENGTH:
+            if sig_pair.signature and len(sig_pair.signature) != SIG_LENGTH:
                 raise RuntimeError("signature has invalid length", sig_pair.signature)
 
             if not sig_pair.signature:

--- a/solana/transaction.py
+++ b/solana/transaction.py
@@ -162,7 +162,8 @@ class Transaction:
             pubkey = str(a_m.pubkey)
             if pubkey in seen:
                 idx = seen[pubkey]
-                uniq_metas[idx].is_writable = uniq_metas[idx].is_writable or a_m.is_writable
+                # uniq_metas[idx].is_writable = uniq_metas[idx].is_writable or a_m.is_writable
+                uniq_metas[idx].is_writable = a_m.is_writable
             else:
                 uniq_metas.append(a_m)
                 seen[pubkey] = len(uniq_metas) - 1
@@ -266,7 +267,7 @@ class Transaction:
         if len(signature) != SIG_LENGTH:
             raise ValueError("signature has invalid length", signature)
         idx = next((i for i, sig_pair in enumerate(self.signatures) if sig_pair.pubkey == pubkey), None)
-        if not idx:
+        if idx is None:
             raise ValueError("unknown signer: ", str(pubkey))
         self.signatures[idx].signature = signature
 
@@ -328,6 +329,7 @@ class Transaction:
         # Encode signatures
         for sig_pair in self.signatures:
             if not sig_pair.signature:
+                wire_transaction.extend(bytearray(64))
                 continue
             if len(sig_pair.signature) != SIG_LENGTH:
                 raise RuntimeError("signature has invalid length", sig_pair.signature)

--- a/solana/transaction.py
+++ b/solana/transaction.py
@@ -162,8 +162,7 @@ class Transaction:
             pubkey = str(a_m.pubkey)
             if pubkey in seen:
                 idx = seen[pubkey]
-                # uniq_metas[idx].is_writable = uniq_metas[idx].is_writable or a_m.is_writable
-                uniq_metas[idx].is_writable = a_m.is_writable
+                uniq_metas[idx].is_writable = uniq_metas[idx].is_writable or a_m.is_writable
             else:
                 uniq_metas.append(a_m)
                 seen[pubkey] = len(uniq_metas) - 1


### PR DESCRIPTION
fix #49 
This is how I fix my issue when I am communicating between solana/web3.js and solana.py. Since I am not familiar about python this should not be a good PR, just want to leave some note if anyone needs it.

`wire_transaction.extend(bytearray(64))` solana/web3.js will have that bytearray(64) even when signature is null.

`if idx is None:` fix bug when idx is 0

`uniq_metas[idx].is_writable = a_m.is_writable` I don't know if this is a good fix or not. Some account will be mark as is_writable by line144 when it is not.