### PR TITLE
Add "until" parameter to get_signatures_for_address

### DIFF
--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -11,8 +11,8 @@ from solana.publickey import PublicKey
 from solana.rpc import types
 from solana.transaction import Transaction
 
-from .commitment import Commitment, Finalized, COMMITMENT_RANKS
-from .core import _ClientCore, RPCException, UnconfirmedTxError
+from .commitment import COMMITMENT_RANKS, Commitment, Finalized
+from .core import RPCException, UnconfirmedTxError, _ClientCore
 from .providers import http
 
 
@@ -272,7 +272,11 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         return self._provider.make_request(*args)
 
     def get_confirmed_signature_for_address2(
-        self, account: Union[str, Keypair, PublicKey], before: Optional[str] = None, limit: Optional[int] = None
+        self,
+        account: Union[str, Keypair, PublicKey],
+        before: Optional[str] = None,
+        until: Optional[str] = None,
+        limit: Optional[int] = None,
     ) -> types.RPCResponse:
         """Returns confirmed signatures for transactions involving an address.
 
@@ -282,6 +286,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         :param account: Account to be queried.
         :param before: (optional) Start searching backwards from this transaction signature.
             If not provided the search starts from the top of the highest max confirmed block.
+        :param until: (optional) Search until this transaction signature, if found before limit reached.
         :param limit: (optoinal) Maximum transaction signatures to return (between 1 and 1,000, default: 1,000).
 
         >>> solana_client = Client("http://localhost:8899")
@@ -293,11 +298,15 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
            'slot': 4290}],
          'id': 2}
         """  # noqa: E501 # pylint: disable=line-too-long
-        args = self._get_confirmed_signature_for_address2_args(account, before, limit)
+        args = self._get_confirmed_signature_for_address2_args(account, before, until, limit)
         return self._provider.make_request(*args)
 
     def get_signatures_for_address(
-        self, account: Union[str, Keypair, PublicKey], before: Optional[str] = None, limit: Optional[int] = None
+        self,
+        account: Union[str, Keypair, PublicKey],
+        before: Optional[str] = None,
+        until: Optional[str] = None,
+        limit: Optional[int] = None,
     ) -> types.RPCResponse:
         """Returns confirmed signatures for transactions involving an address.
 
@@ -307,6 +316,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         :param account: Account to be queried.
         :param before: (optional) Start searching backwards from this transaction signature.
             If not provided the search starts from the top of the highest max confirmed block.
+        :param until: (optional) Search until this transaction signature, if found before limit reached.
         :param limit: (optional) Maximum transaction signatures to return (between 1 and 1,000, default: 1,000).
 
         >>> solana_client = Client("http://localhost:8899")
@@ -318,7 +328,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
            'slot': 4290}],
          'id': 2}
         """  # noqa: E501 # pylint: disable=line-too-long
-        args = self._get_signatures_for_address_args(account, before, limit)
+        args = self._get_signatures_for_address_args(account, before, until, limit)
         return self._provider.make_request(*args)
 
     def get_confirmed_transaction(self, tx_sig: str, encoding: str = "json") -> types.RPCResponse:

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -1,7 +1,7 @@
 """Async API client to interact with the Solana JSON RPC Endpoint."""  # pylint: disable=too-many-lines
 import asyncio
-from typing import List, Optional, Union
 from time import time
+from typing import List, Optional, Union
 
 from solana.blockhash import Blockhash, BlockhashCache
 from solana.keypair import Keypair
@@ -9,8 +9,8 @@ from solana.publickey import PublicKey
 from solana.rpc import types
 from solana.transaction import Transaction
 
-from .commitment import Commitment, Finalized, COMMITMENT_RANKS
-from .core import _ClientCore, RPCException, UnconfirmedTxError
+from .commitment import COMMITMENT_RANKS, Commitment, Finalized
+from .core import RPCException, UnconfirmedTxError, _ClientCore
 from .providers import async_http
 
 
