### PR TITLE
Add get_multiple_accounts and clean up docs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.0
+current_version = 0.14.0
 commit = True
 tag = True
 

--- a/Pipfile
+++ b/Pipfile
@@ -30,6 +30,7 @@ types-requests = "*"
 notebook = "*"
 pytest-asyncio = "*"
 pytest-cov = "*"
+sphinx-rtd-theme = "*"
 
 [packages]
 pynacl = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "842bc919c22935fd509bd23de139dce091d7f92e66061ac746b629d78dafaa28"
+            "sha256": "5ecc952d753759940eeac5a769c8e6495a7b2006b2f01a0d7b6cfec37807ef59"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -499,6 +499,7 @@
                 "sha256:21ca464b3a4b8d8e86ba0ee5045e103a1fcfac3b39319727bc0fc58c09c6aff7",
                 "sha256:34dae04a0dce5730d8eb7894eab617d8a70d0c97da76b905de9efb7128ad7085",
                 "sha256:3520667fda779eb788ea00080124875be18f2d8f0848ec00733c0ec3bb8219fc",
+                "sha256:3c4129fc3fdc0fa8e40861b5ac0c673315b3c902bbdc05fc176764815b43dd1d",
                 "sha256:3fa3a7ccf96e826affdf1a0a9432be74dc73423125c8f96a909e3835a5ef194a",
                 "sha256:5b0fbfae7ff7febdb74b574055c7466da334a5371f253732d7e2e7525d570498",
                 "sha256:695104a9223a7239d155d7627ad912953b540929ef97ae0c34c7b8bf30857e89",
@@ -1446,6 +1447,14 @@
             "index": "pypi",
             "version": "==4.2.0"
         },
