### PR TITLE
Added implementations for get_token_largest_accounts() and get_token_supply()

### DIFF
--- a/solana/rpc/api.py
+++ b/solana/rpc/api.py
@@ -874,12 +874,16 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         args = self._get_token_accounts_args(method, pubkey, opts, commitment)
         return self._provider.make_request(*args)
 
-    def get_token_largest_accounts(self, pubkey: Union[PublicKey, str], commitment: Optional[Commitment] = None) -> types.RPCResponse:
+    def get_token_largest_accounts(
+        self, pubkey: Union[PublicKey, str], commitment: Optional[Commitment] = None
+    ) -> types.RPCResponse:
         """Returns the 20 largest accounts of a particular SPL Token type."""
         args = self._get_token_largest_account_args(pubkey, commitment)
         return self._provider.make_request(*args)
 
-    def get_token_supply(self, pubkey: Union[PublicKey, str], commitment: Optional[Commitment] = None) -> types.RPCResponse:
+    def get_token_supply(
+        self, pubkey: Union[PublicKey, str], commitment: Optional[Commitment] = None
+    ) -> types.RPCResponse:
         """Returns the total supply of an SPL Token type."""
         args = self._get_token_supply_args(pubkey, commitment)
         return self._provider.make_request(*args)

--- a/solana/rpc/api.py
+++ b/solana/rpc/api.py
@@ -874,13 +874,15 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         args = self._get_token_accounts_args(method, pubkey, opts, commitment)
         return self._provider.make_request(*args)
 
-    def get_token_largest_accounts(self, pubkey: Union[PublicKey, str]) -> types.RPCResponse:
-        """Returns the 20 largest accounts of a particular SPL Token type (UNSTABLE)."""
-        raise NotImplementedError("get_token_largbest_accounts not implemented")
+    def get_token_largest_accounts(self, pubkey: Union[PublicKey, str], commitment: Optional[Commitment] = None) -> types.RPCResponse:
+        """Returns the 20 largest accounts of a particular SPL Token type."""
+        args = self._get_token_largest_account_args(pubkey, commitment)
+        return self._provider.make_request(*args)
 
-    def get_token_supply(self, pubkey: Union[PublicKey, str]) -> types.RPCResponse:
-        """Returns the total supply of an SPL Token type(UNSTABLE)."""
-        raise NotImplementedError("get_token_supply not implemented")
+    def get_token_supply(self, pubkey: Union[PublicKey, str], commitment: Optional[Commitment] = None) -> types.RPCResponse:
+        """Returns the total supply of an SPL Token type."""
+        args = self._get_token_supply_args(pubkey, commitment)
+        return self._provider.make_request(*args)
 
     def get_transaction_count(self, commitment: Optional[Commitment] = None) -> types.RPCResponse:
         """Returns the current Transaction count from the ledger.

--- a/solana/rpc/async_api.py
+++ b/solana/rpc/async_api.py
@@ -870,13 +870,19 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         args = self._get_token_accounts_args(method, pubkey, opts, commitment)
         return await self._provider.make_request(*args)
 
-    async def get_token_largest_accounts(self, pubkey: Union[PublicKey, str]) -> types.RPCResponse:
-        """Returns the 20 largest accounts of a particular SPL Token type (UNSTABLE)."""
-        raise NotImplementedError("get_token_largbest_accounts not implemented")
+    async def get_token_largest_accounts(
+        self, pubkey: Union[PublicKey, str], commitment: Optional[Commitment] = None
+    ) -> types.RPCResponse:
+        """Returns the 20 largest accounts of a particular SPL Token type."""
+        args = self._get_token_largest_account_args(pubkey, commitment)
+        return await self._provider.make_request(*args)
 
-    async def get_token_supply(self, pubkey: Union[PublicKey, str]) -> types.RPCResponse:
-        """Returns the total supply of an SPL Token type(UNSTABLE)."""
-        raise NotImplementedError("get_token_supply not implemented")
+    async def get_token_supply(
+        self, pubkey: Union[PublicKey, str], commitment: Optional[Commitment] = None
+    ) -> types.RPCResponse:
+        """Returns the total supply of an SPL Token type."""
+        args = self._get_token_supply_args(pubkey, commitment)
+        return await self._provider.make_request(*args)
 
     async def get_transaction_count(self, commitment: Optional[Commitment] = None) -> types.RPCResponse:
         """Returns the current Transaction count from the ledger.

