### PR TITLE
Install gcc in docs action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Sphinx Build
         uses: ammaraskar/sphinx-action@0.4
         with:
-          pre-build-command: pip install sphinx_rtd_theme
+          pre-build-command: apt-get update -y && apt-get install -y python3-dev build-essential && pip install sphinx_rtd_theme
           docs-folder: .
 
       - name: Deploy


### PR DESCRIPTION
The docs CI has stopped working because it can't find gcc anymore. While it's unclear why this has started happening (nothing changed in this repo), I'm modifying the CI with a command that should get gcc installed. Got the command here:

https://github.com/ammaraskar/sphinx-action/issues/6