### PR TITLE
Fix: replace broken link to Solana docs with new link

### DIFF
--- a/solana/__init__.py
+++ b/solana/__init__.py
@@ -28,5 +28,7 @@ API Client:
     http_client = Client("https://devnet.solana.com")
 
 """  # pylint: disable=line-too-long # noqa: E501
+import sys
+
 if sys.version_info < (3, 7):
     raise EnvironmentError("Python 3.7 or above is required.")

--- a/solana/__init__.py
+++ b/solana/__init__.py
@@ -1,4 +1,4 @@
-"""Solana.py is the Python API for interfacing with the `Solana JSON RPC <https://docs.solana.com/developing/clients/jsonrpc-api/>`_. # noqa: D400, D415, E501 # pylint: disable=line-too-long
+"""Solana.py is the Python API for interfacing with the `Solana JSON RPC <https://docs.solana.com/developing/clients/jsonrpc-api/>`_. # noqa: E501 # pylint: disable=line-too-long
 
 Installation
 ------------

--- a/solana/__init__.py
+++ b/solana/__init__.py
@@ -1,4 +1,4 @@
-"""Solana.py is the Python API for interfacing with the `Solana JSON RPC <https://docs.solana.com/developing/clients/jsonrpc-api/>`_. # noqa: E501 # pylint: disable=line-too-long
+"""Solana.py is the Python API for interfacing with the `Solana JSON RPC <https://docs.solana.com/developing/clients/jsonrpc-api/>`_. # noqa: D400, D415, E501 # pylint: disable=line-too-long
 
 Installation
 ------------

--- a/solana/__init__.py
+++ b/solana/__init__.py
@@ -1,4 +1,4 @@
-"""Solana.py is the Python API for interfacing with the `Solana JSON RPC <https://docs.solana.com/apps/jsonrpc-api/>`_.
+"""Solana.py is the Python API for interfacing with the `Solana JSON RPC <https://docs.solana.com/developing/clients/jsonrpc-api/>`_. # noqa: E501 # pylint: disable=line-too-long
 
 Installation
 ------------

--- a/solana/__init__.py
+++ b/solana/__init__.py
@@ -1,4 +1,4 @@
-"""Solana.py is the Python API for interfacing with the `Solana JSON RPC <https://docs.solana.com/developing/clients/jsonrpc-api/>`_. # noqa: E501 # pylint: disable=line-too-long
+"""Solana.py is the Python API for interfacing with the `Solana JSON RPC <https://docs.solana.com/developing/clients/jsonrpc-api/>`_.
 
 Installation
 ------------
@@ -27,8 +27,6 @@ API Client:
 
     http_client = Client("https://devnet.solana.com")
 
-"""
-import sys
-
+"""  # pylint: disable=line-too-long # noqa: E501
 if sys.version_info < (3, 7):
     raise EnvironmentError("Python 3.7 or above is required.")


### PR DESCRIPTION
Quick fix for the first line of the [docs](https://michaelhly.github.io/solana-py/) of this library