--- a/solana/rpc/core.py
+++ b/solana/rpc/core.py
@@ -275,6 +275,16 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
 
         return method, pubkey, acc_opts, rpc_opts
 
+    def _get_token_largest_account_args(
+        self, pubkey: Union[str, PublicKey], commitment: Optional[Commitment]
+    ) -> Tuple[types.RPCMethod, str, Dict[str, Commitment]]:
+        return types.RPCMethod("getTokenLargestAccounts"), str(pubkey), {self._comm_key: commitment or self._commitment}
+    
+    def _get_token_supply_args(
+        self, pubkey: Union[str, PublicKey], commitment: Optional[Commitment]
+    ) -> Tuple[types.RPCMethod, str, Dict[str, Commitment]]:
+        return types.RPCMethod("getTokenSupply"), str(pubkey), {self._comm_key: commitment or self._commitment}
+
     def _get_transaction_count_args(
         self, commitment: Optional[Commitment]
     ) -> Tuple[types.RPCMethod, Dict[str, Commitment]]:

--- a/solana/rpc/core.py
+++ b/solana/rpc/core.py
@@ -279,7 +279,7 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         self, pubkey: Union[str, PublicKey], commitment: Optional[Commitment]
     ) -> Tuple[types.RPCMethod, str, Dict[str, Commitment]]:
         return types.RPCMethod("getTokenLargestAccounts"), str(pubkey), {self._comm_key: commitment or self._commitment}
-    
+
     def _get_token_supply_args(
         self, pubkey: Union[str, PublicKey], commitment: Optional[Commitment]
     ) -> Tuple[types.RPCMethod, str, Dict[str, Commitment]]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,12 @@ def async_stubbed_sender_cached_blockhash() -> Account:
 
 
 @pytest.fixture(scope="session")
+def stubbed_token_addr() -> PublicKey:
+    """An arbitrary known token address."""
+    return PublicKey("DeV3CnJsrhN5TzCZQvmuQgYn1Up8nDycqmzxZJWH9DAw")
+
+
+@pytest.fixture(scope="session")
 def freeze_authority() -> Account:
     """Arbitrary known account to be used as freeze authority."""
     return Account(bytes([6] * PublicKey.LENGTH))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,12 +112,6 @@ def async_stubbed_sender_cached_blockhash() -> Account:
 
 
 @pytest.fixture(scope="session")
-def stubbed_token_addr() -> PublicKey:
-    """An arbitrary known token address."""
-    return PublicKey("DeV3CnJsrhN5TzCZQvmuQgYn1Up8nDycqmzxZJWH9DAw")
-
-
-@pytest.fixture(scope="session")
 def freeze_authority() -> Account:
     """Arbitrary known account to be used as freeze authority."""
     return Account(bytes([6] * PublicKey.LENGTH))

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -505,7 +505,7 @@ async def test_get_supply(test_http_client_async):
 @pytest.mark.asyncio
 async def test_get_token_largest_accounts(test_http_client_async):
     """Test get token largest accounts."""
-    resp = test_http_client_async.get_token_largest_accounts(WRAPPED_SOL_MINT)
+    resp = await test_http_client_async.get_token_largest_accounts(WRAPPED_SOL_MINT)
     assert_valid_response(resp)
 
 
@@ -513,7 +513,7 @@ async def test_get_token_largest_accounts(test_http_client_async):
 @pytest.mark.asyncio
 async def test_get_token_supply(test_http_client_async):
     """Test get token supply."""
-    resp = test_http_client_async.get_token_supply(WRAPPED_SOL_MINT)
+    resp = await test_http_client_async.get_token_supply(WRAPPED_SOL_MINT)
     assert_valid_response(resp)
 
 

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -4,6 +4,7 @@ import pytest
 import solana.system_program as sp
 from solana.rpc.api import DataSliceOpt
 from solana.transaction import Transaction
+from spl.token.constants import WRAPPED_SOL_MINT
 
 from .utils import AIRDROP_AMOUNT, aconfirm_transaction, assert_valid_response, generate_expected_meta_after_airdrop
 
@@ -497,6 +498,20 @@ async def test_get_slot_leader(test_http_client_async):
 async def test_get_supply(test_http_client_async):
     """Test get slot leader."""
     resp = await test_http_client_async.get_supply()
