### PR TITLE
A valid instruction can contain no keys

### DIFF
--- a/solana/transaction.py
+++ b/solana/transaction.py
@@ -132,7 +132,7 @@ class Transaction:
 
         account_metas, program_ids = [], set()
         for instr in self.instructions:
-            if not instr.program_id or not instr.keys:
+            if not instr.program_id:
                 raise AttributeError("invalid instruction:", instr)
             account_metas.extend(instr.keys)
             program_ids.add(str(instr.program_id))


### PR DESCRIPTION
I'm working on an anchor-py library and running into an issue with this line that is different than the web3-js equivalent method on the basic-0 example.

solana-web3.js equivalent: https://github.com/solana-labs/solana-web3.js/blob/62513cdee2ca0c4f350e811a982ca13731201a9f/src/transaction.ts#L231

Context:
https://project-serum.github.io/anchor/tutorials/tutorial-0.html#building-and-emitting-an-idl
