### PR TITLE
Add missing commission field in test_send_transaction_and_get_balance

### DIFF
--- a/tests/integration/test_http_client.py
+++ b/tests/integration/test_http_client.py
@@ -61,6 +61,7 @@ def test_send_transaction_and_get_balance(stubbed_sender, stubbed_reciever, test
         "preTokenBalances": [],
         "rewards": [
             {
+                "commission": None,
                 "lamports": -46,
                 "postBalance": 954,
                 "pubkey": "J3dxNj7nDRRqRRXuEMynDG57DkZK4jYRuv3Garmb1i99",


### PR DESCRIPTION
The dict inside `expected_meta["rewards"]` is missing `"commission": None`, causing `test_send_transaction_and_get_balance` to fail. This fixes that