### PR TITLE
Replace Account with Keypair

### DIFF
--- a/docs/solana.rst
+++ b/docs/solana.rst
@@ -1,8 +1,8 @@
 Solana
 ======
 
-solana.account
---------------
+solana.account (deprecated)
+---------------------------
 
 .. automodule:: solana.account
    :members:

--- a/docs/solana.rst
+++ b/docs/solana.rst
@@ -19,6 +19,12 @@ solana.instruction
 .. automodule:: solana.instruction
    :members:
 
+solana.keypair
+------------------
+
+.. automodule:: solana.keypair
+   :members:
+
 solana.message
 --------------
 

--- a/solana/account.py
+++ b/solana/account.py
@@ -1,4 +1,7 @@
-"""Account module to manage public-private key pair and signing messages."""
+"""(Deprecated, use ``solana.keypair`` instead).
+
+Account module to manage public-private key pair and signing messages.
+"""
 from __future__ import annotations
 
 from typing import List, Optional, Union

--- a/solana/account.py
+++ b/solana/account.py
@@ -11,7 +11,7 @@ from solana.publickey import PublicKey
 
 
 class Account:
-    """An account key pair (public and secret keys).
+    """(Deprecated) An account key pair (public and secret keys).
 
     >>> # Import account from 64-byte keypair
     >>> keypair = [

--- a/solana/account.py
+++ b/solana/account.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import List, Optional, Union
+from warnings import warn
 
 from base58 import b58encode
 from nacl import public, signing  # type: ignore
@@ -28,6 +29,7 @@ class Account:
 
         :pararm secret_key: Secret key for the account.
         """
+        warn("solana.account.Account is deprecated, please use solana.keypair.KeyPair", category=DeprecationWarning)
         key: Optional[bytes] = None
         if isinstance(secret_key, int):
             key = bytes(PublicKey(secret_key))

--- a/solana/blockhash.py
+++ b/solana/blockhash.py
@@ -5,6 +5,7 @@
 'EETubP5AKHgjPAhzPAFcb8BAY1hMH639CWCFTqi3hq1k'
 """
 from typing import NewType
+
 from cachetools import TTLCache
 
 Blockhash = NewType("Blockhash", str)

--- a/solana/keypair.py
+++ b/solana/keypair.py
@@ -1,8 +1,11 @@
 """Keypair module to manage public-private key pair."""
 from __future__ import annotations
+
 from typing import NamedTuple, Optional
+
 import nacl.public  # type: ignore
 from nacl import signing  # type: ignore
+
 import solana.publickey
 
 

--- a/solana/keypair.py
+++ b/solana/keypair.py
@@ -9,13 +9,6 @@ from nacl import signing  # type: ignore
 import solana.publickey
 
 
-class Signer(NamedTuple):
-    """Keypair signer interface."""
-
-    public_key: solana.publickey.PublicKey
-    secret_key: bytes
-
-
 class Keypair:
     """An account keypair used for signing transactions.
 

--- a/solana/keypair.py
+++ b/solana/keypair.py
@@ -1,8 +1,8 @@
 """Keypair module to manage public-private key pair."""
 from __future__ import annotations
 from typing import NamedTuple, Optional
-import nacl.public
-from nacl import signing
+import nacl.public  # type: ignore
+from nacl import signing  # type: ignore
 import solana.publickey
 
 

--- a/solana/keypair.py
+++ b/solana/keypair.py
@@ -1,0 +1,98 @@
+from typing import NamedTuple, Optional
+from nacl import signing
+from .publickey import PublicKey
+
+class Signer(NamedTuple):
+    """Keypair signer interface."""
+    public_key: PublicKey
+    secret_key: bytes
+
+class Ed25519Keypair(NamedTuple):
+    """Ed25519 Keypair."""
+    public_key: bytes
+    secret_key: bytes
+
+class Keypair:
+    """An account keypair used for signing transactions."""
+    def __init__(self, keypair: Optional[Ed25519Keypair]) -> None:
+        if keypair is None:
+            self._keypair
+
+/**
+ * An account keypair used for signing transactions.
+ */
+export class Keypair {
+  private _keypair: Ed25519Keypair;
+
+  /**
+   * Create a new keypair instance.
+   * Generate random keypair if no {@link Ed25519Keypair} is provided.
+   *
+   * @param keypair ed25519 keypair
+   */
+  constructor(keypair?: Ed25519Keypair) {
+    if (keypair) {
+      this._keypair = keypair;
+    } else {
+      this._keypair = nacl.sign.keyPair();
+    }
+  }
+
+  /**
+   * Generate a new random keypair
+   */
+  static generate(): Keypair {
+    return new Keypair(nacl.sign.keyPair());
+  }
+
+  /**
+   * Create a keypair from a raw secret key byte array.
+   *
+   * This method should only be used to recreate a keypair from a previously
+   * generated secret key. Generating keypairs from a random seed should be done
+   * with the {@link Keypair.fromSeed} method.
+   *
+   * @throws error if the provided secret key is invalid and validation is not skipped.
+   *
+   * @param secretKey secret key byte array
+   * @param options: skip secret key validation
+   */
+  static fromSecretKey(
+    secretKey: Uint8Array,
+    options?: {skipValidation?: boolean},
+  ): Keypair {
+    const keypair = nacl.sign.keyPair.fromSecretKey(secretKey);
+    if (!options || !options.skipValidation) {
+      const encoder = new TextEncoder();
+      const signData = encoder.encode('@solana/web3.js-validation-v1');
+      const signature = nacl.sign.detached(signData, keypair.secretKey);
+      if (!nacl.sign.detached.verify(signData, signature, keypair.publicKey)) {
+        throw new Error('provided secretKey is invalid');
+      }
+    }
+    return new Keypair(keypair);
+  }
+
+  /**
+   * Generate a keypair from a 32 byte seed.
+   *
+   * @param seed seed byte array
+   */
+  static fromSeed(seed: Uint8Array): Keypair {
+    return new Keypair(nacl.sign.keyPair.fromSeed(seed));
+  }
+
+  /**
+   * The public key for this keypair
+   */
+  get publicKey(): PublicKey {
+    return new PublicKey(this._keypair.publicKey);
+  }
+
+  /**
+   * The raw secret key for this keypair
+   */
+  get secretKey(): Uint8Array {
+    return this._keypair.secretKey;
+  }
+}

--- a/solana/keypair.py
+++ b/solana/keypair.py
@@ -67,6 +67,23 @@ class Keypair:
         """
         return cls(nacl.public.PrivateKey(seed))
 
+    def sign(self, msg: bytes) -> signing.SignedMessage:
+        """Sign a message with this keypair.
+
+        :param msg: message to sign.
+        :returns: A signed messeged object.
+
+        >>> seed = bytes([1] * 32)
+        >>> keypair = Keypair.from_seed(seed)
+        >>> msg = b"hello"
+        >>> signed_msg = keypair.sign(msg)
+        >>> signed_msg.signature.hex()
+        'e1430c6ebd0d53573b5c803452174f8991ef5955e0906a09e8fdc7310459e9c82a402526748c3431fe7f0e5faafbf7e703234789734063ee42be17af16438d08'
+        >>> signed_msg.message.decode('utf-8')
+        'hello'
+        """  # pylint: disable=line-too-long
+        return signing.SigningKey(self.seed).sign(msg)
+
     @property
     def seed(self) -> bytes:
         """The 32-byte secret seed."""

--- a/solana/keypair.py
+++ b/solana/keypair.py
@@ -1,7 +1,7 @@
 """Keypair module to manage public-private key pair."""
 from __future__ import annotations
 
-from typing import NamedTuple, Optional
+from typing import Optional
 
 import nacl.public  # type: ignore
 from nacl import signing  # type: ignore
@@ -104,4 +104,4 @@ class Keypair:
 
     def __ne__(self, other) -> bool:
         """Implemented by negating __eq__."""
-        return not (self == other)
+        return not (self == other)  # pylint: disable=superfluous-parens

--- a/solana/rpc/_utils/encoding.py
+++ b/solana/rpc/_utils/encoding.py
@@ -26,7 +26,7 @@ class FriendlyJsonSerde:
             try:
                 self._friendly_json_encode(element)
             except TypeError as exc:
-                yield "%d: because (%s)" % (index, exc)
+                yield f"{index}: because {exc}"
 
     @staticmethod
     def _is_list_like(obj: Any) -> bool:
@@ -42,7 +42,7 @@ class FriendlyJsonSerde:
                 raise TypeError("dict had unencodable value at keys: {{{}}}".format(item_errors)) from full_exception
             if FriendlyJsonSerde._is_list_like(obj):
                 element_errors = "; ".join(self._json_list_errors(obj))
-                raise TypeError("list had unencodable value at index: [{}]".format(element_errors)) from full_exception
+                raise TypeError(f"list had unencodable value at index: [{element_errors}]") from full_exception
             raise full_exception
 
     def json_decode(self, json_str: str) -> Dict[Any, Any]:  # pylint: disable=no-self-use
@@ -51,7 +51,7 @@ class FriendlyJsonSerde:
             decoded = json.loads(json_str)
             return decoded
         except json.decoder.JSONDecodeError as exc:
-            err_msg = "Could not decode {} because of {}.".format(repr(json_str), exc)
+            err_msg = f"Could not decode {repr(json_str)} because of {exc}."
             # Calling code may rely on catching JSONDecodeError to recognize bad json
             # so we have to re-raise the same type.
             raise json.decoder.JSONDecodeError(err_msg, exc.doc, exc.pos)

--- a/solana/rpc/_utils/encoding.py
+++ b/solana/rpc/_utils/encoding.py
@@ -26,7 +26,7 @@ class FriendlyJsonSerde:
             try:
                 self._friendly_json_encode(element)
             except TypeError as exc:
-                yield f"{index}: because {exc}"
+                yield "%d: because (%s)" % (index, exc)
 
     @staticmethod
     def _is_list_like(obj: Any) -> bool:
@@ -42,7 +42,7 @@ class FriendlyJsonSerde:
                 raise TypeError("dict had unencodable value at keys: {{{}}}".format(item_errors)) from full_exception
             if FriendlyJsonSerde._is_list_like(obj):
                 element_errors = "; ".join(self._json_list_errors(obj))
-                raise TypeError(f"list had unencodable value at index: [{element_errors}]") from full_exception
+                raise TypeError("list had unencodable value at index: [{}]".format(element_errors)) from full_exception
             raise full_exception
 
     def json_decode(self, json_str: str) -> Dict[Any, Any]:  # pylint: disable=no-self-use
@@ -51,7 +51,7 @@ class FriendlyJsonSerde:
             decoded = json.loads(json_str)
             return decoded
         except json.decoder.JSONDecodeError as exc:
-            err_msg = f"Could not decode {repr(json_str)} because of {exc}."
+            err_msg = "Could not decode {} because of {}.".format(repr(json_str), exc)
             # Calling code may rely on catching JSONDecodeError to recognize bad json
             # so we have to re-raise the same type.
             raise json.decoder.JSONDecodeError(err_msg, exc.doc, exc.pos)

--- a/solana/rpc/api.py
+++ b/solana/rpc/api.py
@@ -5,7 +5,7 @@ from time import sleep
 from typing import List, Optional, Union
 from warnings import warn
 
-from solana.account import Account
+from solana.keypair import Keypair
 from solana.blockhash import Blockhash, BlockhashCache
 from solana.publickey import PublicKey
 from solana.rpc import types
@@ -272,7 +272,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         return self._provider.make_request(*args)
 
     def get_confirmed_signature_for_address2(
-        self, account: Union[str, Account, PublicKey], before: Optional[str] = None, limit: Optional[int] = None
+        self, account: Union[str, Keypair, PublicKey], before: Optional[str] = None, limit: Optional[int] = None
     ) -> types.RPCResponse:
         """Returns confirmed signatures for transactions involving an address.
 
@@ -297,7 +297,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         return self._provider.make_request(*args)
 
     def get_signatures_for_address(
-        self, account: Union[str, Account, PublicKey], before: Optional[str] = None, limit: Optional[int] = None
+        self, account: Union[str, Keypair, PublicKey], before: Optional[str] = None, limit: Optional[int] = None
     ) -> types.RPCResponse:
         """Returns confirmed signatures for transactions involving an address.
 
@@ -1020,7 +1020,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
     def send_transaction(
         self,
         txn: Transaction,
-        *signers: Account,
+        *signers: Keypair,
         opts: types.TxOpts = types.TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> types.RPCResponse:
@@ -1032,12 +1032,12 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         :param recent_blockhash: (optional) Pass a valid recent blockhash here if you want to
             skip fetching the recent blockhash or relying on the cache.
 
-        >>> from solana.account import Account
+        >>> from solana.keypair import Keypair
         >>> from solana.system_program import TransferParams, transfer
         >>> from solana.transaction import Transaction
-        >>> sender, reciever = Account(1), Account(2)
+        >>> sender, receiver = Keypair.from_seed(bytes(PublicKey(1))), Keypair.from_seed(bytes(PublicKey(2)))
         >>> txn = Transaction().add(transfer(TransferParams(
-        ...     from_pubkey=sender.public_key(), to_pubkey=reciever.public_key(), lamports=1000)))
+        ...     from_pubkey=sender.public_key, to_pubkey=receiver.public_key, lamports=1000)))
         >>> solana_client = Client("http://localhost:8899")
         >>> solana_client.send_transaction(txn, sender) # doctest: +SKIP
         {'jsonrpc': '2.0',

--- a/solana/rpc/api.py
+++ b/solana/rpc/api.py
@@ -5,8 +5,8 @@ from time import sleep
 from typing import List, Optional, Union
 from warnings import warn
 
-from solana.keypair import Keypair
 from solana.blockhash import Blockhash, BlockhashCache
+from solana.keypair import Keypair
 from solana.publickey import PublicKey
 from solana.rpc import types
 from solana.transaction import Transaction

--- a/solana/rpc/async_api.py
+++ b/solana/rpc/async_api.py
@@ -2,8 +2,8 @@
 import asyncio
 from typing import List, Optional, Union
 
-from solana.keypair import Keypair
 from solana.blockhash import Blockhash, BlockhashCache
+from solana.keypair import Keypair
 from solana.publickey import PublicKey
 from solana.rpc import types
 from solana.transaction import Transaction

--- a/solana/rpc/async_api.py
+++ b/solana/rpc/async_api.py
@@ -2,7 +2,7 @@
 import asyncio
 from typing import List, Optional, Union
 
-from solana.account import Account
+from solana.keypair import Keypair
 from solana.blockhash import Blockhash, BlockhashCache
 from solana.publickey import PublicKey
 from solana.rpc import types
@@ -268,7 +268,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         return await self._provider.make_request(*args)
 
     async def get_confirmed_signature_for_address2(
-        self, account: Union[str, Account, PublicKey], before: Optional[str] = None, limit: Optional[int] = None
+        self, account: Union[str, Keypair, PublicKey], before: Optional[str] = None, limit: Optional[int] = None
     ) -> types.RPCResponse:
         """Returns confirmed signatures for transactions involving an address.
 
@@ -293,7 +293,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         return await self._provider.make_request(*args)
 
     async def get_signatures_for_address(
-        self, account: Union[str, Account, PublicKey], before: Optional[str] = None, limit: Optional[int] = None
+        self, account: Union[str, Keypair, PublicKey], before: Optional[str] = None, limit: Optional[int] = None
     ) -> types.RPCResponse:
         """Returns confirmed signatures for transactions involving an address.
 
@@ -1018,7 +1018,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
     async def send_transaction(
         self,
         txn: Transaction,
-        *signers: Account,
+        *signers: Keypair,
         opts: types.TxOpts = types.TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> types.RPCResponse:
@@ -1030,12 +1030,12 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         :param recent_blockhash: (optional) Pass a valid recent blockhash here if you want to
             skip fetching the recent blockhash or relying on the cache.
 
-        >>> from solana.account import Account
+        >>> from solana.keypair import Keypair
         >>> from solana.system_program import TransferParams, transfer
         >>> from solana.transaction import Transaction
-        >>> sender, reciever = Account(1), Account(2)
+        >>> sender, receiver = Keypair.from_seed(bytes(PublicKey(1))), Keypair.from_seed(bytes(PublicKey(2)))
         >>> txn = Transaction().add(transfer(TransferParams(
-        ...     from_pubkey=sender.public_key(), to_pubkey=reciever.public_key(), lamports=1000)))
+        ...     from_pubkey=sender.public_key, to_pubkey=receiver.public_key, lamports=1000)))
         >>> solana_client = AsyncClient("http://localhost:8899")
         >>> asyncio.run(solana_client.send_transaction(txn, sender)) # doctest: +SKIP
         {'jsonrpc': '2.0',

--- a/solana/rpc/core.py
+++ b/solana/rpc/core.py
@@ -11,7 +11,7 @@ from warnings import warn
 
 from base58 import b58decode, b58encode
 
-from solana.account import Account
+from solana.keypair import Keypair
 from solana.blockhash import Blockhash, BlockhashCache
 from solana.publickey import PublicKey
 from solana.rpc import types
@@ -81,7 +81,7 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def _get_confirmed_signature_for_address2_args(
-        account: Union[str, Account, PublicKey], before: Optional[str], limit: Optional[int]
+        account: Union[str, Keypair, PublicKey], before: Optional[str], limit: Optional[int]
     ) -> Tuple[types.RPCMethod, str, Dict[str, Union[int, str]]]:
         warn(
             "solana.rpc.api.getConfirmedSignaturesForAddress2 is deprecated, "
@@ -94,15 +94,15 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         if limit:
             opts["limit"] = limit
 
-        if isinstance(account, Account):
-            account = str(account.public_key())
+        if isinstance(account, Keypair):
+            account = str(account.public_key)
         if isinstance(account, PublicKey):
             account = str(account)
         return types.RPCMethod("getConfirmedSignaturesForAddress2"), account, opts
 
     @staticmethod
     def _get_signatures_for_address_args(
-        account: Union[str, Account, PublicKey], before: Optional[str], limit: Optional[int]
+        account: Union[str, Keypair, PublicKey], before: Optional[str], limit: Optional[int]
     ) -> Tuple[types.RPCMethod, str, Dict[str, Union[int, str]]]:
         opts: Dict[str, Union[int, str]] = {}
         if before:
@@ -110,8 +110,8 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         if limit:
             opts["limit"] = limit
 
-        if isinstance(account, Account):
-            account = str(account.public_key())
+        if isinstance(account, Keypair):
+            account = str(account.public_key)
         if isinstance(account, PublicKey):
             account = str(account)
         return types.RPCMethod("getSignaturesForAddress"), account, opts

--- a/solana/rpc/core.py
+++ b/solana/rpc/core.py
@@ -7,12 +7,13 @@ try:
     from typing import Literal  # type: ignore
 except ImportError:
     from typing_extensions import Literal
+
 from warnings import warn
 
 from base58 import b58decode, b58encode
 
-from solana.keypair import Keypair
 from solana.blockhash import Blockhash, BlockhashCache
+from solana.keypair import Keypair
 from solana.publickey import PublicKey
 from solana.rpc import types
 from solana.transaction import Transaction

--- a/solana/system_program.py
+++ b/solana/system_program.py
@@ -219,9 +219,9 @@ def decode_transfer(instruction: TransactionInstruction) -> TransferParams:
     """Decode a transfer system instruction and retrieve the instruction params.
 
     >>> from solana.publickey import PublicKey
-    >>> sender, reciever = PublicKey(1), PublicKey(2)
+    >>> sender, receiver = PublicKey(1), PublicKey(2)
     >>> instruction = transfer(
-    ...     TransferParams(from_pubkey=sender, to_pubkey=reciever, lamports=1000)
+    ...     TransferParams(from_pubkey=sender, to_pubkey=receiver, lamports=1000)
     ... )
     >>> decode_transfer(instruction)
     TransferParams(from_pubkey=11111111111111111111111111111112, to_pubkey=11111111111111111111111111111113, lamports=1000)
@@ -388,9 +388,9 @@ def transfer(params: TransferParams) -> TransactionInstruction:
     """Generate an instruction that transfers lamports from one account to another.
 
     >>> from solana.publickey import PublicKey
-    >>> sender, reciever = PublicKey(1), PublicKey(2)
+    >>> sender, receiver = PublicKey(1), PublicKey(2)
     >>> instruction = transfer(
-    ...     TransferParams(from_pubkey=sender, to_pubkey=reciever, lamports=1000)
+    ...     TransferParams(from_pubkey=sender, to_pubkey=receiver, lamports=1000)
     ... )
     >>> type(instruction)
     <class 'solana.transaction.TransactionInstruction'>

--- a/solana/transaction.py
+++ b/solana/transaction.py
@@ -146,7 +146,7 @@ class Transaction:
 
         # Cull duplicate accounts
         fee_payer_idx = maxsize
-        seen: Dict[str, int] = dict()
+        seen: Dict[str, int] = {}
         uniq_metas: List[AccountMeta] = []
         for sig in self.signatures:
             pubkey = str(sig.pubkey)

--- a/solana/transaction.py
+++ b/solana/transaction.py
@@ -9,8 +9,8 @@ from base58 import b58decode, b58encode
 from nacl.exceptions import BadSignatureError  # type: ignore
 from nacl.signing import VerifyKey  # type: ignore
 
-from solana.keypair import Keypair
 from solana.blockhash import Blockhash
+from solana.keypair import Keypair
 from solana.message import CompiledInstruction, Message, MessageArgs, MessageHeader
 from solana.publickey import PublicKey
 from solana.utils import shortvec_encoding as shortvec

--- a/solana/transaction.py
+++ b/solana/transaction.py
@@ -9,7 +9,7 @@ from base58 import b58decode, b58encode
 from nacl.exceptions import BadSignatureError  # type: ignore
 from nacl.signing import VerifyKey  # type: ignore
 
-from solana.account import Account
+from solana.keypair import Keypair
 from solana.blockhash import Blockhash
 from solana.message import CompiledInstruction, Message, MessageArgs, MessageHeader
 from solana.publickey import PublicKey
@@ -221,18 +221,18 @@ class Transaction:
         """Get raw transaction data that need to be covered by signatures."""
         return self.compile_message().serialize()
 
-    def sign_partial(self, *partial_signers: Union[PublicKey, Account]) -> None:
+    def sign_partial(self, *partial_signers: Union[PublicKey, Keypair]) -> None:
         """Partially sign a Transaction with the specified accounts.
 
-        The `Account` inputs will be used to sign the Transaction immediately, while any
+        The `Keypair` inputs will be used to sign the Transaction immediately, while any
         `PublicKey` inputs will be referenced in the signed Transaction but need to
-        be filled in later by calling `addSigner()` with the matching `Account`.
+        be filled in later by calling `addSigner()` with the matching `Keypair`.
 
         All the caveats from the `sign` method apply to `signPartial`
         """
 
-        def partial_signer_pubkey(account_or_pubkey: Union[PublicKey, Account]):
-            return account_or_pubkey.public_key() if isinstance(account_or_pubkey, Account) else account_or_pubkey
+        def partial_signer_pubkey(account_or_pubkey: Union[PublicKey, Keypair]):
+            return account_or_pubkey.public_key if isinstance(account_or_pubkey, Keypair) else account_or_pubkey
 
         signatures: List[SigPubkeyPair] = [
             SigPubkeyPair(pubkey=partial_signer_pubkey(partial_signer)) for partial_signer in partial_signers
@@ -241,13 +241,13 @@ class Transaction:
         sign_data = self.serialize_message()
 
         for idx, partial_signer in enumerate(partial_signers):
-            if isinstance(partial_signer, Account):
+            if isinstance(partial_signer, Keypair):
                 sig = partial_signer.sign(sign_data).signature
                 if len(sig) != SIG_LENGTH:
                     raise RuntimeError("signature has invalid length", sig)
                 self.signatures[idx].signature = sig
 
-    def sign(self, *signers: Account) -> None:
+    def sign(self, *signers: Keypair) -> None:
         """Sign the Transaction with the specified accounts.
 
         Multiple signatures may be applied to a Transaction. The first signature
@@ -270,14 +270,14 @@ class Transaction:
             raise ValueError("unknown signer: ", str(pubkey))
         self.signatures[idx].signature = signature
 
-    def add_signer(self, signer: Account) -> None:
+    def add_signer(self, signer: Keypair) -> None:
         """Fill in a signature for a partially signed Transaction.
 
-        The `signer` must be the corresponding `Account` for a `PublicKey` that was
+        The `signer` must be the corresponding `Keypair` for a `PublicKey` that was
         previously provided to `signPartial`
         """
         signed_msg = signer.sign(self.serialize_message())
-        self.add_signature(signer.public_key(), signed_msg.signature)
+        self.add_signature(signer.public_key, signed_msg.signature)
 
     def verify_signatures(self) -> bool:
         """Verify signatures of a complete, signed Transaction."""
@@ -298,12 +298,13 @@ class Transaction:
 
         The Transaction must have a valid `signature` before invoking this method.
 
-        >>> from solana.account import Account
+        >>> from solana.keypair import Keypair
         >>> from solana.blockhash import Blockhash
         >>> from solana.publickey import PublicKey
         >>> from solana.system_program import transfer, TransferParams
-        >>> sender, reciever = Account(1), PublicKey(2)
-        >>> transfer_tx = Transaction().add(transfer(TransferParams(from_pubkey=sender.public_key(), to_pubkey=reciever, lamports=1000)))
+        >>> seed = bytes(PublicKey(1))
+        >>> sender, receiver = Keypair.from_seed(seed), PublicKey(2)
+        >>> transfer_tx = Transaction().add(transfer(TransferParams(from_pubkey=sender.public_key, to_pubkey=receiver, lamports=1000)))
         >>> transfer_tx.recent_blockhash = Blockhash(str(PublicKey(3)))
         >>> transfer_tx.sign(sender)
         >>> transfer_tx.serialize().hex()

--- a/solana/utils/helpers.py
+++ b/solana/utils/helpers.py
@@ -1,6 +1,7 @@
 """Helper functions."""
 
 from base64 import b64decode
+
 from base58 import b58decode
 
 

--- a/spl/token/async_client.py
+++ b/spl/token/async_client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import List, Optional, Union, cast
 
 import spl.token.instructions as spl_token
-from solana.account import Account
+from solana.keypair import Keypair
 from solana.blockhash import Blockhash
 from solana.publickey import PublicKey
 from solana.rpc.async_api import AsyncClient
@@ -18,7 +18,7 @@ from spl.token.core import AccountInfo, MintInfo, _TokenCore
 class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
     """An ERC20-like Token."""
 
-    def __init__(self, conn: AsyncClient, pubkey: PublicKey, program_id: PublicKey, payer: Account) -> None:
+    def __init__(self, conn: AsyncClient, pubkey: PublicKey, program_id: PublicKey, payer: Keypair) -> None:
         """Initialize a client to a SPL-Token program."""
         super().__init__(pubkey, program_id, payer)
         self._conn = conn
@@ -91,7 +91,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
     async def create_mint(
         cls,
         conn: AsyncClient,
-        payer: Account,
+        payer: Keypair,
         mint_authority: PublicKey,
         decimals: int,
         program_id: PublicKey,
@@ -173,7 +173,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         conn: AsyncClient,
         program_id: PublicKey,
         owner: PublicKey,
-        payer: Account,
+        payer: Keypair,
         amount: int,
         skip_confirmation: bool = False,
         recent_blockhash: Optional[Blockhash] = None,
@@ -215,7 +215,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         balance_needed = await AsyncToken.get_min_balance_rent_for_exempt_for_multisig(self._conn)
         txn, payer, multisig = self._create_multisig_args(m, multi_signers, balance_needed)
         await self._conn.send_transaction(txn, payer, multisig, opts=opts, recent_blockhash=recent_blockhash)
-        return multisig.public_key()
+        return multisig.public_key
 
     async def get_mint_info(self) -> MintInfo:
         """Retrieve mint information."""
@@ -231,9 +231,9 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         self,
         source: PublicKey,
         dest: PublicKey,
-        owner: Union[Account, PublicKey],
+        owner: Union[Keypair, PublicKey],
         amount: int,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -255,7 +255,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         delegate: PublicKey,
         owner: PublicKey,
         amount: int,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -275,7 +275,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         self,
         account: PublicKey,
         owner: PublicKey,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -292,10 +292,10 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
     async def set_authority(
         self,
         account: PublicKey,
-        current_authority: Union[Account, PublicKey],
+        current_authority: Union[Keypair, PublicKey],
         authority_type: spl_token.AuthorityType,
         new_authority: Optional[PublicKey] = None,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -316,9 +316,9 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
     async def mint_to(
         self,
         dest: PublicKey,
-        mint_authority: Union[Account, PublicKey],
+        mint_authority: Union[Keypair, PublicKey],
         amount: int,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -341,7 +341,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         account: PublicKey,
         owner: PublicKey,
         amount: int,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -361,7 +361,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         account: PublicKey,
         dest: PublicKey,
         authority: PublicKey,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -380,7 +380,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         self,
         account: PublicKey,
         authority: PublicKey,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -398,7 +398,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         self,
         account: PublicKey,
         authority: PublicKey,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -419,7 +419,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         owner: PublicKey,
         amount: int,
         decimals: int,
-        multi_signers: Optional[List[Account]],
+        multi_signers: Optional[List[Keypair]],
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -443,7 +443,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         owner: PublicKey,
         amount: int,
         decimals: int,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -470,7 +470,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         mint_authority: PublicKey,
         amount: int,
         decimals: int,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -492,7 +492,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         owner: PublicKey,
         amount: int,
         decimals: int,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:

--- a/spl/token/async_client.py
+++ b/spl/token/async_client.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import List, Optional, Union, cast
 
 import spl.token.instructions as spl_token
-from solana.keypair import Keypair
 from solana.blockhash import Blockhash
+from solana.keypair import Keypair
 from solana.publickey import PublicKey
 from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Commitment, Confirmed

--- a/spl/token/client.py
+++ b/spl/token/client.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from typing import List, Optional, Union, cast
 
 import spl.token.instructions as spl_token
+from solana.blockhash import Blockhash
 from solana.keypair import Keypair
 from solana.publickey import PublicKey
 from solana.rpc.api import Client
 from solana.rpc.commitment import Commitment, Confirmed
 from solana.rpc.types import RPCResponse, TxOpts
-from solana.blockhash import Blockhash
 from spl.token._layouts import ACCOUNT_LAYOUT, MINT_LAYOUT, MULTISIG_LAYOUT
 from spl.token.core import AccountInfo, MintInfo, _TokenCore
 

--- a/spl/token/client.py
+++ b/spl/token/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import List, Optional, Union, cast
 
 import spl.token.instructions as spl_token
-from solana.account import Account
+from solana.keypair import Keypair
 from solana.publickey import PublicKey
 from solana.rpc.api import Client
 from solana.rpc.commitment import Commitment, Confirmed
@@ -18,7 +18,7 @@ from spl.token.core import AccountInfo, MintInfo, _TokenCore
 class Token(_TokenCore):  # pylint: disable=too-many-public-methods
     """An ERC20-like Token."""
 
-    def __init__(self, conn: Client, pubkey: PublicKey, program_id: PublicKey, payer: Account) -> None:
+    def __init__(self, conn: Client, pubkey: PublicKey, program_id: PublicKey, payer: Keypair) -> None:
         """Initialize a client to a SPL-Token program."""
         super().__init__(pubkey, program_id, payer)
         self._conn = conn
@@ -91,7 +91,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
     def create_mint(
         cls,
         conn: Client,
-        payer: Account,
+        payer: Keypair,
         mint_authority: PublicKey,
         decimals: int,
         program_id: PublicKey,
@@ -173,7 +173,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         conn: Client,
         program_id: PublicKey,
         owner: PublicKey,
-        payer: Account,
+        payer: Keypair,
         amount: int,
         skip_confirmation: bool = False,
         recent_blockhash: Optional[Blockhash] = None,
@@ -215,7 +215,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         balance_needed = Token.get_min_balance_rent_for_exempt_for_multisig(self._conn)
         txn, payer, multisig = self._create_multisig_args(m, multi_signers, balance_needed)
         self._conn.send_transaction(txn, payer, multisig, opts=opts, recent_blockhash=recent_blockhash)
-        return multisig.public_key()
+        return multisig.public_key
 
     def get_mint_info(self) -> MintInfo:
         """Retrieve mint information."""
@@ -231,9 +231,9 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         self,
         source: PublicKey,
         dest: PublicKey,
-        owner: Union[Account, PublicKey],
+        owner: Union[Keypair, PublicKey],
         amount: int,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -255,7 +255,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         delegate: PublicKey,
         owner: PublicKey,
         amount: int,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -275,7 +275,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         self,
         account: PublicKey,
         owner: PublicKey,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -292,10 +292,10 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
     def set_authority(
         self,
         account: PublicKey,
-        current_authority: Union[Account, PublicKey],
+        current_authority: Union[Keypair, PublicKey],
         authority_type: spl_token.AuthorityType,
         new_authority: Optional[PublicKey] = None,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -316,9 +316,9 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
     def mint_to(
         self,
         dest: PublicKey,
-        mint_authority: Union[Account, PublicKey],
+        mint_authority: Union[Keypair, PublicKey],
         amount: int,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -341,7 +341,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         account: PublicKey,
         owner: PublicKey,
         amount: int,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -360,8 +360,8 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         self,
         account: PublicKey,
         dest: PublicKey,
-        authority: Union[Account, PublicKey],
-        multi_signers: Optional[List[Account]] = None,
+        authority: Union[Keypair, PublicKey],
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -379,8 +379,8 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
     def freeze_account(
         self,
         account: PublicKey,
-        authority: Union[PublicKey, Account],
-        multi_signers: Optional[List[Account]] = None,
+        authority: Union[PublicKey, Keypair],
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -398,7 +398,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         self,
         account: PublicKey,
         authority: PublicKey,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -416,10 +416,10 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         self,
         source: PublicKey,
         dest: PublicKey,
-        owner: Union[Account, PublicKey],
+        owner: Union[Keypair, PublicKey],
         amount: int,
         decimals: int,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -443,7 +443,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         owner: PublicKey,
         amount: int,
         decimals: int,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -467,10 +467,10 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
     def mint_to_checked(
         self,
         dest: PublicKey,
-        mint_authority: Union[Account, PublicKey],
+        mint_authority: Union[Keypair, PublicKey],
         amount: int,
         decimals: int,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:
@@ -489,10 +489,10 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
     def burn_checked(
         self,
         account: PublicKey,
-        owner: Union[Account, PublicKey],
+        owner: Union[Keypair, PublicKey],
         amount: int,
         decimals: int,
-        multi_signers: Optional[List[Account]] = None,
+        multi_signers: Optional[List[Keypair]] = None,
         opts: TxOpts = TxOpts(),
         recent_blockhash: Optional[Blockhash] = None,
     ) -> RPCResponse:

--- a/spl/token/core.py
+++ b/spl/token/core.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, List, NamedTuple, Optional, Tuple, Type, Union
 
 import solana.system_program as sp
 import spl.token.instructions as spl_token
-from solana.account import Account
+from solana.keypair import Keypair
 from solana.publickey import PublicKey
 from solana.rpc.api import Client
 from solana.rpc.async_api import AsyncClient
@@ -79,10 +79,10 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
     program_id: PublicKey
     """Program Identifier for the Token program."""
 
-    payer: Account
+    payer: Keypair
     """Fee payer."""
 
-    def __init__(self, pubkey: PublicKey, program_id: PublicKey, payer: Account) -> None:
+    def __init__(self, pubkey: PublicKey, program_id: PublicKey, payer: Keypair) -> None:
         """Initialize a client to a SPL-Token program."""
         self.pubkey, self.program_id, self.payer = pubkey, program_id, payer
 
@@ -97,7 +97,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
     @staticmethod
     def _create_mint_args(
         conn: Union[Client, AsyncClient],
-        payer: Account,
+        payer: Keypair,
         mint_authority: PublicKey,
         decimals: int,
         program_id: PublicKey,
@@ -105,16 +105,16 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
         skip_confirmation: bool,
         balance_needed: int,
         cls: Union[Type[Token], Type[AsyncToken]],
-    ) -> Tuple[Union[Token, AsyncToken], Transaction, Account, Account, TxOpts]:
-        mint_account = Account()
-        token = cls(conn, mint_account.public_key(), program_id, payer)  # type: ignore
+    ) -> Tuple[Union[Token, AsyncToken], Transaction, Keypair, Keypair, TxOpts]:
+        mint_keypair = Keypair()
+        token = cls(conn, mint_keypair.public_key, program_id, payer)  # type: ignore
         # Construct transaction
         txn = Transaction()
         txn.add(
             sp.create_account(
                 sp.CreateAccountParams(
-                    from_pubkey=payer.public_key(),
-                    new_account_pubkey=mint_account.public_key(),
+                    from_pubkey=payer.public_key,
+                    new_keypair_pubkey=mint_keypair.public_key,
                     lamports=balance_needed,
                     space=MINT_LAYOUT.sizeof(),
                     program_id=program_id,
@@ -125,22 +125,22 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
             spl_token.initialize_mint(
                 spl_token.InitializeMintParams(
                     program_id=program_id,
-                    mint=mint_account.public_key(),
+                    mint=mint_keypair.public_key,
                     decimals=decimals,
                     mint_authority=mint_authority,
                     freeze_authority=freeze_authority,
                 )
             )
         )
-        return token, txn, payer, mint_account, TxOpts(skip_confirmation=skip_confirmation, skip_preflight=True)
+        return token, txn, payer, mint_keypair, TxOpts(skip_confirmation=skip_confirmation, skip_preflight=True)
 
     def _create_account_args(
         self,
         owner: PublicKey,
         skip_confirmation: bool,
         balance_needed: int,
-    ) -> Tuple[PublicKey, Transaction, Account, Account, TxOpts]:
-        new_account = Account()
+    ) -> Tuple[PublicKey, Transaction, Keypair, Keypair, TxOpts]:
+        new_keypair = Keypair()
         # Allocate memory for the account
 
         # Construct transaction
@@ -148,8 +148,8 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
         txn.add(
             sp.create_account(
                 sp.CreateAccountParams(
-                    from_pubkey=self.payer.public_key(),
-                    new_account_pubkey=new_account.public_key(),
+                    from_pubkey=self.payer.public_key,
+                    new_keypair_pubkey=new_keypair.public_key,
                     lamports=balance_needed,
                     space=ACCOUNT_LAYOUT.sizeof(),
                     program_id=self.program_id,
@@ -159,15 +159,15 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
         txn.add(
             spl_token.initialize_account(
                 spl_token.InitializeAccountParams(
-                    account=new_account.public_key(), mint=self.pubkey, owner=owner, program_id=self.program_id
+                    account=new_keypair.public_key, mint=self.pubkey, owner=owner, program_id=self.program_id
                 )
             )
         )
         return (
-            new_account.public_key(),
+            new_keypair.public_key,
             txn,
             self.payer,
-            new_account,
+            new_keypair,
             TxOpts(skip_preflight=True, skip_confirmation=skip_confirmation),
         )
 
@@ -175,12 +175,12 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
         self,
         owner: PublicKey,
         skip_confirmation: bool,
-    ) -> Tuple[PublicKey, Transaction, Account, TxOpts]:
+    ) -> Tuple[PublicKey, Transaction, Keypair, TxOpts]:
 
         # Construct transaction
         txn = Transaction()
         create_txn = spl_token.create_associated_token_account(
-            payer=self.payer.public_key(), owner=owner, mint=self.pubkey
+            payer=self.payer.public_key, owner=owner, mint=self.pubkey
         )
         txn.add(create_txn)
         return create_txn.keys[1].pubkey, txn, self.payer, TxOpts(skip_confirmation=skip_confirmation)
@@ -189,20 +189,20 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
     def _create_wrapped_native_account_args(
         program_id: PublicKey,
         owner: PublicKey,
-        payer: Account,
+        payer: Keypair,
         amount: int,
         skip_confirmation: bool,
         balance_needed: int,
-    ) -> Tuple[PublicKey, Transaction, Account, Account, TxOpts]:
-        new_account = Account()
+    ) -> Tuple[PublicKey, Transaction, Keypair, Keypair, TxOpts]:
+        new_keypair = Keypair()
         # Allocate memory for the account
         # Construct transaction
         txn = Transaction()
         txn.add(
             sp.create_account(
                 sp.CreateAccountParams(
-                    from_pubkey=payer.public_key(),
-                    new_account_pubkey=new_account.public_key(),
+                    from_pubkey=payer.public_key,
+                    new_keypair_pubkey=new_keypair.public_key,
                     lamports=balance_needed,
                     space=ACCOUNT_LAYOUT.sizeof(),
                     program_id=program_id,
@@ -212,31 +212,31 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
 
         txn.add(
             sp.transfer(
-                sp.TransferParams(from_pubkey=payer.public_key(), to_pubkey=new_account.public_key(), lamports=amount)
+                sp.TransferParams(from_pubkey=payer.public_key, to_pubkey=new_keypair.public_key, lamports=amount)
             )
         )
 
         txn.add(
             spl_token.initialize_account(
                 spl_token.InitializeAccountParams(
-                    account=new_account.public_key(), mint=WRAPPED_SOL_MINT, owner=owner, program_id=program_id
+                    account=new_keypair.public_key, mint=WRAPPED_SOL_MINT, owner=owner, program_id=program_id
                 )
             )
         )
 
-        return new_account.public_key(), txn, payer, new_account, TxOpts(skip_confirmation=skip_confirmation)
+        return new_keypair.public_key, txn, payer, new_keypair, TxOpts(skip_confirmation=skip_confirmation)
 
     def _transfer_args(
         self,
         source: PublicKey,
         dest: PublicKey,
-        owner: Union[Account, PublicKey],
+        owner: Union[Keypair, PublicKey],
         amount: int,
-        multi_signers: Optional[List[Account]],
+        multi_signers: Optional[List[Keypair]],
         opts: TxOpts,
-    ) -> Tuple[Transaction, List[Account], TxOpts]:
-        if isinstance(owner, Account):
-            owner_pubkey = owner.public_key()
+    ) -> Tuple[Transaction, List[Keypair], TxOpts]:
+        if isinstance(owner, Keypair):
+            owner_pubkey = owner.public_key
             signers = [owner]
         else:
             owner_pubkey = owner
@@ -250,7 +250,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
                     dest=dest,
                     owner=owner_pubkey,
                     amount=amount,
-                    signers=[signer.public_key() for signer in signers],
+                    signers=[signer.public_key for signer in signers],
                 )
             )
         )
@@ -259,14 +259,14 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
     def _set_authority_args(
         self,
         account: PublicKey,
-        current_authority: Union[Account, PublicKey],
+        current_authority: Union[Keypair, PublicKey],
         authority_type: spl_token.AuthorityType,
         new_authority: Optional[PublicKey],
-        multi_signers: Optional[List[Account]],
+        multi_signers: Optional[List[Keypair]],
         opts: TxOpts = TxOpts(),
-    ) -> Tuple[Transaction, Account, List[Account], TxOpts]:
-        if isinstance(current_authority, Account):
-            current_authority_pubkey = current_authority.public_key()
+    ) -> Tuple[Transaction, Keypair, List[Keypair], TxOpts]:
+        if isinstance(current_authority, Keypair):
+            current_authority_pubkey = current_authority.public_key
             signers = [current_authority]
         else:
             current_authority_pubkey = current_authority
@@ -279,7 +279,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
                     account=account,
                     authority=authority_type,
                     current_authority=current_authority_pubkey,
-                    signers=[signer.public_key() for signer in signers],
+                    signers=[signer.public_key for signer in signers],
                     new_authority=new_authority,
                 )
             )
@@ -290,13 +290,13 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
     def _mint_to_args(
         self,
         dest: PublicKey,
-        mint_authority: Union[Account, PublicKey],
+        mint_authority: Union[Keypair, PublicKey],
         amount: int,
-        multi_signers: Optional[List[Account]],
+        multi_signers: Optional[List[Keypair]],
         opts: TxOpts,
-    ) -> Tuple[Transaction, List[Account], TxOpts]:
-        if isinstance(mint_authority, Account):
-            owner_pubkey = mint_authority.public_key()
+    ) -> Tuple[Transaction, List[Keypair], TxOpts]:
+        if isinstance(mint_authority, Keypair):
+            owner_pubkey = mint_authority.public_key
             signers = [mint_authority]
         else:
             owner_pubkey = mint_authority
@@ -310,7 +310,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
                     dest=dest,
                     mint_authority=owner_pubkey,
                     amount=amount,
-                    signers=[signer.public_key() for signer in signers],
+                    signers=[signer.public_key for signer in signers],
                 )
             )
         )
@@ -404,13 +404,13 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
         self,
         source: PublicKey,
         delegate: PublicKey,
-        owner: Union[Account, PublicKey],
+        owner: Union[Keypair, PublicKey],
         amount: int,
-        multi_signers: Optional[List[Account]],
+        multi_signers: Optional[List[Keypair]],
         opts: TxOpts = TxOpts(),
-    ) -> Tuple[Transaction, Account, List[Account], TxOpts]:
-        if isinstance(owner, Account):
-            owner_pubkey = owner.public_key()
+    ) -> Tuple[Transaction, Keypair, List[Keypair], TxOpts]:
+        if isinstance(owner, Keypair):
+            owner_pubkey = owner.public_key
             signers = [owner]
         else:
             owner_pubkey = owner
@@ -424,7 +424,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
                     delegate=delegate,
                     owner=owner_pubkey,
                     amount=amount,
-                    signers=[signer.public_key() for signer in signers],
+                    signers=[signer.public_key for signer in signers],
                 )
             )
         )
@@ -433,12 +433,12 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
     def _revoke_args(
         self,
         account: PublicKey,
-        owner: Union[Account, PublicKey],
-        multi_signers: Optional[List[Account]],
+        owner: Union[Keypair, PublicKey],
+        multi_signers: Optional[List[Keypair]],
         opts: TxOpts = TxOpts(),
-    ) -> Tuple[Transaction, Account, List[Account], TxOpts]:
-        if isinstance(owner, Account):
-            owner_pubkey = owner.public_key()
+    ) -> Tuple[Transaction, Keypair, List[Keypair], TxOpts]:
+        if isinstance(owner, Keypair):
+            owner_pubkey = owner.public_key
             signers = [owner]
         else:
             owner_pubkey = owner
@@ -450,7 +450,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
                     program_id=self.program_id,
                     account=account,
                     owner=owner_pubkey,
-                    signers=[signer.public_key() for signer in signers],
+                    signers=[signer.public_key for signer in signers],
                 )
             )
         )
@@ -459,12 +459,12 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
     def _freeze_account_args(
         self,
         account: PublicKey,
-        authority: Union[PublicKey, Account],
-        multi_signers: Optional[List[Account]],
+        authority: Union[PublicKey, Keypair],
+        multi_signers: Optional[List[Keypair]],
         opts: TxOpts = TxOpts(),
-    ) -> Tuple[Transaction, List[Account], TxOpts]:
-        if isinstance(authority, Account):
-            authority_pubkey = authority.public_key()
+    ) -> Tuple[Transaction, List[Keypair], TxOpts]:
+        if isinstance(authority, Keypair):
+            authority_pubkey = authority.public_key
             signers = [authority]
         else:
             authority_pubkey = authority
@@ -477,7 +477,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
                     account=account,
                     mint=self.pubkey,
                     authority=authority_pubkey,
-                    multi_signers=[signer.public_key() for signer in signers],
+                    multi_signers=[signer.public_key for signer in signers],
                 )
             )
         )
@@ -486,12 +486,12 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
     def _thaw_account_args(
         self,
         account: PublicKey,
-        authority: Union[PublicKey, Account],
-        multi_signers: Optional[List[Account]],
+        authority: Union[PublicKey, Keypair],
+        multi_signers: Optional[List[Keypair]],
         opts: TxOpts = TxOpts(),
-    ) -> Tuple[Transaction, List[Account], TxOpts]:
-        if isinstance(authority, Account):
-            authority_pubkey = authority.public_key()
+    ) -> Tuple[Transaction, List[Keypair], TxOpts]:
+        if isinstance(authority, Keypair):
+            authority_pubkey = authority.public_key
             signers = [authority]
         else:
             authority_pubkey = authority
@@ -504,7 +504,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
                     account=account,
                     mint=self.pubkey,
                     authority=authority_pubkey,
-                    multi_signers=[signer.public_key() for signer in signers],
+                    multi_signers=[signer.public_key for signer in signers],
                 )
             )
         )
@@ -514,12 +514,12 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
         self,
         account: PublicKey,
         dest: PublicKey,
-        authority: Union[PublicKey, Account],
-        multi_signers: Optional[List[Account]],
+        authority: Union[PublicKey, Keypair],
+        multi_signers: Optional[List[Keypair]],
         opts: TxOpts = TxOpts(),
-    ) -> Tuple[Transaction, List[Account], TxOpts]:
-        if isinstance(authority, Account):
-            authority_pubkey = authority.public_key()
+    ) -> Tuple[Transaction, List[Keypair], TxOpts]:
+        if isinstance(authority, Keypair):
+            authority_pubkey = authority.public_key
             signers = [authority]
         else:
             authority_pubkey = authority
@@ -532,7 +532,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
                     account=account,
                     dest=dest,
                     owner=authority_pubkey,
-                    signers=[signer.public_key() for signer in signers],
+                    signers=[signer.public_key for signer in signers],
                 )
             )
         )
@@ -541,13 +541,13 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
     def _burn_args(
         self,
         account: PublicKey,
-        owner: Union[PublicKey, Account],
+        owner: Union[PublicKey, Keypair],
         amount: int,
-        multi_signers: Optional[List[Account]],
+        multi_signers: Optional[List[Keypair]],
         opts: TxOpts = TxOpts(),
-    ) -> Tuple[Transaction, List[Account], TxOpts]:
-        if isinstance(owner, Account):
-            owner_pubkey = owner.public_key()
+    ) -> Tuple[Transaction, List[Keypair], TxOpts]:
+        if isinstance(owner, Keypair):
+            owner_pubkey = owner.public_key
             signers = [owner]
         else:
             owner_pubkey = owner
@@ -561,7 +561,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
                     mint=self.pubkey,
                     owner=owner_pubkey,
                     amount=amount,
-                    signers=[signer.public_key() for signer in signers],
+                    signers=[signer.public_key for signer in signers],
                 )
             )
         )
@@ -572,15 +572,15 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
         m: int,
         signers: List[PublicKey],
         balance_needed: int,
-    ) -> Tuple[Transaction, Account, Account]:
-        multisig_account = Account()
+    ) -> Tuple[Transaction, Keypair, Keypair]:
+        multisig_keypair = Keypair()
 
         txn = Transaction()
         txn.add(
             sp.create_account(
                 sp.CreateAccountParams(
-                    from_pubkey=self.payer.public_key(),
-                    new_account_pubkey=multisig_account.public_key(),
+                    from_pubkey=self.payer.public_key,
+                    new_keypair_pubkey=multisig_keypair.public_key,
                     lamports=balance_needed,
                     space=MULTISIG_LAYOUT.sizeof(),
                     program_id=self.program_id,
@@ -591,27 +591,27 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
             spl_token.initialize_multisig(
                 spl_token.InitializeMultisigParams(
                     program_id=self.program_id,
-                    multisig=multisig_account.public_key(),
+                    multisig=multisig_keypair.public_key,
                     m=m,
                     signers=signers,
                 )
             )
         )
 
-        return txn, self.payer, multisig_account
+        return txn, self.payer, multisig_keypair
 
     def _transfer_checked_args(
         self,
         source: PublicKey,
         dest: PublicKey,
-        owner: Union[Account, PublicKey],
+        owner: Union[Keypair, PublicKey],
         amount: int,
         decimals: int,
-        multi_signers: Optional[List[Account]],
+        multi_signers: Optional[List[Keypair]],
         opts: TxOpts,
-    ) -> Tuple[Transaction, List[Account], TxOpts]:
-        if isinstance(owner, Account):
-            owner_pubkey = owner.public_key()
+    ) -> Tuple[Transaction, List[Keypair], TxOpts]:
+        if isinstance(owner, Keypair):
+            owner_pubkey = owner.public_key
             signers = [owner]
         else:
             owner_pubkey = owner
@@ -627,7 +627,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
                     owner=owner_pubkey,
                     amount=amount,
                     decimals=decimals,
-                    signers=[signer.public_key() for signer in signers],
+                    signers=[signer.public_key for signer in signers],
                 )
             )
         )
@@ -636,14 +636,14 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
     def _mint_to_checked_args(
         self,
         dest: PublicKey,
-        mint_authority: Union[Account, PublicKey],
+        mint_authority: Union[Keypair, PublicKey],
         amount: int,
         decimals: int,
-        multi_signers: Optional[List[Account]],
+        multi_signers: Optional[List[Keypair]],
         opts: TxOpts,
-    ) -> Tuple[Transaction, List[Account], TxOpts]:
-        if isinstance(mint_authority, Account):
-            owner_pubkey = mint_authority.public_key()
+    ) -> Tuple[Transaction, List[Keypair], TxOpts]:
+        if isinstance(mint_authority, Keypair):
+            owner_pubkey = mint_authority.public_key
             signers = [mint_authority]
         else:
             owner_pubkey = mint_authority
@@ -658,7 +658,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
                     mint_authority=owner_pubkey,
                     amount=amount,
                     decimals=decimals,
-                    signers=[signer.public_key() for signer in signers],
+                    signers=[signer.public_key for signer in signers],
                 )
             )
         )
@@ -667,14 +667,14 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
     def _burn_checked_args(
         self,
         account: PublicKey,
-        owner: Union[Account, PublicKey],
+        owner: Union[Keypair, PublicKey],
         amount: int,
         decimals: int,
-        multi_signers: Optional[List[Account]],
+        multi_signers: Optional[List[Keypair]],
         opts: TxOpts,
-    ) -> Tuple[Transaction, List[Account], TxOpts]:
-        if isinstance(owner, Account):
-            owner_pubkey = owner.public_key()
+    ) -> Tuple[Transaction, List[Keypair], TxOpts]:
+        if isinstance(owner, Keypair):
+            owner_pubkey = owner.public_key
             signers = [owner]
         else:
             owner_pubkey = owner
@@ -689,7 +689,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
                     owner=owner_pubkey,
                     amount=amount,
                     decimals=decimals,
-                    signers=[signer.public_key() for signer in signers],
+                    signers=[signer.public_key for signer in signers],
                 )
             )
         )
@@ -699,14 +699,14 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
         self,
         source: PublicKey,
         delegate: PublicKey,
-        owner: Union[Account, PublicKey],
+        owner: Union[Keypair, PublicKey],
         amount: int,
         decimals: int,
-        multi_signers: Optional[List[Account]],
+        multi_signers: Optional[List[Keypair]],
         opts: TxOpts,
-    ) -> Tuple[Transaction, Account, List[Account], TxOpts]:
-        if isinstance(owner, Account):
-            owner_pubkey = owner.public_key()
+    ) -> Tuple[Transaction, Keypair, List[Keypair], TxOpts]:
+        if isinstance(owner, Keypair):
+            owner_pubkey = owner.public_key
             signers = [owner]
         else:
             owner_pubkey = owner
@@ -722,7 +722,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
                     owner=owner_pubkey,
                     amount=amount,
                     decimals=decimals,
-                    signers=[signer.public_key() for signer in signers],
+                    signers=[signer.public_key for signer in signers],
                 )
             )
         )

--- a/spl/token/core.py
+++ b/spl/token/core.py
@@ -12,8 +12,8 @@ from solana.rpc.api import Client
 from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Commitment, Confirmed
 from solana.rpc.types import RPCResponse, TokenAccountOpts, TxOpts
-from solana.utils.helpers import decode_byte_string
 from solana.transaction import Transaction
+from solana.utils.helpers import decode_byte_string
 from spl.token._layouts import ACCOUNT_LAYOUT, MINT_LAYOUT, MULTISIG_LAYOUT  # type: ignore
 from spl.token.constants import WRAPPED_SOL_MINT
 

--- a/spl/token/core.py
+++ b/spl/token/core.py
@@ -114,7 +114,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
             sp.create_account(
                 sp.CreateAccountParams(
                     from_pubkey=payer.public_key,
-                    new_keypair_pubkey=mint_keypair.public_key,
+                    new_account_pubkey=mint_keypair.public_key,
                     lamports=balance_needed,
                     space=MINT_LAYOUT.sizeof(),
                     program_id=program_id,
@@ -149,7 +149,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
             sp.create_account(
                 sp.CreateAccountParams(
                     from_pubkey=self.payer.public_key,
-                    new_keypair_pubkey=new_keypair.public_key,
+                    new_account_pubkey=new_keypair.public_key,
                     lamports=balance_needed,
                     space=ACCOUNT_LAYOUT.sizeof(),
                     program_id=self.program_id,
@@ -202,7 +202,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
             sp.create_account(
                 sp.CreateAccountParams(
                     from_pubkey=payer.public_key,
-                    new_keypair_pubkey=new_keypair.public_key,
+                    new_account_pubkey=new_keypair.public_key,
                     lamports=balance_needed,
                     space=ACCOUNT_LAYOUT.sizeof(),
                     program_id=program_id,
@@ -580,7 +580,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
             sp.create_account(
                 sp.CreateAccountParams(
                     from_pubkey=self.payer.public_key,
-                    new_keypair_pubkey=multisig_keypair.public_key,
+                    new_account_pubkey=multisig_keypair.public_key,
                     lamports=balance_needed,
                     space=MULTISIG_LAYOUT.sizeof(),
                     program_id=self.program_id,

--- a/spl/token/core.py
+++ b/spl/token/core.py
@@ -319,9 +319,9 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
     def _create_mint_info(self, info: RPCResponse) -> MintInfo:
         if not info:
             raise ValueError("Failed to find mint account")
-
-        if info["result"]["value"]["owner"] != str(self.program_id):
-            raise AttributeError("Invalid mint owner: {}".format(info["result"]["value"]["owner"]))
+        owner = info["result"]["value"]["owner"]
+        if owner != str(self.program_id):
+            raise AttributeError(f"Invalid mint owner: {owner}")
 
         bytes_data = decode_byte_string(info["result"]["value"]["data"][0])
         if len(bytes_data) != MINT_LAYOUT.sizeof():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from typing import NamedTuple
 
 import pytest
 
+from solana.keypair import Keypair
 from solana.account import Account
 from solana.blockhash import Blockhash
 from solana.publickey import PublicKey
@@ -70,51 +71,51 @@ def async_stubbed_receiver_cached_blockhash() -> PublicKey:
 
 
 @pytest.fixture(scope="session")
-def stubbed_sender() -> Account:
+def stubbed_sender() -> Keypair:
     """Arbitrary known account to be used as sender."""
-    return Account(bytes([8] * PublicKey.LENGTH))
+    return Keypair.from_seed(bytes([8] * PublicKey.LENGTH))
 
 
 @pytest.fixture(scope="session")
-def stubbed_sender_prefetched_blockhash() -> Account:
+def stubbed_sender_prefetched_blockhash() -> Keypair:
     """Arbitrary known account to be used as sender."""
-    return Account(bytes([9] * PublicKey.LENGTH))
+    return Keypair.from_seed(bytes([9] * PublicKey.LENGTH))
 
 
 @pytest.fixture(scope="session")
-def stubbed_sender_cached_blockhash() -> Account:
+def stubbed_sender_cached_blockhash() -> Keypair:
     """Arbitrary known account to be used as sender."""
-    return Account(bytes([4] * PublicKey.LENGTH))
+    return Keypair.from_seed(bytes([4] * PublicKey.LENGTH))
 
 
 @pytest.fixture(scope="session")
-def stubbed_sender_for_token() -> Account:
+def stubbed_sender_for_token() -> Keypair:
     """Arbitrary known account to be used as sender."""
-    return Account(bytes([2] * PublicKey.LENGTH))
+    return Keypair.from_seed(bytes([2] * PublicKey.LENGTH))
 
 
 @pytest.fixture(scope="session")
-def async_stubbed_sender() -> Account:
+def async_stubbed_sender() -> Keypair:
     """Another arbitrary known account to be used as sender."""
-    return Account(bytes([7] * PublicKey.LENGTH))
+    return Keypair.from_seed(bytes([7] * PublicKey.LENGTH))
 
 
 @pytest.fixture(scope="session")
-def async_stubbed_sender_prefetched_blockhash() -> Account:
+def async_stubbed_sender_prefetched_blockhash() -> Keypair:
     """Another arbitrary known account to be used as sender."""
-    return Account(bytes([5] * PublicKey.LENGTH))
+    return Keypair.from_seed(bytes([5] * PublicKey.LENGTH))
 
 
 @pytest.fixture(scope="session")
-def async_stubbed_sender_cached_blockhash() -> Account:
+def async_stubbed_sender_cached_blockhash() -> Keypair:
     """Another arbitrary known account to be used as sender."""
-    return Account(bytes([3] * PublicKey.LENGTH))
+    return Keypair.from_seed(bytes([3] * PublicKey.LENGTH))
 
 
 @pytest.fixture(scope="session")
-def freeze_authority() -> Account:
+def freeze_authority() -> Keypair:
     """Arbitrary known account to be used as freeze authority."""
-    return Account(bytes([6] * PublicKey.LENGTH))
+    return Keypair.from_seed(bytes([6] * PublicKey.LENGTH))
 
 
 @pytest.mark.integration

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from typing import NamedTuple
 import pytest
 
 from solana.keypair import Keypair
-from solana.account import Account
 from solana.blockhash import Blockhash
 from solana.publickey import PublicKey
 from solana.rpc.api import Client
@@ -36,37 +35,37 @@ def stubbed_blockhash() -> Blockhash:
 
 @pytest.fixture(scope="session")
 def stubbed_receiver() -> PublicKey:
-    """Arbitrary known public key to be used as reciever."""
+    """Arbitrary known public key to be used as receiver."""
     return PublicKey("J3dxNj7nDRRqRRXuEMynDG57DkZK4jYRuv3Garmb1i99")
 
 
 @pytest.fixture(scope="session")
 def stubbed_receiver_prefetched_blockhash() -> PublicKey:
-    """Arbitrary known public key to be used as reciever."""
+    """Arbitrary known public key to be used as receiver."""
     return PublicKey("J3dxNj7nDRRqRRXuEMynDG57DkZK4jYRuv3Garmb1i97")
 
 
 @pytest.fixture(scope="session")
 def stubbed_receiver_cached_blockhash() -> PublicKey:
-    """Arbitrary known public key to be used as reciever."""
+    """Arbitrary known public key to be used as receiver."""
     return PublicKey("J3dxNj7nDRRqRRXuEMynDG57DkZK4jYRuv3Garmb1i95")
 
 
 @pytest.fixture(scope="session")
 def async_stubbed_receiver() -> PublicKey:
-    """Arbitrary known public key to be used as reciever."""
+    """Arbitrary known public key to be used as receiver."""
     return PublicKey("J3dxNj7nDRRqRRXuEMynDG57DkZK4jYRuv3Garmb1i98")
 
 
 @pytest.fixture(scope="session")
 def async_stubbed_receiver_prefetched_blockhash() -> PublicKey:
-    """Arbitrary known public key to be used as reciever."""
+    """Arbitrary known public key to be used as receiver."""
     return PublicKey("J3dxNj7nDRRqRRXuEMynDG57DkZK4jYRuv3Garmb1i96")
 
 
 @pytest.fixture(scope="session")
 def async_stubbed_receiver_cached_blockhash() -> PublicKey:
-    """Arbitrary known public key to be used as reciever."""
+    """Arbitrary known public key to be used as receiver."""
     return PublicKey("J3dxNj7nDRRqRRXuEMynDG57DkZK4jYRuv3Garmb1i94")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,8 @@ from typing import NamedTuple
 
 import pytest
 
-from solana.keypair import Keypair
 from solana.blockhash import Blockhash
+from solana.keypair import Keypair
 from solana.publickey import PublicKey
 from solana.rpc.api import Client
 from solana.rpc.async_api import AsyncClient

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -13,7 +13,7 @@ from .utils import AIRDROP_AMOUNT, aconfirm_transaction, assert_valid_response, 
 @pytest.mark.asyncio
 async def test_request_air_drop(async_stubbed_sender, test_http_client_async):
     """Test air drop to async_stubbed_sender."""
-    resp = await test_http_client_async.request_airdrop(async_stubbed_sender.public_key(), AIRDROP_AMOUNT)
+    resp = await test_http_client_async.request_airdrop(async_stubbed_sender.public_key, AIRDROP_AMOUNT)
     assert_valid_response(resp)
     resp = await aconfirm_transaction(test_http_client_async, resp["result"])
     assert_valid_response(resp)
@@ -59,7 +59,7 @@ async def test_send_transaction_and_get_balance(async_stubbed_sender, async_stub
     transfer_tx = Transaction().add(
         sp.transfer(
             sp.TransferParams(
-                from_pubkey=async_stubbed_sender.public_key(), to_pubkey=async_stubbed_receiver, lamports=1000
+                from_pubkey=async_stubbed_sender.public_key, to_pubkey=async_stubbed_receiver, lamports=1000
             )
         )
     )
@@ -93,7 +93,7 @@ async def test_send_transaction_and_get_balance(async_stubbed_sender, async_stub
     }
     assert resp["result"]["meta"] == expected_meta
     # Check balances
-    resp = await test_http_client_async.get_balance(async_stubbed_sender.public_key())
+    resp = await test_http_client_async.get_balance(async_stubbed_sender.public_key)
     assert_valid_response(resp)
     assert resp["result"]["value"] == 9999994000
     resp = await test_http_client_async.get_balance(async_stubbed_receiver)
@@ -273,7 +273,7 @@ async def test_send_raw_transaction_and_get_balance(
     transfer_tx = Transaction(recent_blockhash=recent_blockhash).add(
         sp.transfer(
             sp.TransferParams(
-                from_pubkey=async_stubbed_sender.public_key(), to_pubkey=async_stubbed_receiver, lamports=1000
+                from_pubkey=async_stubbed_sender.public_key, to_pubkey=async_stubbed_receiver, lamports=1000
             )
         )
     )
@@ -302,7 +302,7 @@ async def test_send_raw_transaction_and_get_balance(
     }
     assert resp["result"]["meta"] == expected_meta
     # Check balances
-    resp = await test_http_client_async.get_balance(async_stubbed_sender.public_key())
+    resp = await test_http_client_async.get_balance(async_stubbed_sender.public_key)
     assert_valid_response(resp)
     assert resp["result"]["value"] == 9999988000
     resp = await test_http_client_async.get_balance(async_stubbed_receiver)
@@ -537,13 +537,11 @@ async def test_get_version(test_http_client_async):
 @pytest.mark.asyncio
 async def test_get_account_info(async_stubbed_sender, test_http_client_async):
     """Test get_account_info."""
-    resp = await test_http_client_async.get_account_info(async_stubbed_sender.public_key())
+    resp = await test_http_client_async.get_account_info(async_stubbed_sender.public_key)
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_account_info(async_stubbed_sender.public_key(), encoding="jsonParsed")
+    resp = await test_http_client_async.get_account_info(async_stubbed_sender.public_key, encoding="jsonParsed")
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_account_info(
-        async_stubbed_sender.public_key(), data_slice=DataSliceOpt(1, 1)
-    )
+    resp = await test_http_client_async.get_account_info(async_stubbed_sender.public_key, data_slice=DataSliceOpt(1, 1))
     assert_valid_response(resp)
 
 
@@ -551,7 +549,7 @@ async def test_get_account_info(async_stubbed_sender, test_http_client_async):
 @pytest.mark.asyncio
 async def test_get_multiple_accounts(async_stubbed_sender, test_http_client_async):
     """Test get_multiple_accounts."""
-    pubkeys = [async_stubbed_sender.public_key()] * 2
+    pubkeys = [async_stubbed_sender.public_key] * 2
     resp = await test_http_client_async.get_multiple_accounts(pubkeys)
     assert_valid_response(resp)
     resp = await test_http_client_async.get_multiple_accounts(pubkeys, encoding="jsonParsed")

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -26,7 +26,7 @@ async def test_request_air_drop(async_stubbed_sender, test_http_client_async):
 async def test_request_air_drop_prefetched_blockhash(async_stubbed_sender_prefetched_blockhash, test_http_client_async):
     """Test air drop to async_stubbed_sender."""
     resp = await test_http_client_async.request_airdrop(
-        async_stubbed_sender_prefetched_blockhash.public_key(), AIRDROP_AMOUNT
+        async_stubbed_sender_prefetched_blockhash.public_key, AIRDROP_AMOUNT
     )
     assert_valid_response(resp)
     resp = await aconfirm_transaction(test_http_client_async, resp["result"])
@@ -42,7 +42,7 @@ async def test_request_air_drop_cached_blockhash(
 ):
     """Test air drop to async_stubbed_sender."""
     resp = await test_http_client_async_cached_blockhash.request_airdrop(
-        async_stubbed_sender_cached_blockhash.public_key(), AIRDROP_AMOUNT
+        async_stubbed_sender_cached_blockhash.public_key, AIRDROP_AMOUNT
     )
     assert_valid_response(resp)
     resp = await aconfirm_transaction(test_http_client_async_cached_blockhash, resp["result"])
@@ -111,7 +111,7 @@ async def test_send_transaction_prefetched_blockhash(
     transfer_tx = Transaction().add(
         sp.transfer(
             sp.TransferParams(
-                from_pubkey=async_stubbed_sender_prefetched_blockhash.public_key(),
+                from_pubkey=async_stubbed_sender_prefetched_blockhash.public_key,
                 to_pubkey=async_stubbed_receiver_prefetched_blockhash,
                 lamports=1000,
             )
@@ -147,7 +147,7 @@ async def test_send_transaction_prefetched_blockhash(
     }
     assert resp["result"]["meta"] == expected_meta
     # Check balances
-    resp = await test_http_client_async.get_balance(async_stubbed_sender_prefetched_blockhash.public_key())
+    resp = await test_http_client_async.get_balance(async_stubbed_sender_prefetched_blockhash.public_key)
     assert_valid_response(resp)
     assert resp["result"]["value"] == 9999994000
     resp = await test_http_client_async.get_balance(async_stubbed_receiver_prefetched_blockhash)
@@ -167,7 +167,7 @@ async def test_send_transaction_cached_blockhash(
     transfer_tx = Transaction().add(
         sp.transfer(
             sp.TransferParams(
-                from_pubkey=async_stubbed_sender_cached_blockhash.public_key(),
+                from_pubkey=async_stubbed_sender_cached_blockhash.public_key,
                 to_pubkey=async_stubbed_receiver_cached_blockhash,
                 lamports=1000,
             )
@@ -210,7 +210,7 @@ async def test_send_transaction_cached_blockhash(
     }
     assert resp["result"]["meta"] == expected_meta
     # Check balances
-    resp = await test_http_client_async_cached_blockhash.get_balance(async_stubbed_sender_cached_blockhash.public_key())
+    resp = await test_http_client_async_cached_blockhash.get_balance(async_stubbed_sender_cached_blockhash.public_key)
     assert_valid_response(resp)
     assert resp["result"]["value"] == 9999994000
 
@@ -218,7 +218,7 @@ async def test_send_transaction_cached_blockhash(
     transfer_tx = Transaction().add(
         sp.transfer(
             sp.TransferParams(
-                from_pubkey=async_stubbed_sender_cached_blockhash.public_key(),
+                from_pubkey=async_stubbed_sender_cached_blockhash.public_key,
                 to_pubkey=async_stubbed_receiver_cached_blockhash,
                 lamports=2000,
             )
@@ -254,7 +254,7 @@ async def test_send_transaction_cached_blockhash(
     }
     assert resp["result"]["meta"] == expected_meta
     # Check balances
-    resp = await test_http_client_async_cached_blockhash.get_balance(async_stubbed_sender_cached_blockhash.public_key())
+    resp = await test_http_client_async_cached_blockhash.get_balance(async_stubbed_sender_cached_blockhash.public_key)
     assert_valid_response(resp)
     assert resp["result"]["value"] == 9999987000
 

--- a/tests/integration/test_async_token_client.py
+++ b/tests/integration/test_async_token_client.py
@@ -17,7 +17,7 @@ from .utils import AIRDROP_AMOUNT, aconfirm_transaction, assert_valid_response
 @pytest.fixture(scope="module")
 async def test_token(async_stubbed_sender, freeze_authority, test_http_client_async) -> AsyncToken:
     """Test create mint."""
-    resp = await test_http_client_async.request_airdrop(async_stubbed_sender.public_key(), AIRDROP_AMOUNT)
+    resp = await test_http_client_async.request_airdrop(async_stubbed_sender.public_key, AIRDROP_AMOUNT)
     confirmed = await aconfirm_transaction(test_http_client_async, resp["result"])
     assert_valid_response(confirmed)
 
@@ -25,7 +25,7 @@ async def test_token(async_stubbed_sender, freeze_authority, test_http_client_as
     token_client = await AsyncToken.create_mint(
         test_http_client_async,
         async_stubbed_sender,
-        async_stubbed_sender.public_key(),
+        async_stubbed_sender.public_key,
         expected_decimals,
         TOKEN_PROGRAM_ID,
         freeze_authority.public_key(),
@@ -33,7 +33,7 @@ async def test_token(async_stubbed_sender, freeze_authority, test_http_client_as
 
     assert token_client.pubkey
     assert token_client.program_id == TOKEN_PROGRAM_ID
-    assert token_client.payer.public_key() == async_stubbed_sender.public_key()
+    assert token_client.payer.public_key() == async_stubbed_sender.public_key
 
     resp = await test_http_client_async.get_account_info(token_client.pubkey)
     assert_valid_response(resp)
@@ -43,7 +43,7 @@ async def test_token(async_stubbed_sender, freeze_authority, test_http_client_as
     assert mint_data.is_initialized
     assert mint_data.decimals == expected_decimals
     assert mint_data.supply == 0
-    assert PublicKey(mint_data.mint_authority) == async_stubbed_sender.public_key()
+    assert PublicKey(mint_data.mint_authority) == async_stubbed_sender.public_key
     assert PublicKey(mint_data.freeze_authority) == freeze_authority.public_key()
     return token_client
 
@@ -55,7 +55,7 @@ async def async_stubbed_sender_token_account_pk(
     async_stubbed_sender, test_token  # pylint: disable=redefined-outer-name
 ) -> PublicKey:
     """Token account for stubbed sender."""
-    return await test_token.create_account(async_stubbed_sender.public_key())
+    return await test_token.create_account(async_stubbed_sender.public_key)
 
 
 @pytest.mark.integration
@@ -74,7 +74,7 @@ async def test_new_account(
     async_stubbed_sender, test_http_client_async, test_token
 ):  # pylint: disable=redefined-outer-name
     """Test creating a new token account."""
-    token_account_pk = await test_token.create_account(async_stubbed_sender.public_key())
+    token_account_pk = await test_token.create_account(async_stubbed_sender.public_key)
     resp = await test_http_client_async.get_account_info(token_account_pk)
     assert_valid_response(resp)
     assert resp["result"]["value"]["owner"] == str(TOKEN_PROGRAM_ID)
@@ -90,7 +90,7 @@ async def test_new_account(
     assert not account_data.close_authority_option and PublicKey(account_data.close_authority) == PublicKey(0)
     assert not account_data.is_native_option and not account_data.is_native
     assert PublicKey(account_data.mint) == test_token.pubkey
-    assert PublicKey(account_data.owner) == async_stubbed_sender.public_key()
+    assert PublicKey(account_data.owner) == async_stubbed_sender.public_key
 
 
 @pytest.mark.integration
@@ -115,7 +115,7 @@ async def test_get_account_info(
     account_info = await test_token.get_account_info(async_stubbed_sender_token_account_pk)
     assert account_info.is_initialized is True
     assert account_info.mint == test_token.pubkey
-    assert account_info.owner == async_stubbed_sender.public_key()
+    assert account_info.owner == async_stubbed_sender.public_key
     assert account_info.amount == 0
     assert account_info.delegate is None
     assert account_info.delegated_amount == 0
@@ -132,7 +132,7 @@ async def test_get_mint_info(
 ):  # pylint: disable=redefined-outer-name
     """Test get token mint info."""
     mint_info = await test_token.get_mint_info()
-    assert mint_info.mint_authority == async_stubbed_sender.public_key()
+    assert mint_info.mint_authority == async_stubbed_sender.public_key
     assert mint_info.supply == 0
     assert mint_info.decimals == 6
     assert mint_info.is_initialized is True
@@ -294,13 +294,13 @@ async def test_burn_checked(
 @pytest.mark.asyncio
 async def test_get_accounts(async_stubbed_sender, test_token):  # pylint: disable=redefined-outer-name
     """Test get token accounts."""
-    resp = await test_token.get_accounts(async_stubbed_sender.public_key())
+    resp = await test_token.get_accounts(async_stubbed_sender.public_key)
     assert_valid_response(resp)
     assert len(resp["result"]["value"]) == 2
     for resp_data in resp["result"]["value"]:
         assert PublicKey(resp_data["pubkey"])
         parsed_data = resp_data["account"]["data"]["parsed"]["info"]
-        assert parsed_data["owner"] == str(async_stubbed_sender.public_key())
+        assert parsed_data["owner"] == str(async_stubbed_sender.public_key)
 
 
 @pytest.mark.integration
@@ -317,7 +317,7 @@ async def test_approve(
     resp = await test_token.approve(
         source=async_stubbed_sender_token_account_pk,
         delegate=async_stubbed_receiver,
-        owner=async_stubbed_sender.public_key(),
+        owner=async_stubbed_sender.public_key,
         amount=expected_amount_delegated,
     )
     confirmed = await aconfirm_transaction(test_http_client_async, resp["result"])
@@ -344,7 +344,7 @@ async def test_revoke(
 
     revoke_resp = await test_token.revoke(
         account=async_stubbed_sender_token_account_pk,
-        owner=async_stubbed_sender.public_key(),
+        owner=async_stubbed_sender.public_key,
     )
     revoke_confirmed = await aconfirm_transaction(test_http_client_async, revoke_resp["result"])
     assert_valid_response(revoke_confirmed)
@@ -367,7 +367,7 @@ async def test_approve_checked(
     resp = await test_token.approve_checked(
         source=async_stubbed_sender_token_account_pk,
         delegate=async_stubbed_receiver,
-        owner=async_stubbed_sender.public_key(),
+        owner=async_stubbed_sender.public_key,
         amount=expected_amount_delegated,
         decimals=6,
     )
@@ -451,7 +451,7 @@ async def test_create_multisig(
     """Test creating a multisig account."""
     min_signers = 2
     multisig_pubkey = await test_token.create_multisig(
-        min_signers, [async_stubbed_sender.public_key(), async_stubbed_receiver]
+        min_signers, [async_stubbed_sender.public_key, async_stubbed_receiver]
     )
     resp = test_http_client.get_account_info(multisig_pubkey)
     assert_valid_response(resp)
@@ -460,5 +460,5 @@ async def test_create_multisig(
     multisig_data = layouts.MULTISIG_LAYOUT.parse(decode_byte_string(resp["result"]["value"]["data"][0]))
     assert multisig_data.is_initialized
     assert multisig_data.m == min_signers
-    assert PublicKey(multisig_data.signer1) == async_stubbed_sender.public_key()
+    assert PublicKey(multisig_data.signer1) == async_stubbed_sender.public_key
     assert PublicKey(multisig_data.signer2) == async_stubbed_receiver

--- a/tests/integration/test_async_token_client.py
+++ b/tests/integration/test_async_token_client.py
@@ -28,12 +28,12 @@ async def test_token(async_stubbed_sender, freeze_authority, test_http_client_as
         async_stubbed_sender.public_key,
         expected_decimals,
         TOKEN_PROGRAM_ID,
-        freeze_authority.public_key(),
+        freeze_authority.public_key,
     )
 
     assert token_client.pubkey
     assert token_client.program_id == TOKEN_PROGRAM_ID
-    assert token_client.payer.public_key() == async_stubbed_sender.public_key
+    assert token_client.payer.public_key == async_stubbed_sender.public_key
 
     resp = await test_http_client_async.get_account_info(token_client.pubkey)
     assert_valid_response(resp)
@@ -44,7 +44,7 @@ async def test_token(async_stubbed_sender, freeze_authority, test_http_client_as
     assert mint_data.decimals == expected_decimals
     assert mint_data.supply == 0
     assert PublicKey(mint_data.mint_authority) == async_stubbed_sender.public_key
-    assert PublicKey(mint_data.freeze_authority) == freeze_authority.public_key()
+    assert PublicKey(mint_data.freeze_authority) == freeze_authority.public_key
     return token_client
 
 
@@ -64,7 +64,7 @@ async def async_stubbed_sender_token_account_pk(
 async def async_stubbed_receiver_token_account_pk(
     async_stubbed_receiver, test_token  # pylint: disable=redefined-outer-name
 ) -> PublicKey:
-    """Token account for stubbed reciever."""
+    """Token account for stubbed receiver."""
     return await test_token.create_account(async_stubbed_receiver)
 
 
@@ -136,7 +136,7 @@ async def test_get_mint_info(
     assert mint_info.supply == 0
     assert mint_info.decimals == 6
     assert mint_info.is_initialized is True
-    assert mint_info.freeze_authority == freeze_authority.public_key()
+    assert mint_info.freeze_authority == freeze_authority.public_key
 
 
 @pytest.mark.integration
@@ -384,7 +384,7 @@ async def test_freeze_account(
     async_stubbed_sender_token_account_pk, freeze_authority, test_token, test_http_client_async
 ):  # pylint: disable=redefined-outer-name
     """Test freezing an account."""
-    resp = await test_http_client_async.request_airdrop(freeze_authority.public_key(), AIRDROP_AMOUNT)
+    resp = await test_http_client_async.request_airdrop(freeze_authority.public_key, AIRDROP_AMOUNT)
     confirmed = await aconfirm_transaction(test_http_client_async, resp["result"])
     assert_valid_response(confirmed)
 

--- a/tests/integration/test_http_client.py
+++ b/tests/integration/test_http_client.py
@@ -23,7 +23,7 @@ def test_request_air_drop(stubbed_sender, test_http_client):
 @pytest.mark.integration
 def test_request_air_drop_prefetched_blockhash(stubbed_sender_prefetched_blockhash, test_http_client):
     """Test air drop to stubbed_sender."""
-    resp = test_http_client.request_airdrop(stubbed_sender_prefetched_blockhash.public_key(), AIRDROP_AMOUNT)
+    resp = test_http_client.request_airdrop(stubbed_sender_prefetched_blockhash.public_key, AIRDROP_AMOUNT)
     assert_valid_response(resp)
     resp = confirm_transaction(test_http_client, resp["result"])
     assert_valid_response(resp)
@@ -34,7 +34,7 @@ def test_request_air_drop_prefetched_blockhash(stubbed_sender_prefetched_blockha
 @pytest.mark.integration
 def test_request_air_drop_cached_blockhash(stubbed_sender_cached_blockhash, test_http_client):
     """Test air drop to stubbed_sender."""
-    resp = test_http_client.request_airdrop(stubbed_sender_cached_blockhash.public_key(), AIRDROP_AMOUNT)
+    resp = test_http_client.request_airdrop(stubbed_sender_cached_blockhash.public_key, AIRDROP_AMOUNT)
     assert_valid_response(resp)
     resp = confirm_transaction(test_http_client, resp["result"])
     assert_valid_response(resp)
@@ -96,7 +96,7 @@ def test_send_transaction_prefetched_blockhash(
     transfer_tx = Transaction().add(
         sp.transfer(
             sp.TransferParams(
-                from_pubkey=stubbed_sender_prefetched_blockhash.public_key(),
+                from_pubkey=stubbed_sender_prefetched_blockhash.public_key,
                 to_pubkey=stubbed_receiver_prefetched_blockhash,
                 lamports=1000,
             )
@@ -135,7 +135,7 @@ def test_send_transaction_prefetched_blockhash(
     }
     assert resp["result"]["meta"] == expected_meta
     # Check balances
-    resp = test_http_client.get_balance(stubbed_sender_prefetched_blockhash.public_key())
+    resp = test_http_client.get_balance(stubbed_sender_prefetched_blockhash.public_key)
     assert_valid_response(resp)
     assert resp["result"]["value"] == 9999994000
     resp = test_http_client.get_balance(stubbed_receiver_prefetched_blockhash)
@@ -152,7 +152,7 @@ def test_send_transaction_cached_blockhash(
     transfer_tx = Transaction().add(
         sp.transfer(
             sp.TransferParams(
-                from_pubkey=stubbed_sender_cached_blockhash.public_key(),
+                from_pubkey=stubbed_sender_cached_blockhash.public_key,
                 to_pubkey=stubbed_receiver_cached_blockhash,
                 lamports=1000,
             )
@@ -193,7 +193,7 @@ def test_send_transaction_cached_blockhash(
     }
     assert resp["result"]["meta"] == expected_meta
     # Check balances
-    resp = test_http_client_cached_blockhash.get_balance(stubbed_sender_cached_blockhash.public_key())
+    resp = test_http_client_cached_blockhash.get_balance(stubbed_sender_cached_blockhash.public_key)
     assert_valid_response(resp)
     assert resp["result"]["value"] == 9999994000
 
@@ -201,7 +201,7 @@ def test_send_transaction_cached_blockhash(
     transfer_tx = Transaction().add(
         sp.transfer(
             sp.TransferParams(
-                from_pubkey=stubbed_sender_cached_blockhash.public_key(),
+                from_pubkey=stubbed_sender_cached_blockhash.public_key,
                 to_pubkey=stubbed_receiver_cached_blockhash,
                 lamports=2000,
             )
@@ -235,7 +235,7 @@ def test_send_transaction_cached_blockhash(
     }
     assert resp["result"]["meta"] == expected_meta
     # Check balances
-    resp = test_http_client_cached_blockhash.get_balance(stubbed_sender_cached_blockhash.public_key())
+    resp = test_http_client_cached_blockhash.get_balance(stubbed_sender_cached_blockhash.public_key)
     assert_valid_response(resp)
     assert resp["result"]["value"] == 9999987000
     assert len(test_http_client_cached_blockhash.blockhash_cache.unused_blockhashes) == 1

--- a/tests/integration/test_http_client.py
+++ b/tests/integration/test_http_client.py
@@ -12,7 +12,7 @@ from .utils import AIRDROP_AMOUNT, assert_valid_response, confirm_transaction, g
 @pytest.mark.integration
 def test_request_air_drop(stubbed_sender, test_http_client):
     """Test air drop to stubbed_sender."""
-    resp = test_http_client.request_airdrop(stubbed_sender.public_key(), AIRDROP_AMOUNT)
+    resp = test_http_client.request_airdrop(stubbed_sender.public_key, AIRDROP_AMOUNT)
     assert_valid_response(resp)
     resp = confirm_transaction(test_http_client, resp["result"])
     assert_valid_response(resp)
@@ -47,9 +47,7 @@ def test_send_transaction_and_get_balance(stubbed_sender, stubbed_receiver, test
     """Test sending a transaction to localnet."""
     # Create transfer tx to transfer lamports from stubbed sender to stubbed_receiver
     transfer_tx = Transaction().add(
-        sp.transfer(
-            sp.TransferParams(from_pubkey=stubbed_sender.public_key(), to_pubkey=stubbed_receiver, lamports=1000)
-        )
+        sp.transfer(sp.TransferParams(from_pubkey=stubbed_sender.public_key, to_pubkey=stubbed_receiver, lamports=1000))
     )
     resp = test_http_client.send_transaction(transfer_tx, stubbed_sender)
     assert_valid_response(resp)
@@ -81,7 +79,7 @@ def test_send_transaction_and_get_balance(stubbed_sender, stubbed_receiver, test
     }
     assert resp["result"]["meta"] == expected_meta
     # Check balances
-    resp = test_http_client.get_balance(stubbed_sender.public_key())
+    resp = test_http_client.get_balance(stubbed_sender.public_key)
     assert_valid_response(resp)
     assert resp["result"]["value"] == 9999994000
     resp = test_http_client.get_balance(stubbed_receiver)
@@ -253,9 +251,7 @@ def test_send_raw_transaction_and_get_balance(stubbed_sender, stubbed_receiver, 
     recent_blockhash = resp["result"]["value"]["blockhash"]
     # Create transfer tx transfer lamports from stubbed sender to stubbed_receiver
     transfer_tx = Transaction(recent_blockhash=recent_blockhash).add(
-        sp.transfer(
-            sp.TransferParams(from_pubkey=stubbed_sender.public_key(), to_pubkey=stubbed_receiver, lamports=1000)
-        )
+        sp.transfer(sp.TransferParams(from_pubkey=stubbed_sender.public_key, to_pubkey=stubbed_receiver, lamports=1000))
     )
     # Sign transaction
     transfer_tx.sign(stubbed_sender)
@@ -282,7 +278,7 @@ def test_send_raw_transaction_and_get_balance(stubbed_sender, stubbed_receiver, 
     }
     assert resp["result"]["meta"] == expected_meta
     # Check balances
-    resp = test_http_client.get_balance(stubbed_sender.public_key())
+    resp = test_http_client.get_balance(stubbed_sender.public_key)
     assert_valid_response(resp)
     assert resp["result"]["value"] == 9999988000
     resp = test_http_client.get_balance(stubbed_receiver)
@@ -471,18 +467,18 @@ def test_get_version(test_http_client):
 @pytest.mark.integration
 def test_get_account_info(stubbed_sender, test_http_client):
     """Test get_account_info."""
-    resp = test_http_client.get_account_info(stubbed_sender.public_key())
+    resp = test_http_client.get_account_info(stubbed_sender.public_key)
     assert_valid_response(resp)
-    resp = test_http_client.get_account_info(stubbed_sender.public_key(), encoding="jsonParsed")
+    resp = test_http_client.get_account_info(stubbed_sender.public_key, encoding="jsonParsed")
     assert_valid_response(resp)
-    resp = test_http_client.get_account_info(stubbed_sender.public_key(), data_slice=DataSliceOpt(1, 1))
+    resp = test_http_client.get_account_info(stubbed_sender.public_key, data_slice=DataSliceOpt(1, 1))
     assert_valid_response(resp)
 
 
 @pytest.mark.integration
 def test_get_multiple_accounts(stubbed_sender, test_http_client):
     """Test get_multiple_accounts."""
-    pubkeys = [stubbed_sender.public_key()] * 2
+    pubkeys = [stubbed_sender.public_key] * 2
     resp = test_http_client.get_multiple_accounts(pubkeys)
     assert_valid_response(resp)
     resp = test_http_client.get_multiple_accounts(pubkeys, encoding="jsonParsed")

--- a/tests/integration/test_token_client.py
+++ b/tests/integration/test_token_client.py
@@ -16,14 +16,14 @@ from .utils import AIRDROP_AMOUNT, assert_valid_response, confirm_transaction
 @pytest.fixture(scope="module")
 def test_token(stubbed_sender, freeze_authority, test_http_client) -> Token:
     """Test create mint."""
-    resp = test_http_client.request_airdrop(stubbed_sender.public_key(), AIRDROP_AMOUNT)
+    resp = test_http_client.request_airdrop(stubbed_sender.public_key, AIRDROP_AMOUNT)
     assert_valid_response(confirm_transaction(test_http_client, resp["result"]))
 
     expected_decimals = 6
     token_client = Token.create_mint(
         test_http_client,
         stubbed_sender,
-        stubbed_sender.public_key(),
+        stubbed_sender.public_key,
         expected_decimals,
         TOKEN_PROGRAM_ID,
         freeze_authority.public_key(),
@@ -31,7 +31,7 @@ def test_token(stubbed_sender, freeze_authority, test_http_client) -> Token:
 
     assert token_client.pubkey
     assert token_client.program_id == TOKEN_PROGRAM_ID
-    assert token_client.payer.public_key() == stubbed_sender.public_key()
+    assert token_client.payer.public_key() == stubbed_sender.public_key
 
     resp = test_http_client.get_account_info(token_client.pubkey)
     assert_valid_response(resp)
@@ -41,7 +41,7 @@ def test_token(stubbed_sender, freeze_authority, test_http_client) -> Token:
     assert mint_data.is_initialized
     assert mint_data.decimals == expected_decimals
     assert mint_data.supply == 0
-    assert PublicKey(mint_data.mint_authority) == stubbed_sender.public_key()
+    assert PublicKey(mint_data.mint_authority) == stubbed_sender.public_key
     assert PublicKey(mint_data.freeze_authority) == freeze_authority.public_key()
     return token_client
 
@@ -50,7 +50,7 @@ def test_token(stubbed_sender, freeze_authority, test_http_client) -> Token:
 @pytest.fixture(scope="module")
 def stubbed_sender_token_account_pk(stubbed_sender, test_token) -> PublicKey:  # pylint: disable=redefined-outer-name
     """Token account for stubbed sender."""
-    return test_token.create_account(stubbed_sender.public_key())
+    return test_token.create_account(stubbed_sender.public_key)
 
 
 @pytest.mark.integration
@@ -65,7 +65,7 @@ def stubbed_receiver_token_account_pk(
 @pytest.mark.integration
 def test_new_account(stubbed_sender, test_http_client, test_token):  # pylint: disable=redefined-outer-name
     """Test creating a new token account."""
-    token_account_pk = test_token.create_account(stubbed_sender.public_key())
+    token_account_pk = test_token.create_account(stubbed_sender.public_key)
     resp = test_http_client.get_account_info(token_account_pk)
     assert_valid_response(resp)
     assert resp["result"]["value"]["owner"] == str(TOKEN_PROGRAM_ID)
@@ -81,7 +81,7 @@ def test_new_account(stubbed_sender, test_http_client, test_token):  # pylint: d
     assert not account_data.close_authority_option and PublicKey(account_data.close_authority) == PublicKey(0)
     assert not account_data.is_native_option and not account_data.is_native
     assert PublicKey(account_data.mint) == test_token.pubkey
-    assert PublicKey(account_data.owner) == stubbed_sender.public_key()
+    assert PublicKey(account_data.owner) == stubbed_sender.public_key
 
 
 @pytest.mark.integration
@@ -104,7 +104,7 @@ def test_get_account_info(
     account_info = test_token.get_account_info(stubbed_sender_token_account_pk)
     assert account_info.is_initialized is True
     assert account_info.mint == test_token.pubkey
-    assert account_info.owner == stubbed_sender.public_key()
+    assert account_info.owner == stubbed_sender.public_key
     assert account_info.amount == 0
     assert account_info.delegate is None
     assert account_info.delegated_amount == 0
@@ -118,7 +118,7 @@ def test_get_account_info(
 def test_get_mint_info(stubbed_sender, freeze_authority, test_token):  # pylint: disable=redefined-outer-name
     """Test get token mint info."""
     mint_info = test_token.get_mint_info()
-    assert mint_info.mint_authority == stubbed_sender.public_key()
+    assert mint_info.mint_authority == stubbed_sender.public_key
     assert mint_info.supply == 0
     assert mint_info.decimals == 6
     assert mint_info.is_initialized is True
@@ -273,13 +273,13 @@ def test_burn_checked(
 @pytest.mark.integration
 def test_get_accounts(stubbed_sender, test_token):  # pylint: disable=redefined-outer-name
     """Test get token accounts."""
-    resp = test_token.get_accounts(stubbed_sender.public_key())
+    resp = test_token.get_accounts(stubbed_sender.public_key)
     assert_valid_response(resp)
     assert len(resp["result"]["value"]) == 2
     for resp_data in resp["result"]["value"]:
         assert PublicKey(resp_data["pubkey"])
         parsed_data = resp_data["account"]["data"]["parsed"]["info"]
-        assert parsed_data["owner"] == str(stubbed_sender.public_key())
+        assert parsed_data["owner"] == str(stubbed_sender.public_key)
 
 
 @pytest.mark.integration
@@ -291,7 +291,7 @@ def test_approve(
     resp = test_token.approve(
         source=stubbed_sender_token_account_pk,
         delegate=stubbed_receiver,
-        owner=stubbed_sender.public_key(),
+        owner=stubbed_sender.public_key,
         amount=expected_amount_delegated,
     )
     assert_valid_response(confirm_transaction(test_http_client, resp["result"]))
@@ -312,7 +312,7 @@ def test_revoke(
 
     revoke_resp = test_token.revoke(
         account=stubbed_sender_token_account_pk,
-        owner=stubbed_sender.public_key(),
+        owner=stubbed_sender.public_key,
     )
     assert_valid_response(confirm_transaction(test_http_client, revoke_resp["result"]))
     account_info = test_token.get_account_info(stubbed_sender_token_account_pk)
@@ -329,7 +329,7 @@ def test_approve_checked(
     resp = test_token.approve_checked(
         source=stubbed_sender_token_account_pk,
         delegate=stubbed_receiver,
-        owner=stubbed_sender.public_key(),
+        owner=stubbed_sender.public_key,
         amount=expected_amount_delegated,
         decimals=6,
     )
@@ -396,7 +396,7 @@ def test_create_multisig(
 ):  # pylint: disable=redefined-outer-name
     """Test creating a multisig account."""
     min_signers = 2
-    multisig_pubkey = test_token.create_multisig(min_signers, [stubbed_sender.public_key(), stubbed_receiver])
+    multisig_pubkey = test_token.create_multisig(min_signers, [stubbed_sender.public_key, stubbed_receiver])
     resp = test_http_client.get_account_info(multisig_pubkey)
     assert_valid_response(resp)
     assert resp["result"]["value"]["owner"] == str(TOKEN_PROGRAM_ID)
@@ -404,5 +404,5 @@ def test_create_multisig(
     multisig_data = layouts.MULTISIG_LAYOUT.parse(decode_byte_string(resp["result"]["value"]["data"][0]))
     assert multisig_data.is_initialized
     assert multisig_data.m == min_signers
-    assert PublicKey(multisig_data.signer1) == stubbed_sender.public_key()
+    assert PublicKey(multisig_data.signer1) == stubbed_sender.public_key
     assert PublicKey(multisig_data.signer2) == stubbed_receiver

--- a/tests/integration/test_token_client.py
+++ b/tests/integration/test_token_client.py
@@ -26,12 +26,12 @@ def test_token(stubbed_sender, freeze_authority, test_http_client) -> Token:
         stubbed_sender.public_key,
         expected_decimals,
         TOKEN_PROGRAM_ID,
-        freeze_authority.public_key(),
+        freeze_authority.public_key,
     )
 
     assert token_client.pubkey
     assert token_client.program_id == TOKEN_PROGRAM_ID
-    assert token_client.payer.public_key() == stubbed_sender.public_key
+    assert token_client.payer.public_key == stubbed_sender.public_key
 
     resp = test_http_client.get_account_info(token_client.pubkey)
     assert_valid_response(resp)
@@ -42,7 +42,7 @@ def test_token(stubbed_sender, freeze_authority, test_http_client) -> Token:
     assert mint_data.decimals == expected_decimals
     assert mint_data.supply == 0
     assert PublicKey(mint_data.mint_authority) == stubbed_sender.public_key
-    assert PublicKey(mint_data.freeze_authority) == freeze_authority.public_key()
+    assert PublicKey(mint_data.freeze_authority) == freeze_authority.public_key
     return token_client
 
 
@@ -58,7 +58,7 @@ def stubbed_sender_token_account_pk(stubbed_sender, test_token) -> PublicKey:  #
 def stubbed_receiver_token_account_pk(
     stubbed_receiver, test_token  # pylint: disable=redefined-outer-name
 ) -> PublicKey:
-    """Token account for stubbed reciever."""
+    """Token account for stubbed receiver."""
     return test_token.create_account(stubbed_receiver)
 
 
@@ -122,7 +122,7 @@ def test_get_mint_info(stubbed_sender, freeze_authority, test_token):  # pylint:
     assert mint_info.supply == 0
     assert mint_info.decimals == 6
     assert mint_info.is_initialized is True
-    assert mint_info.freeze_authority == freeze_authority.public_key()
+    assert mint_info.freeze_authority == freeze_authority.public_key
 
 
 @pytest.mark.integration
@@ -344,7 +344,7 @@ def test_freeze_account(
     stubbed_sender_token_account_pk, freeze_authority, test_token, test_http_client
 ):  # pylint: disable=redefined-outer-name
     """Test freezing an account."""
-    resp = test_http_client.request_airdrop(freeze_authority.public_key(), AIRDROP_AMOUNT)
+    resp = test_http_client.request_airdrop(freeze_authority.public_key, AIRDROP_AMOUNT)
     assert_valid_response(confirm_transaction(test_http_client, resp["result"]))
 
     account_info = test_token.get_account_info(stubbed_sender_token_account_pk)

--- a/tests/unit/test_account.py
+++ b/tests/unit/test_account.py
@@ -58,7 +58,7 @@ def test_sign_message(stubbed_sender):
     """Test message signing."""
     msg = b"hello"
     signed_msg = stubbed_sender.sign(msg)
-    assert VerifyKey(bytes(stubbed_sender.public_key())).verify(signed_msg.message, signed_msg.signature) == msg
+    assert VerifyKey(bytes(stubbed_sender.public_key)).verify(signed_msg.message, signed_msg.signature) == msg
 
 
 def test_account_keypair():

--- a/tests/unit/test_confirmed_block.py
+++ b/tests/unit/test_confirmed_block.py
@@ -1,22 +1,22 @@
 """Test get confirmed block."""
 
 import solana.transaction as txlib
-from solana.account import Account
+from solana.keypair import Keypair
 from solana.system_program import TransferParams, transfer
 
 
 def test_verify_confirmed_block(stubbed_blockhash):
     """Test verifying signature in a confirmed block."""
-    acc0, acc1, acc2, acc3 = (Account() for _ in range(4))
+    kp0, kp1, kp2, kp3 = (Keypair() for _ in range(4))
     # Create a couple signed transaction
     txn1 = txlib.Transaction(recent_blockhash=stubbed_blockhash).add(
-        transfer(TransferParams(from_pubkey=acc0.public_key(), to_pubkey=acc1.public_key(), lamports=123))
+        transfer(TransferParams(from_pubkey=kp0.public_key, to_pubkey=kp1.public_key, lamports=123))
     )
-    txn1.sign(acc0)
+    txn1.sign(kp0)
     txn2 = txlib.Transaction(recent_blockhash=stubbed_blockhash).add(
-        transfer(TransferParams(from_pubkey=acc2.public_key(), to_pubkey=acc3.public_key(), lamports=456))
+        transfer(TransferParams(from_pubkey=kp2.public_key, to_pubkey=kp3.public_key, lamports=456))
     )
-    txn2.sign(acc2)
+    txn2.sign(kp2)
     # Build confirmed_block with dummy data for blockhases and balances
     confirmed_block = {
         "blockhash": stubbed_blockhash,
@@ -48,7 +48,7 @@ def test_verify_confirmed_block(stubbed_blockhash):
     # Verify signatures in confirmed_block
     assert all(tx_with_meta["transaction"].verify_signatures() for tx_with_meta in confirmed_block["transactions"])
     # Test block with bogus signature
-    bogus_signature = txlib.SigPubkeyPair(acc2.public_key(), bytes([9] * 64))  # pylint: disable=protected-access
+    bogus_signature = txlib.SigPubkeyPair(kp2.public_key, bytes([9] * 64))  # pylint: disable=protected-access
     txn1.signatures[0] = bogus_signature
     bad_confirmed_block = confirmed_block
     bad_confirmed_block["transactions"][0]["transaction"] = txn1

--- a/tests/unit/test_keypair.py
+++ b/tests/unit/test_keypair.py
@@ -1,5 +1,4 @@
 import base64
-import pytest
 from nacl.bindings import crypto_box_PUBLICKEYBYTES
 from solana.keypair import Keypair
 

--- a/tests/unit/test_keypair.py
+++ b/tests/unit/test_keypair.py
@@ -1,5 +1,7 @@
 import base64
+
 from nacl.bindings import crypto_box_PUBLICKEYBYTES
+
 from solana.keypair import Keypair
 
 

--- a/tests/unit/test_keypair.py
+++ b/tests/unit/test_keypair.py
@@ -1,0 +1,35 @@
+import base64
+import pytest
+from nacl.bindings import crypto_box_PUBLICKEYBYTES
+from solana.keypair import Keypair
+
+
+def test_new_keypair() -> None:
+    """Test new keypair with random seed is created successfully."""
+    keypair = Keypair()
+    assert len(keypair.secret_key) == 64
+    assert len(bytes(keypair.public_key)) == crypto_box_PUBLICKEYBYTES
+
+
+def test_generate_keypair() -> None:
+    """Test .generate constructor works."""
+    keypair = Keypair.generate()
+    assert len(keypair.secret_key) == 64
+
+
+def test_create_from_secret_key() -> None:
+    """Test creation with 64-byte secret key."""
+    secret_key = base64.b64decode(
+        "mdqVWeFekT7pqy5T49+tV12jO0m+ESW7ki4zSU9JiCgbL0kJbj5dvQ/PqcDAzZLZqzshVEs01d1KZdmLh4uZIg=="
+    )
+    keypair = Keypair.from_secret_key(secret_key)
+    assert str(keypair.public_key) == "2q7pyhPwAwZ3QMfZrnAbDhnh9mDUqycszcpf86VgQxhF"
+    assert keypair.secret_key == secret_key
+
+
+def test_create_from_seed() -> None:
+    """Test creation with 32-byte secret seed."""
+    seed = bytes([8] * 32)
+    keypair = Keypair.from_seed(seed)
+    assert str(keypair.public_key) == "2KW2XRd9kwqet15Aha2oK3tYvd3nWbTFH1MBiRAv1BE1"
+    assert keypair.seed == seed

--- a/tests/unit/test_spl_token_instructions.py
+++ b/tests/unit/test_spl_token_instructions.py
@@ -11,7 +11,7 @@ def test_initialize_mint(stubbed_sender):
     params_with_freeze = spl_token.InitializeMintParams(
         decimals=18,
         program_id=TOKEN_PROGRAM_ID,
-        mint=stubbed_sender.public_key(),
+        mint=stubbed_sender.public_key,
         mint_authority=mint_authority,
         freeze_authority=freeze_authority,
     )
@@ -21,7 +21,7 @@ def test_initialize_mint(stubbed_sender):
     params_no_freeze = spl_token.InitializeMintParams(
         decimals=18,
         program_id=TOKEN_PROGRAM_ID,
-        mint=stubbed_sender.public_key(),
+        mint=stubbed_sender.public_key,
         mint_authority=mint_authority,
     )
     instruction = spl_token.initialize_mint(params_no_freeze)
@@ -37,7 +37,7 @@ def test_initialize_account(stubbed_sender):
         program_id=TOKEN_PROGRAM_ID,
         account=new_account,
         mint=token_mint,
-        owner=stubbed_sender.public_key(),
+        owner=stubbed_sender.public_key,
     )
     instruction = spl_token.initialize_account(params)
     assert spl_token.decode_initialize_account(instruction) == params
@@ -61,9 +61,9 @@ def test_transfer(stubbed_receiver, stubbed_sender):
     """Test transfer."""
     params = spl_token.TransferParams(
         program_id=TOKEN_PROGRAM_ID,
-        source=stubbed_sender.public_key(),
+        source=stubbed_sender.public_key,
         dest=stubbed_receiver,
-        owner=stubbed_sender.public_key(),
+        owner=stubbed_sender.public_key,
         amount=123,
     )
     instruction = spl_token.transfer(params)
@@ -71,9 +71,9 @@ def test_transfer(stubbed_receiver, stubbed_sender):
 
     multisig_params = spl_token.TransferParams(
         program_id=TOKEN_PROGRAM_ID,
-        source=stubbed_sender.public_key(),
+        source=stubbed_sender.public_key,
         dest=stubbed_receiver,
-        owner=stubbed_sender.public_key(),
+        owner=stubbed_sender.public_key,
         signers=[PublicKey(i + 1) for i in range(3)],
         amount=123,
     )
@@ -86,9 +86,9 @@ def test_approve(stubbed_sender):
     delegate_account = PublicKey(0)
     params = spl_token.ApproveParams(
         program_id=TOKEN_PROGRAM_ID,
-        source=stubbed_sender.public_key(),
+        source=stubbed_sender.public_key,
         delegate=delegate_account,
-        owner=stubbed_sender.public_key(),
+        owner=stubbed_sender.public_key,
         amount=123,
     )
     instruction = spl_token.approve(params)
@@ -96,9 +96,9 @@ def test_approve(stubbed_sender):
 
     multisig_params = spl_token.ApproveParams(
         program_id=TOKEN_PROGRAM_ID,
-        source=stubbed_sender.public_key(),
+        source=stubbed_sender.public_key,
         delegate=delegate_account,
-        owner=stubbed_sender.public_key(),
+        owner=stubbed_sender.public_key,
         signers=[PublicKey(i + 1) for i in range(3)],
         amount=123,
     )
@@ -112,7 +112,7 @@ def test_revoke(stubbed_sender):
     params = spl_token.RevokeParams(
         program_id=TOKEN_PROGRAM_ID,
         account=delegate_account,
-        owner=stubbed_sender.public_key(),
+        owner=stubbed_sender.public_key,
     )
     instruction = spl_token.revoke(params)
     assert spl_token.decode_revoke(instruction) == params
@@ -120,7 +120,7 @@ def test_revoke(stubbed_sender):
     multisig_params = spl_token.RevokeParams(
         program_id=TOKEN_PROGRAM_ID,
         account=delegate_account,
-        owner=stubbed_sender.public_key(),
+        owner=stubbed_sender.public_key,
         signers=[PublicKey(i + 1) for i in range(3)],
     )
     instruction = spl_token.revoke(multisig_params)
@@ -209,8 +209,8 @@ def test_close_account(stubbed_sender):
     params = spl_token.CloseAccountParams(
         program_id=TOKEN_PROGRAM_ID,
         account=token_account,
-        dest=stubbed_sender.public_key(),
-        owner=stubbed_sender.public_key(),
+        dest=stubbed_sender.public_key,
+        owner=stubbed_sender.public_key,
     )
     instruction = spl_token.close_account(params)
     assert spl_token.decode_close_account(instruction) == params
@@ -218,8 +218,8 @@ def test_close_account(stubbed_sender):
     multisig_params = spl_token.CloseAccountParams(
         program_id=TOKEN_PROGRAM_ID,
         account=token_account,
-        dest=stubbed_sender.public_key(),
-        owner=stubbed_sender.public_key(),
+        dest=stubbed_sender.public_key,
+        owner=stubbed_sender.public_key,
         signers=[PublicKey(i + 1) for i in range(3)],
     )
     instruction = spl_token.close_account(multisig_params)
@@ -233,7 +233,7 @@ def test_freeze_account(stubbed_sender):
         program_id=TOKEN_PROGRAM_ID,
         account=token_account,
         mint=mint,
-        authority=stubbed_sender.public_key(),
+        authority=stubbed_sender.public_key,
     )
     instruction = spl_token.freeze_account(params)
     assert spl_token.decode_freeze_account(instruction) == params
@@ -242,7 +242,7 @@ def test_freeze_account(stubbed_sender):
         program_id=TOKEN_PROGRAM_ID,
         account=token_account,
         mint=mint,
-        authority=stubbed_sender.public_key(),
+        authority=stubbed_sender.public_key,
         multi_signers=[PublicKey(i) for i in range(2, 10)],
     )
     instruction = spl_token.freeze_account(multisig_params)
@@ -256,7 +256,7 @@ def test_thaw_account(stubbed_sender):
         program_id=TOKEN_PROGRAM_ID,
         account=token_account,
         mint=mint,
-        authority=stubbed_sender.public_key(),
+        authority=stubbed_sender.public_key,
     )
     instruction = spl_token.thaw_account(params)
     assert spl_token.decode_thaw_account(instruction) == params
@@ -265,7 +265,7 @@ def test_thaw_account(stubbed_sender):
         program_id=TOKEN_PROGRAM_ID,
         account=token_account,
         mint=mint,
-        authority=stubbed_sender.public_key(),
+        authority=stubbed_sender.public_key,
         multi_signers=[PublicKey(i) for i in range(2, 10)],
     )
     instruction = spl_token.thaw_account(multisig_params)
@@ -277,10 +277,10 @@ def test_transfer_checked(stubbed_receiver, stubbed_sender):
     mint = PublicKey(0)
     params = spl_token.TransferCheckedParams(
         program_id=TOKEN_PROGRAM_ID,
-        source=stubbed_sender.public_key(),
+        source=stubbed_sender.public_key,
         mint=mint,
         dest=stubbed_receiver,
-        owner=stubbed_sender.public_key(),
+        owner=stubbed_sender.public_key,
         amount=123,
         decimals=6,
     )
@@ -289,10 +289,10 @@ def test_transfer_checked(stubbed_receiver, stubbed_sender):
 
     multisig_params = spl_token.TransferCheckedParams(
         program_id=TOKEN_PROGRAM_ID,
-        source=stubbed_sender.public_key(),
+        source=stubbed_sender.public_key,
         mint=mint,
         dest=stubbed_receiver,
-        owner=stubbed_sender.public_key(),
+        owner=stubbed_sender.public_key,
         signers=[PublicKey(i + 1) for i in range(3)],
         amount=123,
         decimals=6,
@@ -306,10 +306,10 @@ def test_approve_checked(stubbed_receiver, stubbed_sender):
     mint = PublicKey(0)
     params = spl_token.ApproveCheckedParams(
         program_id=TOKEN_PROGRAM_ID,
-        source=stubbed_sender.public_key(),
+        source=stubbed_sender.public_key,
         mint=mint,
         delegate=stubbed_receiver,
-        owner=stubbed_sender.public_key(),
+        owner=stubbed_sender.public_key,
         amount=123,
         decimals=6,
     )
@@ -318,10 +318,10 @@ def test_approve_checked(stubbed_receiver, stubbed_sender):
 
     multisig_params = spl_token.ApproveCheckedParams(
         program_id=TOKEN_PROGRAM_ID,
-        source=stubbed_sender.public_key(),
+        source=stubbed_sender.public_key,
         mint=mint,
         delegate=stubbed_receiver,
-        owner=stubbed_sender.public_key(),
+        owner=stubbed_sender.public_key,
         signers=[PublicKey(i + 1) for i in range(3)],
         amount=123,
         decimals=6,

--- a/tests/unit/test_system_program.py
+++ b/tests/unit/test_system_program.py
@@ -1,7 +1,6 @@
 """Unit tests for solana.system_program."""
 import solana.system_program as sp
 from solana.keypair import Keypair
-from solana.keypair import Keypair
 from solana.publickey import PublicKey
 
 

--- a/tests/unit/test_system_program.py
+++ b/tests/unit/test_system_program.py
@@ -1,14 +1,15 @@
 """Unit tests for solana.system_program."""
 import solana.system_program as sp
-from solana.account import Account
+from solana.keypair import Keypair
+from solana.keypair import Keypair
 from solana.publickey import PublicKey
 
 
 def test_create_account():
     """Test creating a transaction for create account."""
     params = sp.CreateAccountParams(
-        from_pubkey=Account().public_key(),
-        new_account_pubkey=Account().public_key(),
+        from_pubkey=Keypair().public_key,
+        new_account_pubkey=Keypair().public_key,
         lamports=123,
         space=1,
         program_id=PublicKey(1),
@@ -18,14 +19,14 @@ def test_create_account():
 
 def test_transfer():
     """Test creating a transaction for transfer."""
-    params = sp.TransferParams(from_pubkey=Account().public_key(), to_pubkey=Account().public_key(), lamports=123)
+    params = sp.TransferParams(from_pubkey=Keypair().public_key, to_pubkey=Keypair().public_key, lamports=123)
     assert sp.decode_transfer(sp.transfer(params)) == params
 
 
 def test_assign():
     """Test creating a transaction for assign."""
     params = sp.AssignParams(
-        account_pubkey=Account().public_key(),
+        account_pubkey=Keypair().public_key,
         program_id=PublicKey(1),
     )
     assert sp.decode_assign(sp.assign(params)) == params
@@ -34,7 +35,7 @@ def test_assign():
 def test_allocate():
     """Test creating a transaction for allocate."""
     params = sp.AllocateParams(
-        account_pubkey=Account().public_key(),
+        account_pubkey=Keypair().public_key,
         space=12345,
     )
     assert sp.decode_allocate(sp.allocate(params)) == params
@@ -43,7 +44,7 @@ def test_allocate():
 def test_allocate_with_seed():
     """Test creating a transaction for allocate with seed."""
     params = sp.AllocateWithSeedParams(
-        account_pubkey=Account().public_key(),
+        account_pubkey=Keypair().public_key,
         base_pubkey=PublicKey(1),
         seed={"length": 4, "chars": "gqln"},
         space=65537,
@@ -55,7 +56,7 @@ def test_allocate_with_seed():
 def test_create_account_with_seed():
     """Test creating a an account with seed."""
     params = sp.CreateAccountWithSeedParams(
-        from_pubkey=Account().public_key(),
+        from_pubkey=Keypair().public_key,
         new_account_pubkey=PublicKey(3),
         base_pubkey=PublicKey(1),
         seed={"length": 4, "chars": "gqln"},

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -7,33 +7,34 @@ from base58 import b58encode
 import solana.system_program as sp
 import solana.transaction as txlib
 from solana.account import Account
+from solana.keypair import Keypair
 from solana.message import CompiledInstruction, Message, MessageArgs, MessageHeader
 from solana.publickey import PublicKey
 
 
 def test_sign_partial(stubbed_blockhash):
     """Test paritally sigining a transaction."""
-    acc1, acc2 = Account(), Account()
-    transfer = sp.transfer(sp.TransferParams(from_pubkey=acc1.public_key(), to_pubkey=acc2.public_key(), lamports=123))
+    kp1, kp2 = Keypair(), Keypair()
+    transfer = sp.transfer(sp.TransferParams(from_pubkey=kp1.public_key, to_pubkey=kp2.public_key, lamports=123))
     partial_txn = txlib.Transaction(recent_blockhash=stubbed_blockhash).add(transfer)
-    partial_txn.sign_partial(acc1, acc2.public_key())
+    partial_txn.sign_partial(kp1, kp2.public_key)
     assert len(partial_txn.signature()) == txlib.SIG_LENGTH
     assert len(partial_txn.signatures) == 2
     assert not partial_txn.signatures[1].signature
 
-    partial_txn.add_signer(acc2)
+    partial_txn.add_signer(kp2)
     expected_txn = txlib.Transaction(recent_blockhash=stubbed_blockhash).add(transfer)
-    expected_txn.sign(acc1, acc2)
+    expected_txn.sign(kp1, kp2)
     assert partial_txn == expected_txn
 
 
 def test_transfer_signatures(stubbed_blockhash):
     """Test signing transfer transactions."""
-    acc1, acc2 = Account(), Account()
-    transfer1 = sp.transfer(sp.TransferParams(from_pubkey=acc1.public_key(), to_pubkey=acc2.public_key(), lamports=123))
-    transfer2 = sp.transfer(sp.TransferParams(from_pubkey=acc2.public_key(), to_pubkey=acc1.public_key(), lamports=123))
+    kp1, kp2 = Keypair(), Keypair()
+    transfer1 = sp.transfer(sp.TransferParams(from_pubkey=kp1.public_key, to_pubkey=kp2.public_key, lamports=123))
+    transfer2 = sp.transfer(sp.TransferParams(from_pubkey=kp2.public_key, to_pubkey=kp1.public_key, lamports=123))
     txn = txlib.Transaction(recent_blockhash=stubbed_blockhash).add(transfer1, transfer2)
-    txn.sign(acc1, acc2)
+    txn.sign(kp1, kp2)
 
     expected = txlib.Transaction(recent_blockhash=stubbed_blockhash, signatures=txn.signatures).add(
         transfer1, transfer2
@@ -43,17 +44,17 @@ def test_transfer_signatures(stubbed_blockhash):
 
 def test_dedup_signatures(stubbed_blockhash):
     """Test signature deduplication."""
-    acc1, acc2 = Account(), Account()
-    transfer1 = sp.transfer(sp.TransferParams(from_pubkey=acc1.public_key(), to_pubkey=acc2.public_key(), lamports=123))
-    transfer2 = sp.transfer(sp.TransferParams(from_pubkey=acc1.public_key(), to_pubkey=acc2.public_key(), lamports=123))
+    kp1, kp2 = Keypair(), Keypair()
+    transfer1 = sp.transfer(sp.TransferParams(from_pubkey=kp1.public_key, to_pubkey=kp2.public_key, lamports=123))
+    transfer2 = sp.transfer(sp.TransferParams(from_pubkey=kp1.public_key, to_pubkey=kp2.public_key, lamports=123))
     txn = txlib.Transaction(recent_blockhash=stubbed_blockhash).add(transfer1, transfer2)
-    txn.sign(acc1)
+    txn.sign(kp1)
 
 
 def test_wire_format_and_desrialize(stubbed_blockhash, stubbed_receiver, stubbed_sender):
     """Test serialize/derialize transaction to/from wire format."""
     transfer = sp.transfer(
-        sp.TransferParams(from_pubkey=stubbed_sender.public_key(), to_pubkey=stubbed_receiver, lamports=49)
+        sp.TransferParams(from_pubkey=stubbed_sender.public_key, to_pubkey=stubbed_receiver, lamports=49)
     )
     expected_txn = txlib.Transaction(recent_blockhash=stubbed_blockhash).add(transfer)
     expected_txn.sign(stubbed_sender)
@@ -90,7 +91,7 @@ def test_populate(stubbed_blockhash):
 def test_serialize_unsigned_transaction(stubbed_blockhash, stubbed_receiver, stubbed_sender):
     """Test to serialize an unsigned transaction."""
     transfer = sp.transfer(
-        sp.TransferParams(from_pubkey=stubbed_sender.public_key(), to_pubkey=stubbed_receiver, lamports=49)
+        sp.TransferParams(from_pubkey=stubbed_sender.public_key, to_pubkey=stubbed_receiver, lamports=49)
     )
     txn = txlib.Transaction(recent_blockhash=stubbed_blockhash).add(transfer)
     assert len(txn.signatures) == 0
@@ -100,7 +101,7 @@ def test_serialize_unsigned_transaction(stubbed_blockhash, stubbed_receiver, stu
     assert len(txn.signatures) == 0
 
     # Set fee payer
-    txn.fee_payer = stubbed_sender.public_key()
+    txn.fee_payer = stubbed_sender.public_key
     # Serialize message
     assert b64encode(txn.serialize_message()) == (
         b"AQABAxOY9ixtGkV8UbpqS189vS9p/KkyFiGNyJl+QWvRfZPK/UOfzLZnJ/KJxcbeO8So/l3V13dwvI/xXD7u3LFK8/wAAAAAAAAA"

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -6,7 +6,6 @@ from base58 import b58encode
 
 import solana.system_program as sp
 import solana.transaction as txlib
-from solana.account import Account
 from solana.keypair import Keypair
 from solana.message import CompiledInstruction, Message, MessageArgs, MessageHeader
 from solana.publickey import PublicKey


### PR DESCRIPTION
Closes #62 

Making this a draft PR because I'll want to look again tomorrow, but would like to hear thoughts in the meantime.

Summary of changes:

- Add keypair.py similar to keypair.ts
- Replace all usage of Account with Keypair, except in account.py itself
- Add deprecation warning to Account