+        "sphinx-rtd-theme": {
+            "hashes": [
+                "sha256:4d35a56f4508cfee4c4fb604373ede6feae2a306731d533f409ef5c3496fdbd8",
+                "sha256:eec6d497e4c2195fa0e8b2016b337532b8a699a68bcb22a512870e16925c6a5c"
+            ],
+            "index": "pypi",
+            "version": "==1.0.0"
+        },
         "sphinxcontrib-applehelp": {
             "hashes": [
                 "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a",
@@ -1582,11 +1591,11 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:80aead664e6c1672c4ae20dc50e1cdc5e20eeff9b14aa23ecd426375b28be588",
-                "sha256:a4d6d112e507ef98513ac119ead1159d286deab17dffedd96921412c2d236ff5"
+                "sha256:8dd278a422499cd6b727e6ae4061c40b48fce8b76d1ccbf5d34fca9b7f925b0c",
+                "sha256:d359de7217506c9851b7869f3708d8ee53ed70a1b8edbba4dbcb47442592920d"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==4.62.2"
+            "version": "==4.62.3"
         },
         "traitlets": {
             "hashes": [
@@ -1642,11 +1651,11 @@
         },
         "types-requests": {
             "hashes": [
-                "sha256:a5a305b43ea57bf64d6731f89816946a405b591eff6de28d4c0fd58422cee779",
-                "sha256:e21541c0f55c066c491a639309159556dd8c5833e49fcde929c4c47bdb0002ee"
+                "sha256:24bbe4682373ce0b1927f432b30ba1dcf46b66512fb6e848e72998c79797d040",
+                "sha256:4b279513a34b789bef75ce05bee5eb4ce934a892318388400f7511fbcdf56f87"
             ],
             "index": "pypi",
-            "version": "==2.25.6"
+            "version": "==2.25.7"
         },
         "typing-extensions": {
             "hashes": [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "alabaster"
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "solana.py"
 copyright = "2020, Michael Huang"
 # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.4
-version = "0.13.0"
+version = "0.14.0"
 author = "Michael Huang"
 
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open("README.md", "r") as file_handle:
 setup(
     name="solana",
     # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
-    version="0.13.0",
+    version="0.14.0",
     author="Michael Huang",
     author_mail="michaelhly@gmail.com",
     description="""Solana.py""",

--- a/solana/blockhash.py
+++ b/solana/blockhash.py
@@ -12,16 +12,13 @@ Blockhash = NewType("Blockhash", str)
 
 
 class BlockhashCache:
-    """A recent blockhash cache that expires after a given number of seconds."""
+    """A recent blockhash cache that expires after a given number of seconds.
+
+    :param ttl: Seconds until cached blockhash expires.
+    """
 
     def __init__(self, ttl: int = 60) -> None:
-        """Instantiate the cache (you only need to do this once).
-
-        Args:
-        ----
-            ttl (int): Seconds until cached blockhash expires.
-
-        """
+        """Instantiate the cache (you only need to do this once)."""
         maxsize = 300
         self.unused_blockhashes: TTLCache = TTLCache(maxsize=maxsize, ttl=ttl)
         self.used_blockhashes: TTLCache = TTLCache(maxsize=maxsize, ttl=ttl)
@@ -29,10 +26,9 @@ class BlockhashCache:
     def set(self, blockhash: Blockhash, slot: int) -> None:
         """Update the cache.
 
-        Args:
-        ----
-            blockhash (Blockhash): new Blockhash value.
-            slot (int): the slot which the blockhash came from
+        :param blockhash: new Blockhash value.
+        :param slot: the slot which the blockhash came from
+
 
         """
         if slot in self.used_blockhashes or slot in self.unused_blockhashes:
@@ -42,9 +38,7 @@ class BlockhashCache:
     def get(self) -> Blockhash:
         """Get the cached Blockhash. Raises KeyError if cache has expired.
 
-        Returns
-        -------
-            Blockhash: cached Blockhash.
+        :return: cached Blockhash.
 
         """
         try:

--- a/solana/rpc/api.py
+++ b/solana/rpc/api.py
@@ -104,7 +104,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
 
             - "base58" is limited to Account data of less than 128 bytes.
             - "base64" will return base64 encoded data for Account data of any size.
-            - "jsonPrased" encoding attempts to use program-specific state parsers to return more human-readable and explicit account state data.
+            - "jsonParsed" encoding attempts to use program-specific state parsers to return more human-readable and explicit account state data.
 
             If jsonParsed is requested but a parser cannot be found, the field falls back to base64 encoding,
             detectable when the data field is type. (jsonParsed encoding is UNSTABLE).

--- a/solana/rpc/api.py
+++ b/solana/rpc/api.py
@@ -598,6 +598,62 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         args = self._get_minimum_balance_for_rent_exemption_args(usize, commitment)
         return self._provider.make_request(*args)
 
+    def get_multiple_accounts(
+        self,
+        pubkeys: List[Union[PublicKey, str]],
+        commitment: Optional[Commitment] = None,
+        encoding: str = "base64",
+        data_slice: Optional[types.DataSliceOpts] = None,
+    ) -> types.RPCResponse:
+        """Returns all the account info for a list of public keys.
+
+        :param pubkeys: list of Pubkeys to query, as base-58 encoded string or PublicKey object.
+        :param commitment: Bank state to query. It can be either "finalized", "confirmed" or "processed".
+        :param encoding: (optional) Encoding for Account data, either "base58" (slow), "base64", or
+            "jsonParsed". Default is "base64".
+
+            - "base58" is limited to Account data of less than 128 bytes.
+            - "base64" will return base64 encoded data for Account data of any size.
+            - "jsonParsed" encoding attempts to use program-specific state parsers to return more human-readable and explicit account state data.
+
+            If jsonParsed is requested but a parser cannot be found, the field falls back to base64 encoding,
+            detectable when the data field is type. (jsonParsed encoding is UNSTABLE).
+        :param data_slice: (optional) Option to limit the returned account data using the provided `offset`: <usize> and
+            `length`: <usize> fields; only available for "base58" or "base64" encoding.
+
+        >>> from solana.publickey import PublicKey
+        >>> solana_client = Client("http://localhost:8899")
+        >>> pubkeys = [PublicKey("6ZWcsUiWJ63awprYmbZgBQSreqYZ4s6opowP4b7boUdh"), PublicKey("HkcE9sqQAnjJtECiFsqGMNmUho3ptXkapUPAqgZQbBSY")]
+        >>> solana_client.get_multiple_accounts(pubkeys) # doctest: +SKIP
+        {
+            "jsonrpc": "2.0",
+            "result": {
+                "context": {"slot": 97531946},
+                "value": [
+                    {
+                        "data": ["", "base64"],
+                        "executable": False,
+                        "lamports": 1,
+                        "owner": "11111111111111111111111111111111",
+                        "rentEpoch": 225,
+                    },
+                    {
+                        "data": ["", "base64"],
+                        "executable": False,
+                        "lamports": 809441127,
+                        "owner": "11111111111111111111111111111111",
+                        "rentEpoch": 225,
+                    },
+                ],
+            },
+            "id": 1,
+        }
+        """  # noqa: E501 # pylint: disable=line-too-long
+        args = self._get_multiple_accounts_args(
+            pubkeys=pubkeys, commitment=commitment, encoding=encoding, data_slice=data_slice
+        )
+        return self._provider.make_request(*args)
+
     def get_program_accounts(  # pylint: disable=too-many-arguments
         self,
         pubkey: Union[str, PublicKey],

--- a/solana/rpc/api.py
+++ b/solana/rpc/api.py
@@ -32,7 +32,28 @@ def MemcmpOpt(*args, **kwargs) -> types.MemcmpOpts:  # pylint: disable=invalid-n
 
 
 class Client(_ClientCore):  # pylint: disable=too-many-public-methods
-    """Client class."""
+    """Client class.
+
+    :param endpoint: URL of the RPC endpoint.
+    :param commitment: Default bank state to query. It can be either "finalized", "confirmed" or "processed".
+    :param blockhash_cache: (Experimental) If True, keep a cache of recent blockhashes to make
+        ``send_transaction`` calls faster.
+        You can also pass your own BlockhashCache object to customize its parameters.
+
+        The cache works as follows:
+
+        1.  Retrieve the oldest unused cached blockhash that is younger than ``ttl`` seconds,
+            where ``ttl`` is defined in the BlockhashCache (we prefer unused blockhashes because
+            reusing blockhashes can cause errors in some edge cases, and we prefer slightly
+            older blockhashes because they're more likely to be accepted by every validator).
+        2.  If there are no unused blockhashes in the cache, take the oldest used
+            blockhash that is younger than ``ttl`` seconds.
+        3.  Fetch a new recent blockhash *after* sending the transaction. This is to keep the cache up-to-date.
+
+        If you want something tailored to your use case, run your own loop that fetches the recent blockhash,
+        and pass that value in your ``.send_transaction`` calls.
+
+    """
 
     def __init__(
         self,
@@ -40,28 +61,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         commitment: Optional[Commitment] = None,
         blockhash_cache: Union[BlockhashCache, bool] = False,
     ):
-        """Init API client.
-
-        :param endpoint: URL of the RPC endpoint.
-        :param commitment: Default bank state to query. It can be either "finalized", "confirmed" or "processed".
-        :param blockhash_cache: (Experimental) If True, keep a cache of recent blockhashes to make
-            `send_transaction` calls faster.
-            You can also pass your own BlockhashCache object to customize its parameters.
-
-            The cache works as follows:
-
-            1. Retrieve the oldest unused cached blockhash that is younger than `ttl` seconds,
-                where `ttl` is defined in the BlockhashCache
-                (we prefer unused blockhashes because reusing blockhashes can cause errors in some edge cases,
-                and we prefer slightly older blockhashes because they're more likely to be accepted by every validator).
-            2. If there are no unused blockhashes in the cache, take the oldest used
-                blockhash that is younger than `ttl` seconds.
-            3. Fetch a new recent blockhash *after* sending the transaction. This is to keep the cache up-to-date.
-
-            If you want something tailored to your use case, run your own loop that fetches the recent blockhash,
-            and pass that value in your `.send_transaction` calls.
-
-        """
+        """Init API client."""
         super().__init__(commitment, blockhash_cache)
         self._provider = http.HTTPProvider(endpoint)
 
@@ -724,9 +724,9 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
     ) -> types.RPCResponse:
         """Returns the statuses of a list of signatures.
 
-        Unless the `searchTransactionHistory` configuration parameter is included, this method only
+        Unless the ``search_transaction_history`` configuration parameter is included, this method only
         searches the recent status cache of signatures, which retains statuses for all active slots plus
-        `MAX_RECENT_BLOCKHASHES` rooted slots.
+        ``MAX_RECENT_BLOCKHASHES`` rooted slots.
 
         :param signatures: An array of transaction signatures to confirm.
         :param search_transaction_history: If true, a Solana node will search its ledger cache for

--- a/solana/rpc/async_api.py
+++ b/solana/rpc/async_api.py
@@ -101,7 +101,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
 
             - "base58" is limited to Account data of less than 128 bytes.
             - "base64" will return base64 encoded data for Account data of any size.
-            - "jsonPrased" encoding attempts to use program-specific state parsers to return more human-readable and explicit account state data.
+            - "jsonParsed" encoding attempts to use program-specific state parsers to return more human-readable and explicit account state data.
 
             If jsonParsed is requested but a parser cannot be found, the field falls back to base64 encoding,
             detectable when the data field is type. (jsonParsed encoding is UNSTABLE).

--- a/solana/rpc/async_api.py
+++ b/solana/rpc/async_api.py
@@ -14,7 +14,27 @@ from .providers import async_http
 
 
 class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
-    """Async client class."""
+    """Async client class.
+
+    :param endpoint: URL of the RPC endpoint.
+    :param commitment: Default bank state to query. It can be either "finalized", "confirmed" or "processed".
+    :param blockhash_cache: (Experimental) If True, keep a cache of recent blockhashes to make
+        ``send_transaction`` calls faster.
+        You can also pass your own BlockhashCache object to customize its parameters.
+
+        The cache works as follows:
+
+        1.  Retrieve the oldest unused cached blockhash that is younger than ``ttl`` seconds,
+            where ``ttl`` is defined in the BlockhashCache (we prefer unused blockhashes because
+            reusing blockhashes can cause errors in some edge cases, and we prefer slightly
+            older blockhashes because they're more likely to be accepted by every validator).
+        2.  If there are no unused blockhashes in the cache, take the oldest used
+            blockhash that is younger than ``ttl`` seconds.
+        3.  Fetch a new recent blockhash *after* sending the transaction. This is to keep the cache up-to-date.
+
+        If you want something tailored to your use case, run your own loop that fetches the recent blockhash,
+        and pass that value in your ``.send_transaction`` calls.
+    """
 
     def __init__(
         self,
@@ -22,28 +42,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         commitment: Optional[Commitment] = None,
         blockhash_cache: Union[BlockhashCache, bool] = False,
     ) -> None:
-        """Init API client.
-
-        :param endpoint: URL of the RPC endpoint.
-        :param commitment: Default bank state to query. It can be either "finalized", "confirmed" or "processed".
-        :param blockhash_cache: (Experimental) If True, keep a cache of recent blockhashes to make
-            `send_transaction` calls faster.
-            You can also pass your own BlockhashCache object to customize its parameters.
-
-            The cache works as follows:
-
-            1. Retrieve the oldest unused cached blockhash that is younger than `ttl` seconds,
-                where `ttl` is defined in the BlockhashCache
-                (we prefer unused blockhashes because reusing blockhashes can cause errors in some edge cases,
-                and we prefer slightly older blockhashes because they're more likely to be accepted by every validator).
-            2. If there are no unused blockhashes in the cache, take the oldest used
-                blockhash that is younger than `ttl` seconds.
-            3. Fetch a new recent blockhash *after* sending the transaction. This is to keep the cache up-to-date.
-
-            If you want something tailored to your use case, run your own loop that fetches the recent blockhash,
-            and pass that value in your `.send_transaction` calls.
-
-        """
+        """Init API client."""
         super().__init__(commitment, blockhash_cache)
         self._provider = async_http.AsyncHTTPProvider(endpoint)
 
@@ -721,9 +720,9 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
     ) -> types.RPCResponse:
         """Returns the statuses of a list of signatures.
 
-        Unless the `searchTransactionHistory` configuration parameter is included, this method only
+        Unless the ``search_transaction_history`` configuration parameter is included, this method only
         searches the recent status cache of signatures, which retains statuses for all active slots plus
-        `MAX_RECENT_BLOCKHASHES` rooted slots.
+        ``MAX_RECENT_BLOCKHASHES`` rooted slots.
 
         :param signatures: An array of transaction signatures to confirm.
         :param search_transaction_history: If true, a Solana node will search its ledger cache for

--- a/solana/rpc/async_api.py
+++ b/solana/rpc/async_api.py
@@ -595,6 +595,62 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         args = self._get_minimum_balance_for_rent_exemption_args(usize, commitment)
         return await self._provider.make_request(*args)
 
+    async def get_multiple_accounts(
+        self,
+        pubkeys: List[Union[PublicKey, str]],
+        commitment: Optional[Commitment] = None,
+        encoding: str = "base64",
+        data_slice: Optional[types.DataSliceOpts] = None,
+    ) -> types.RPCResponse:
+        """Returns all the account info for a list of public keys.
+
+        :param pubkeys: list of Pubkeys to query, as base-58 encoded string or PublicKey object.
+        :param commitment: Bank state to query. It can be either "finalized", "confirmed" or "processed".
+        :param encoding: (optional) Encoding for Account data, either "base58" (slow), "base64", or
+            "jsonParsed". Default is "base64".
+
+            - "base58" is limited to Account data of less than 128 bytes.
+            - "base64" will return base64 encoded data for Account data of any size.
+            - "jsonParsed" encoding attempts to use program-specific state parsers to return more human-readable and explicit account state data.
+
+            If jsonParsed is requested but a parser cannot be found, the field falls back to base64 encoding,
+            detectable when the data field is type. (jsonParsed encoding is UNSTABLE).
+        :param data_slice: (optional) Option to limit the returned account data using the provided `offset`: <usize> and
+            `length`: <usize> fields; only available for "base58" or "base64" encoding.
+
+        >>> from solana.publickey import PublicKey
+        >>> solana_client = AsyncClient("http://localhost:8899")
+        >>> pubkeys = [PublicKey("6ZWcsUiWJ63awprYmbZgBQSreqYZ4s6opowP4b7boUdh"), PublicKey("HkcE9sqQAnjJtECiFsqGMNmUho3ptXkapUPAqgZQbBSY")]
+        >>> asyncio.run(solana_client.get_multiple_accounts(pubkeys)) # doctest: +SKIP
+        {
+            "jsonrpc": "2.0",
+            "result": {
+                "context": {"slot": 97531946},
+                "value": [
+                    {
+                        "data": ["", "base64"],
+                        "executable": False,
+                        "lamports": 1,
+                        "owner": "11111111111111111111111111111111",
+                        "rentEpoch": 225,
+                    },
+                    {
+                        "data": ["", "base64"],
+                        "executable": False,
+                        "lamports": 809441127,
+                        "owner": "11111111111111111111111111111111",
+                        "rentEpoch": 225,
+                    },
+                ],
+            },
+            "id": 1,
+        }
+        """  # noqa: E501 # pylint: disable=line-too-long
+        args = self._get_multiple_accounts_args(
+            pubkeys=pubkeys, commitment=commitment, encoding=encoding, data_slice=data_slice
+        )
+        return await self._provider.make_request(*args)
+
     async def get_program_accounts(  # pylint: disable=too-many-arguments
         self,
         pubkey: Union[str, PublicKey],

--- a/solana/rpc/core.py
+++ b/solana/rpc/core.py
@@ -161,6 +161,18 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
             {self._comm_key: commitment or self._commitment},
         )
 
+    def _get_multiple_accounts_args(
+        self,
+        pubkeys: List[Union[PublicKey, str]],
+        commitment: Optional[Commitment],
+        encoding: str,
+        data_slice: Optional[types.DataSliceOpts],
+    ) -> Tuple[types.RPCMethod, List[str], Dict[str, Any]]:
+        opts: Dict[str, Any] = {self._encoding_key: encoding, self._comm_key: commitment or self._commitment}
+        if data_slice:
+            opts[self._data_slice_key] = dict(data_slice._asdict())
+        return types.RPCMethod("getMultipleAccounts"), [str(pubkey) for pubkey in pubkeys], opts
+
     def _get_program_accounts_args(
         self,
         pubkey: Union[str, PublicKey],

--- a/solana/transaction.py
+++ b/solana/transaction.py
@@ -30,9 +30,9 @@ class AccountMeta:
     pubkey: PublicKey
     """An account's public key."""
     is_signer: bool
-    """True if an instruction requires a transaction signature matching `pubkey`"""
+    """True if an instruction requires a transaction signature matching ``pubkey``"""
     is_writable: bool
-    """True if the `pubkey` can be loaded as a read-write account."""
+    """True if the ``pubkey`` can be loaded as a read-write account."""
 
 
 class TransactionInstruction(NamedTuple):

--- a/spl/token/async_client.py
+++ b/spl/token/async_client.py
@@ -6,11 +6,11 @@ from typing import List, Optional, Union, cast
 
 import spl.token.instructions as spl_token
 from solana.account import Account
+from solana.blockhash import Blockhash
 from solana.publickey import PublicKey
 from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Commitment, Confirmed
 from solana.rpc.types import RPCResponse, TxOpts
-from solana.blockhash import Blockhash
 from spl.token._layouts import ACCOUNT_LAYOUT, MINT_LAYOUT, MULTISIG_LAYOUT
 from spl.token.core import AccountInfo, MintInfo, _TokenCore
 

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -527,6 +527,19 @@ async def test_get_account_info(async_stubbed_sender, test_http_client_async):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_get_multiple_accounts(async_stubbed_sender, test_http_client_async):
+    """Test get_multiple_accounts."""
+    pubkeys = [async_stubbed_sender.public_key()] * 2
+    resp = await test_http_client_async.get_multiple_accounts(pubkeys)
+    assert_valid_response(resp)
+    resp = await test_http_client_async.get_multiple_accounts(pubkeys, encoding="jsonParsed")
+    assert_valid_response(resp)
+    resp = await test_http_client_async.get_multiple_accounts(pubkeys, data_slice=DataSliceOpt(1, 1))
+    assert_valid_response(resp)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_get_vote_accounts(test_http_client_async):
     """Test get vote accounts."""
     resp = await test_http_client_async.get_vote_accounts()

--- a/tests/integration/test_http_client.py
+++ b/tests/integration/test_http_client.py
@@ -472,6 +472,18 @@ def test_get_account_info(stubbed_sender, test_http_client):
 
 
 @pytest.mark.integration
+def test_get_multiple_accounts(stubbed_sender, test_http_client):
+    """Test get_multiple_accounts."""
+    pubkeys = [stubbed_sender.public_key()] * 2
+    resp = test_http_client.get_multiple_accounts(pubkeys)
+    assert_valid_response(resp)
+    resp = test_http_client.get_multiple_accounts(pubkeys, encoding="jsonParsed")
+    assert_valid_response(resp)
+    resp = test_http_client.get_multiple_accounts(pubkeys, data_slice=DataSliceOpt(1, 1))
+    assert_valid_response(resp)
+
+
+@pytest.mark.integration
 def test_get_vote_accounts(test_http_client):
     """Test get vote accounts."""
     resp = test_http_client.get_vote_accounts()


### PR DESCRIPTION
Adds support for the the `getMultipleAccounts` RPC method https://docs.solana.com/developing/clients/jsonrpc-api#getmultipleaccounts

Also cleans up docs a bit, most notably changing to the ReadTheDocs theme which is much easier to look at imo.