### PR TITLE
add --dev to poetry export

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
         run: poetry install
 
       - name: Doc dependencies
-        run: poetry export -f requirements.txt --output requirements.txt
+        run: poetry export --dev -f requirements.txt --output requirements.txt
 
       - name: Sphinx Build
         uses: ammaraskar/sphinx-action@0.4


### PR DESCRIPTION
Docs CI was breaking because sphinx-rtd-theme wasn't installed, because `poetry export` doesn't include dev deps by default