+    assert_valid_response(resp)
+
+
+@pytest.mark.integration
+async def test_get_token_largest_accounts(test_http_client):
+    """Test get token largest accounts."""
+    resp = test_http_client.get_token_largest_accounts(WRAPPED_SOL_MINT)
+    assert_valid_response(resp)
+
+
+@pytest.mark.integration
+async def test_get_token_supply(test_http_client):
+    """Test get token largest accounts."""
+    resp = test_http_client.get_token_supply(WRAPPED_SOL_MINT)
     assert_valid_response(resp)
 
 

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -502,16 +502,18 @@ async def test_get_supply(test_http_client_async):
 
 
 @pytest.mark.integration
-async def test_get_token_largest_accounts(test_http_client):
+@pytest.mark.asyncio
+async def test_get_token_largest_accounts(test_http_client_async):
     """Test get token largest accounts."""
-    resp = test_http_client.get_token_largest_accounts(WRAPPED_SOL_MINT)
+    resp = test_http_client_async.get_token_largest_accounts(WRAPPED_SOL_MINT)
     assert_valid_response(resp)
 
 
 @pytest.mark.integration
-async def test_get_token_supply(test_http_client):
-    """Test get token largest accounts."""
-    resp = test_http_client.get_token_supply(WRAPPED_SOL_MINT)
+@pytest.mark.asyncio
+async def test_get_token_supply(test_http_client_async):
+    """Test get token supply."""
+    resp = test_http_client_async.get_token_supply(WRAPPED_SOL_MINT)
     assert_valid_response(resp)
 
 

--- a/tests/integration/test_http_client.py
+++ b/tests/integration/test_http_client.py
@@ -4,6 +4,7 @@ import pytest
 import solana.system_program as sp
 from solana.rpc.api import DataSliceOpt
 from solana.transaction import Transaction
+from spl.token.constants import WRAPPED_SOL_MINT
 
 from .utils import AIRDROP_AMOUNT, assert_valid_response, confirm_transaction, generate_expected_meta_after_airdrop
 
@@ -491,16 +492,16 @@ def test_get_multiple_accounts(stubbed_sender, test_http_client):
 
 
 @pytest.mark.integration
-def test_get_token_largest_accounts(stubbed_token_addr, test_http_client):
+def test_get_token_largest_accounts(test_http_client):
     """Test get token largest accounts."""
-    resp = test_http_client.get_token_largest_accounts(stubbed_token_addr.public_key())
+    resp = test_http_client.get_token_largest_accounts(WRAPPED_SOL_MINT)
     assert_valid_response(resp)
 
 
 @pytest.mark.integration
-def test_get_token_supply(stubbed_token_addr, test_http_client):
+def test_get_token_supply(test_http_client):
     """Test get token largest accounts."""
-    resp = test_http_client.get_token_supply(stubbed_token_addr.public_key())
+    resp = test_http_client.get_token_supply(WRAPPED_SOL_MINT)
     assert_valid_response(resp)
 
 

--- a/tests/integration/test_http_client.py
+++ b/tests/integration/test_http_client.py
@@ -491,6 +491,20 @@ def test_get_multiple_accounts(stubbed_sender, test_http_client):
 
 
 @pytest.mark.integration
+def test_get_token_largest_accounts(stubbed_token_addr, test_http_client):
+    """Test get token largest accounts."""
+    resp = test_http_client.get_token_largest_accounts(stubbed_token_addr.public_key())
+    assert_valid_response(resp)
+
+
+@pytest.mark.integration
+def test_get_token_supply(stubbed_token_addr, test_http_client):
+    """Test get token largest accounts."""
+    resp = test_http_client.get_token_supply(stubbed_token_addr.public_key())
+    assert_valid_response(resp)
+
+
+@pytest.mark.integration
 def test_get_vote_accounts(test_http_client):
     """Test get vote accounts."""
     resp = test_http_client.get_vote_accounts()

--- a/tests/integration/test_http_client.py
+++ b/tests/integration/test_http_client.py
@@ -500,7 +500,7 @@ def test_get_token_largest_accounts(test_http_client):
 
 @pytest.mark.integration
 def test_get_token_supply(test_http_client):
-    """Test get token largest accounts."""
+    """Test get token supply."""
     resp = test_http_client.get_token_supply(WRAPPED_SOL_MINT)
     assert_valid_response(resp)
 


### PR DESCRIPTION
I have added implementations for the get_token_largest_accounts() and get_token_supply() methods in the synchronous RPC client as well as their respective _args methods in rpc.core.