@@ -269,7 +269,11 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         return await self._provider.make_request(*args)
 
     async def get_confirmed_signature_for_address2(
-        self, account: Union[str, Keypair, PublicKey], before: Optional[str] = None, limit: Optional[int] = None
+        self,
+        account: Union[str, Keypair, PublicKey],
+        before: Optional[str] = None,
+        until: Optional[str] = None,
+        limit: Optional[int] = None,
     ) -> types.RPCResponse:
         """Returns confirmed signatures for transactions involving an address.
 
@@ -279,6 +283,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         :param account: Account to be queried.
         :param before: (optional) Start searching backwards from this transaction signature.
             If not provided the search starts from the top of the highest max confirmed block.
+        :param until: (optional) Search until this transaction signature, if found before limit reached.
         :param limit: (optoinal) Maximum transaction signatures to return (between 1 and 1,000, default: 1,000).
 
         >>> solana_client = AsyncClient("http://localhost:8899")
@@ -290,11 +295,15 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
            'slot': 4290}],
          'id': 2}
         """  # noqa: E501 # pylint: disable=line-too-long
-        args = self._get_confirmed_signature_for_address2_args(account, before, limit)
+        args = self._get_confirmed_signature_for_address2_args(account, before, until, limit)
         return await self._provider.make_request(*args)
 
     async def get_signatures_for_address(
-        self, account: Union[str, Keypair, PublicKey], before: Optional[str] = None, limit: Optional[int] = None
+        self,
+        account: Union[str, Keypair, PublicKey],
+        before: Optional[str] = None,
+        until: Optional[str] = None,
+        limit: Optional[int] = None,
     ) -> types.RPCResponse:
         """Returns confirmed signatures for transactions involving an address.
 
@@ -304,6 +313,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         :param account: Account to be queried.
         :param before: (optional) Start searching backwards from this transaction signature.
             If not provided the search starts from the top of the highest max confirmed block.
+        :param until: (optional) Search until this transaction signature, if found before limit reached.
         :param limit: (optional) Maximum transaction signatures to return (between 1 and 1,000, default: 1,000).
 
         >>> solana_client = AsyncClient("http://localhost:8899")
@@ -315,7 +325,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
            'slot': 4290}],
          'id': 2}
         """  # noqa: E501 # pylint: disable=line-too-long
-        args = self._get_signatures_for_address_args(account, before, limit)
+        args = self._get_signatures_for_address_args(account, before, until, limit)
         return await self._provider.make_request(*args)
 
     async def get_confirmed_transaction(self, tx_sig: str, encoding: str = "json") -> types.RPCResponse:

--- a/src/solana/rpc/core.py
+++ b/src/solana/rpc/core.py
@@ -91,7 +91,7 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def _get_confirmed_signature_for_address2_args(
-        account: Union[str, Keypair, PublicKey], before: Optional[str], limit: Optional[int]
+        account: Union[str, Keypair, PublicKey], before: Optional[str], until: Optional[str], limit: Optional[int]
     ) -> Tuple[types.RPCMethod, str, Dict[str, Union[int, str]]]:
         warn(
             "solana.rpc.api.getConfirmedSignaturesForAddress2 is deprecated, "
@@ -101,6 +101,8 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         opts: Dict[str, Union[int, str]] = {}
         if before:
             opts["before"] = before
+        if until:
+            opts["until"] = until
         if limit:
             opts["limit"] = limit
 
@@ -112,11 +114,13 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def _get_signatures_for_address_args(
-        account: Union[str, Keypair, PublicKey], before: Optional[str], limit: Optional[int]
+        account: Union[str, Keypair, PublicKey], before: Optional[str], until: Optional[str], limit: Optional[int]
     ) -> Tuple[types.RPCMethod, str, Dict[str, Union[int, str]]]:
         opts: Dict[str, Union[int, str]] = {}
         if before:
             opts["before"] = before
+        if until:
+            opts["until"] = until
         if limit:
             opts["limit"] = limit
 


### PR DESCRIPTION
See: https://docs.solana.com/developing/clients/jsonrpc-api#getsignaturesforaddress

Also added to deprecated get_confirmed_signature_for_address2, because it's supported, see: https://docs.solana.com/developing/clients/jsonrpc-api#getconfirmedsignaturesforaddress2

Fixes #44