### PR TITLE
More docs ci deps

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Sphinx Build
         uses: ammaraskar/sphinx-action@0.4
         with:
-          pre-build-command: apt-get update -y && apt-get install -y python3-dev build-essential && pip install sphinx_rtd_theme
+          pre-build-command: apt-get update -y && apt-get install -y python3-dev build-essential libssl-dev libffi-dev cargo && pip install sphinx_rtd_theme
           docs-folder: .
 
       - name: Deploy


### PR DESCRIPTION
Installing more deps to get the docs ci working again. Going off this https://cryptography.io/en/latest/installation/#debian-ubuntu