### PR TITLE
Add missing imports to send_transaction doc entry

### DIFF
--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -1033,6 +1033,8 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
             skip fetching the recent blockhash or relying on the cache.
 
         >>> from solana.keypair import Keypair
+        >>> from solana.publickey import PublicKey
+        >>> from solana.rpc.api import Client
         >>> from solana.system_program import TransferParams, transfer
         >>> from solana.transaction import Transaction
         >>> sender, receiver = Keypair.from_seed(bytes(PublicKey(1))), Keypair.from_seed(bytes(PublicKey(2)))


### PR DESCRIPTION
Hi!

In case this is desirable, I've created this PR that adds the following imports so the example provided in the docs works when executed in a shell:
- "from solana.publickey import PublicKey"
- "from solana.rpc.api import Client"