### PR TITLE
Packaging fixes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.1
+current_version = 0.11.2
 commit = True
 tag = True
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,7 @@ jobs:
           pipenv run black --check --diff --line-length=120 setup.py solana spl tests
           pipenv run pydocstyle setup.py solana spl/**/*.py tests
           pipenv run flake8 setup.py solana spl tests
-          pipenv run mypy solana
-          pipenv run mypy --namespace-packages --explicit-package-bases spl
+          pipenv run mypy solana spl
           pipenv run pylint --rcfile=.pylintrc setup.py solana spl tests
 
       - name: Run unit tests

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ format:
 lint:
 	pipenv run pydocstyle setup.py solana spl/**/*.py test
 	pipenv run flake8 setup.py solana spl tests
-	pipenv run mypy solana
-	pipenv run mypy --namespace-packages --explicit-package-bases spl
+	pipenv run mypy solana spl
 	pipenv run pylint --rcfile=.pylintrc setup.py solana spl tests
 
 .PHONY: notebook

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "solana.py"
 copyright = "2020, Michael Huang"
 # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.4
-version = "0.11.1"
+version = "0.11.2"
 author = "Michael Huang"
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 """setuptools module for solana.py."""
 
-from setuptools import find_namespace_packages, setup
+from setuptools import find_packages, setup
 
 extras_require = {
     "dev": [
@@ -33,7 +33,6 @@ setup(
     license_files=("LICENSE",),
     long_description=README_MD,
     long_description_content_type="text/markdown",
-    include_package_data=True,
     install_requires=[
         "base58>=2.0.1, <3.0.0",
         "construct>=2.10.56, <3.0.0",
@@ -46,8 +45,8 @@ setup(
     python_requires=">=3.7, <4",
     keywords="solana blockchain web3",
     license="MIT",
-    package_data={"solana": ["py.typed"]},
-    packages=find_namespace_packages(exclude=["tests", "tests.*"]),
+    package_data={"solana": ["py.typed"], "spl": ["py.typed"]},
+    packages=find_packages(exclude=["tests"]),
     url="https://github.com/michaelhly/solanapy",
     zip_safe=False,  # required per mypy
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open("README.md", "r") as file_handle:
 setup(
     name="solana",
     # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
-    version="0.11.1",
+    version="0.11.2",
     author="Michael Huang",
     author_mail="michaelhly@gmail.com",
     description="""Solana.py""",

--- a/solana/system_program.py
+++ b/solana/system_program.py
@@ -362,10 +362,9 @@ def assign(params: Union[AssignParams, AssignWithSeedParams]) -> TransactionInst
     """
     if isinstance(params, AssignWithSeedParams):
         raise NotImplementedError("assign with key is not implemented")
-    else:
-        data = SYSTEM_INSTRUCTIONS_LAYOUT.build(
-            dict(instruction_type=InstructionType.ASSIGN, args=dict(program_id=bytes(params.program_id)))
-        )
+    data = SYSTEM_INSTRUCTIONS_LAYOUT.build(
+        dict(instruction_type=InstructionType.ASSIGN, args=dict(program_id=bytes(params.program_id)))
+    )
 
     return TransactionInstruction(
         keys=[

--- a/spl/__init__.py
+++ b/spl/__init__.py
@@ -1,0 +1,1 @@
+"""Solana Program Library packages."""

--- a/spl/token/__init__.py
+++ b/spl/token/__init__.py
@@ -1,0 +1,1 @@
+"""Client code for interacting with the SPL Token Program."""

--- a/spl/token/async_client.py
+++ b/spl/token/async_client.py
@@ -10,7 +10,7 @@ from solana.publickey import PublicKey
 from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Commitment, Confirmed
 from solana.rpc.types import RPCResponse, TxOpts
-from spl.token._layouts import ACCOUNT_LAYOUT, MINT_LAYOUT, MULTISIG_LAYOUT  # type: ignore
+from spl.token._layouts import ACCOUNT_LAYOUT, MINT_LAYOUT, MULTISIG_LAYOUT
 from spl.token.core import AccountInfo, MintInfo, _TokenCore
 
 

--- a/spl/token/client.py
+++ b/spl/token/client.py
@@ -10,7 +10,7 @@ from solana.publickey import PublicKey
 from solana.rpc.api import Client
 from solana.rpc.commitment import Commitment, Confirmed
 from solana.rpc.types import RPCResponse, TxOpts
-from spl.token._layouts import ACCOUNT_LAYOUT, MINT_LAYOUT, MULTISIG_LAYOUT  # type: ignore
+from spl.token._layouts import ACCOUNT_LAYOUT, MINT_LAYOUT, MULTISIG_LAYOUT
 from spl.token.core import AccountInfo, MintInfo, _TokenCore
 
 

--- a/spl/token/core.py
+++ b/spl/token/core.py
@@ -13,7 +13,7 @@ from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Commitment, Confirmed
 from solana.rpc.types import TokenAccountOpts, TxOpts
 from solana.transaction import Transaction
-from spl.token._layouts import ACCOUNT_LAYOUT, MINT_LAYOUT  # type: ignore
+from spl.token._layouts import ACCOUNT_LAYOUT, MINT_LAYOUT
 from spl.token.constants import WRAPPED_SOL_MINT
 
 if TYPE_CHECKING:

--- a/spl/token/instructions.py
+++ b/spl/token/instructions.py
@@ -8,7 +8,7 @@ from solana.system_program import SYS_PROGRAM_ID
 from solana.sysvar import SYSVAR_RENT_PUBKEY
 from solana.transaction import AccountMeta, TransactionInstruction
 from solana.utils.validate import validate_instruction_keys, validate_instruction_type
-from spl.token._layouts import INSTRUCTIONS_LAYOUT, InstructionType  # type: ignore
+from spl.token._layouts import INSTRUCTIONS_LAYOUT, InstructionType
 from spl.token.constants import ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID
 
 

--- a/tests/integration/test_async_token_client.py
+++ b/tests/integration/test_async_token_client.py
@@ -1,3 +1,4 @@
+# pylint: disable=R0401
 """Tests for the SPL Token Client."""
 import pytest
 

--- a/tests/integration/test_token_client.py
+++ b/tests/integration/test_token_client.py
@@ -1,3 +1,4 @@
+# pylint: disable=R0401
 """Tests for the SPL Token Client."""
 import pytest
 


### PR DESCRIPTION
Fixes the fact that the type hints don't actually work when you install the package.

Changes:

- Makes `spl` a regular package instead of a namespace package
- Gives `spl` a `py.typed` file.
- Removes `include_package_data=True` in setup.py, which makes `py.typed` not work because setuptools is weird https://stackoverflow.com/a/13783919

I've tried this out with TestPyPI and the type hints now work properly.