### PR TITLE
Adding nondeprecated client functions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,11 +26,6 @@ jobs:
       #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
-      - name: Load cached Poetry installation
-        uses: actions/cache@v2
-        with:
-          path: ~/.local  # the path depends on the OS
-          key: poetry-1  # increment to reset cache
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,11 +27,6 @@ jobs:
       #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
-      - name: Load cached Poetry installation
-        uses: actions/cache@v2
-        with:
-          path: ~/.local  # the path depends on the OS
-          key: poetry-1  # increment to reset cache
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,11 +143,6 @@ jobs:
       #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
-      - name: Load cached Poetry installation
-        uses: actions/cache@v2
-        with:
-          path: ~/.local  # the path depends on the OS
-          key: poetry-1  # increment to reset cache
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,11 +84,6 @@ jobs:
       #----------------------------------------------
       #  -----  install & configure poetry  -----
       #----------------------------------------------
-      - name: Load cached Poetry installation
-        uses: actions/cache@v2
-        with:
-          path: ~/.local  # the path depends on the OS
-          key: poetry-1  # increment to reset cache
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
         with:

--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -258,6 +258,63 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         args = self._get_confirmed_block_args(slot, encoding)
         return self._provider.make_request(*args)
 
+    def get_block(
+        self,
+        slot: int,
+        encoding: str = "json",
+    ) -> types.RPCResponse:
+        """Returns identity and transaction information about a confirmed block in the ledger.
+
+        :param slot: Slot, as u64 integer.
+        :param encoding: (optional) Encoding for the returned Transaction, either "json", "jsonParsed",
+            "base58" (slow), or "base64". If parameter not provided, the default encoding is JSON.
+
+        >>> solana_client = Client("http://localhost:8899")
+        >>> solana_client.get_block(1) # doctest: +SKIP
+        {'jsonrpc': '2.0',
+         'result': {'blockTime': None, 'blockHeight': 0,
+          'blockhash': '39pJzWsPn59k2PuHqhB7xNYBNGFXcFVkXLertHPBV4Tj',
+          'parentSlot': 0,
+          'previousBlockhash': 'EwF9gtehrrvPUoNticgmiEadAWzn4XeN8bNaNVBkS6S2',
+          'rewards': [],
+          'transactions': [{'meta': {'err': None,
+             'fee': 0,
+             'postBalances': [500000000000, 26858640, 1, 1, 1],
+             'preBalances': [500000000000, 26858640, 1, 1, 1],
+             'status': {'Ok': None}},
+            'transaction': {'message': {'accountKeys': ['LjvEBM78ufAikBfxqtj4RNiAECUi7Xqtz9k3QM3DzPk',
+               'EKAar3bMQUZvGSonq7vcPF2nPaCYowbnat44FPafW8Po',
+               'SysvarS1otHashes111111111111111111111111111',
+               'SysvarC1ock11111111111111111111111111111111',
+               'Vote111111111111111111111111111111111111111'],
+              'header': {'numReadonlySignedAccounts': 0,
+               'numReadonlyUnsignedAccounts': 3,
+               'numRequiredSignatures': 1},
+              'instructions': [{'accounts': [1, 2, 3, 0],
+                'data': '37u9WtQpcm6ULa3VmTgTKEBCtYMxq84mk82tRvKdFEwj3rALiptAzuMJ1yoVSFAMARMZYp7q',
+                'programIdIndex': 4}],
+              'recentBlockhash': 'EwF9gtehrrvPUoNticgmiEadAWzn4XeN8bNaNVBkS6S2'},
+             'signatures': ['63jnpMCs7TNnCjnTqUrX7Mvqc5CbJMtVkLxBjPHUQkjXyZrQuZpfhjvzA7A29D9tMqVaiQC3UNP1NeaZKFFHJyQE']}}]},
+         'id': 9}
+        >>> solana_client.get_block(1, encoding="base64") # doctest: +SKIP
+        {'jsonrpc': '2.0',
+         'result': {'blockTime': None, 'blockHeight': 0,
+          'blockhash': '39pJzWsPn59k2PuHqhB7xNYBNGFXcFVkXLertHPBV4Tj',
+          'parentSlot': 0,
+          'previousBlockhash': 'EwF9gtehrrvPUoNticgmiEadAWzn4XeN8bNaNVBkS6S2',
+          'rewards': [],
+          'transactions': [{'meta': {'err': None,
+             'fee': 0,
+             'postBalances': [500000000000, 26858640, 1, 1, 1],
+             'preBalances': [500000000000, 26858640, 1, 1, 1],
+             'status': {'Ok': None}},
+            'transaction': ['AfxyKHmHIjXWjkyHODGeAbVxmfQWPj1ydS9nF+ynJHo8I1vCPDp2P9Cj5aA6W1CAHEHCqY0B1FDKomCzRo3qrAsBAAMFBQ6QBWfhQF7rG02xhuEsmmrUtz3AUjBtJKkqaHPJEmvFzziDX0C0robPrl9RbOyXHoc9/Dxa0zoGL6cEjvCjLgan1RcZLwqvxvJl4/t3zHragsUp0L47E24tAFUgAAAABqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAAHYUgdNXR0u3xNdiTr072z2DVec9EQQ/wNo1OAAAAAAM8NSv7ISDPN9E9XNL9vX7h8LuJHWlopUcX39DxsDx23AQQEAQIDADUCAAAAAQAAAAAAAAAAAAAAAAAAAIWWp5Il3Kg312pzVk6Jt61iyFhTbtmkh/ORbj3JUQRbAA==',
+             'base64']}]},
+         'id': 10}
+        """  # noqa: E501 # pylint: disable=line-too-long
+        args = self._get_block_args(slot, encoding)
+        return self._provider.make_request(*args)
+
     def get_confirmed_blocks(self, start_slot: int, end_slot: Optional[int] = None) -> types.RPCResponse:
         """Returns a list of confirmed blocks.
 

--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -435,6 +435,40 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         args = self._get_confirmed_transaction_args(tx_sig, encoding)
         return self._provider.make_request(*args)
 
+    def get_transaction(self, tx_sig: str, encoding: str = "json") -> types.RPCResponse:
+        """Returns transaction details for a confirmed transaction.
+
+        :param tx_sig: Transaction signature as base-58 encoded string N encoding attempts to use program-specific
+            instruction parsers to return more human-readable and explicit data in the
+            `transaction.message.instructions` list.
+        :param encoding: (optional) Encoding for the returned Transaction, either "json", "jsonParsed",
+            "base58" (slow), or "base64". If parameter not provided, the default encoding is JSON.
+
+        >>> solana_client = Client("http://localhost:8899")
+        >>> solana_client.get_transaction("3PtGYH77LhhQqTXP4SmDVJ85hmDieWsgXCUbn14v7gYyVYPjZzygUQhTk3bSTYnfA48vCM1rmWY7zWL3j1EVKmEy") # doctest: +SKIP
+        {'jsonrpc': '2.0',
+         'result': {'meta': {'err': None,
+           'fee': 5000, 'rewards': [],
+           'postBalances': [498449233720610510, 1000001001987940, 1],
+           'preBalances': [498449233721615510, 1000001000987940, 1],
+           'status': {'Ok': None}},
+          'slot': 1659335,
+          'transaction': {'message': {'accountKeys': ['9B5XszUGdMaxCZ7uSQhPzdks5ZQSmWxrmzCSvtJ6Ns6g',
+             '2KW2XRd9kwqet15Aha2oK3tYvd3nWbTFH1MBiRAv1BE1',
+             '11111111111111111111111111111111'],
+            'header': {'numReadonlySignedAccounts': 0,
+             'numReadonlyUnsignedAccounts': 1,
+             'numRequiredSignatures': 1},
+            'instructions': [{'accounts': [0, 1],
+              'data': '3Bxs4Bc3VYuGVB19',
+              'programIdIndex': 2}],
+            'recentBlockhash': 'FwcsKNptGtMLccXAA9YgnivVFK95mKzECLT1DNPi3SDr'},
+           'signatures': ['3PtGYH77LhhQqTXP4SmDVJ85hmDieWsgXCUbn14v7gYyVYPjZzygUQhTk3bSTYnfA48vCM1rmWY7zWL3j1EVKmEy']}},
+         'id': 4}
+        """  # noqa: E501 # pylint: disable=line-too-long
+        args = self._get_transaction_args(tx_sig, encoding)
+        return self._provider.make_request(*args)
+
     def get_epoch_info(self, commitment: Optional[Commitment] = None) -> types.RPCResponse:
         """Returns information about the current epoch.
 

--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -328,6 +328,19 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         args = self._get_confirmed_blocks_args(start_slot, end_slot)
         return self._provider.make_request(*args)
 
+    def get_blocks(self, start_slot: int, end_slot: Optional[int] = None) -> types.RPCResponse:
+        """Returns a list of confirmed blocks.
+
+        :param start_slot: Start slot, as u64 integer.
+        :param end_slot: (optional) End slot, as u64 integer.
+
+        >>> solana_client = Client("http://localhost:8899")
+        >>> solana_client.get_blocks(5, 10) # doctest: +SKIP
+        {'jsonrpc': '2.0', 'result': [5, 6, 7, 8, 9, 10], 'id': 1}
+        """
+        args = self._get_blocks_args(start_slot, end_slot)
+        return self._provider.make_request(*args)
+
     def get_confirmed_signature_for_address2(
         self,
         account: Union[str, Keypair, PublicKey],

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -325,6 +325,19 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         args = self._get_confirmed_blocks_args(start_slot, end_slot)
         return await self._provider.make_request(*args)
 
+    async def get_blocks(self, start_slot: int, end_slot: Optional[int] = None) -> types.RPCResponse:
+        """Returns a list of confirmed blocks.
+
+        :param start_slot: Start slot, as u64 integer.
+        :param end_slot: (optional) End slot, as u64 integer.
+
+        >>> solana_client = AsyncClient("http://localhost:8899")
+        >>> asyncio.run(solana_client.get_blocks(5, 10)) # doctest: +SKIP
+        {'jsonrpc': '2.0', 'result': [5, 6, 7, 8, 9, 10], 'id': 1}
+        """
+        args = self._get_blocks_args(start_slot, end_slot)
+        return await self._provider.make_request(*args)
+
     async def get_confirmed_signature_for_address2(
         self,
         account: Union[str, Keypair, PublicKey],

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -255,6 +255,63 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         args = self._get_confirmed_block_args(slot, encoding)
         return await self._provider.make_request(*args)
 
+    async def get_block(
+        self,
+        slot: int,
+        encoding: str = "json",
+    ) -> types.RPCResponse:
+        """Returns identity and transaction information about a confirmed block in the ledger.
+
+        :param slot: Slot, as u64 integer.
+        :param encoding: (optional) Encoding for the returned Transaction, either "json", "jsonParsed",
+            "base58" (slow), or "base64". If parameter not provided, the default encoding is JSON.
+
+        >>> solana_client = AsyncClient("http://localhost:8899")
+        >>> asyncio.run(solana_client.get_block(1)O # doctest: +SKIP
+        {'jsonrpc': '2.0',
+         'result': {'blockTime': None, 'blockHeight': 0,
+          'blockhash': '39pJzWsPn59k2PuHqhB7xNYBNGFXcFVkXLertHPBV4Tj',
+          'parentSlot': 0,
+          'previousBlockhash': 'EwF9gtehrrvPUoNticgmiEadAWzn4XeN8bNaNVBkS6S2',
+          'rewards': [],
+          'transactions': [{'meta': {'err': None,
+             'fee': 0,
+             'postBalances': [500000000000, 26858640, 1, 1, 1],
+             'preBalances': [500000000000, 26858640, 1, 1, 1],
+             'status': {'Ok': None}},
+            'transaction': {'message': {'accountKeys': ['LjvEBM78ufAikBfxqtj4RNiAECUi7Xqtz9k3QM3DzPk',
+               'EKAar3bMQUZvGSonq7vcPF2nPaCYowbnat44FPafW8Po',
+               'SysvarS1otHashes111111111111111111111111111',
+               'SysvarC1ock11111111111111111111111111111111',
+               'Vote111111111111111111111111111111111111111'],
+              'header': {'numReadonlySignedAccounts': 0,
+               'numReadonlyUnsignedAccounts': 3,
+               'numRequiredSignatures': 1},
+              'instructions': [{'accounts': [1, 2, 3, 0],
+                'data': '37u9WtQpcm6ULa3VmTgTKEBCtYMxq84mk82tRvKdFEwj3rALiptAzuMJ1yoVSFAMARMZYp7q',
+                'programIdIndex': 4}],
+              'recentBlockhash': 'EwF9gtehrrvPUoNticgmiEadAWzn4XeN8bNaNVBkS6S2'},
+             'signatures': ['63jnpMCs7TNnCjnTqUrX7Mvqc5CbJMtVkLxBjPHUQkjXyZrQuZpfhjvzA7A29D9tMqVaiQC3UNP1NeaZKFFHJyQE']}}]},
+         'id': 9}
+        >>> asyncio.run(solana_client.get_block(1, encoding="base64")) # doctest: +SKIP
+        {'jsonrpc': '2.0',
+         'result': {'blockTime': None, 'blockHeight': 0,
+          'blockhash': '39pJzWsPn59k2PuHqhB7xNYBNGFXcFVkXLertHPBV4Tj',
+          'parentSlot': 0,
+          'previousBlockhash': 'EwF9gtehrrvPUoNticgmiEadAWzn4XeN8bNaNVBkS6S2',
+          'rewards': [],
+          'transactions': [{'meta': {'err': None,
+             'fee': 0,
+             'postBalances': [500000000000, 26858640, 1, 1, 1],
+             'preBalances': [500000000000, 26858640, 1, 1, 1],
+             'status': {'Ok': None}},
+            'transaction': ['AfxyKHmHIjXWjkyHODGeAbVxmfQWPj1ydS9nF+ynJHo8I1vCPDp2P9Cj5aA6W1CAHEHCqY0B1FDKomCzRo3qrAsBAAMFBQ6QBWfhQF7rG02xhuEsmmrUtz3AUjBtJKkqaHPJEmvFzziDX0C0robPrl9RbOyXHoc9/Dxa0zoGL6cEjvCjLgan1RcZLwqvxvJl4/t3zHragsUp0L47E24tAFUgAAAABqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAAHYUgdNXR0u3xNdiTr072z2DVec9EQQ/wNo1OAAAAAAM8NSv7ISDPN9E9XNL9vX7h8LuJHWlopUcX39DxsDx23AQQEAQIDADUCAAAAAQAAAAAAAAAAAAAAAAAAAIWWp5Il3Kg312pzVk6Jt61iyFhTbtmkh/ORbj3JUQRbAA==',
+             'base64']}]},
+         'id': 10}
+        """  # noqa: E501 # pylint: disable=line-too-long
+        args = self._get_block_args(slot, encoding)
+        return await self._provider.make_request(*args)
+
     async def get_confirmed_blocks(self, start_slot: int, end_slot: Optional[int] = None) -> types.RPCResponse:
         """Returns a list of confirmed blocks.
 

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -432,6 +432,40 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         args = self._get_confirmed_transaction_args(tx_sig, encoding)
         return await self._provider.make_request(*args)
 
+    async def get_transaction(self, tx_sig: str, encoding: str = "json") -> types.RPCResponse:
+        """Returns transaction details for a confirmed transaction.
+
+        :param tx_sig: Transaction signature as base-58 encoded string N encoding attempts to use program-specific
+            instruction parsers to return more human-readable and explicit data in the
+            `transaction.message.instructions` list.
+        :param encoding: (optional) Encoding for the returned Transaction, either "json", "jsonParsed",
+            "base58" (slow), or "base64". If parameter not provided, the default encoding is JSON.
+
+        >>> solana_client = AsyncClient("http://localhost:8899")
+        >>> asyncio.run(solana_client.get_transaction("3PtGYH77LhhQqTXP4SmDVJ85hmDieWsgXCUbn14v7gYyVYPjZzygUQhTk3bSTYnfA48vCM1rmWY7zWL3j1EVKmEy")) # doctest: +SKIP
+        {'jsonrpc': '2.0',
+         'result': {'meta': {'err': None,
+           'fee': 5000, 'rewards': [],
+           'postBalances': [498449233720610510, 1000001001987940, 1],
+           'preBalances': [498449233721615510, 1000001000987940, 1],
+           'status': {'Ok': None}},
+          'slot': 1659335,
+          'transaction': {'message': {'accountKeys': ['9B5XszUGdMaxCZ7uSQhPzdks5ZQSmWxrmzCSvtJ6Ns6g',
+             '2KW2XRd9kwqet15Aha2oK3tYvd3nWbTFH1MBiRAv1BE1',
+             '11111111111111111111111111111111'],
+            'header': {'numReadonlySignedAccounts': 0,
+             'numReadonlyUnsignedAccounts': 1,
+             'numRequiredSignatures': 1},
+            'instructions': [{'accounts': [0, 1],
+              'data': '3Bxs4Bc3VYuGVB19',
+              'programIdIndex': 2}],
+            'recentBlockhash': 'FwcsKNptGtMLccXAA9YgnivVFK95mKzECLT1DNPi3SDr'},
+           'signatures': ['3PtGYH77LhhQqTXP4SmDVJ85hmDieWsgXCUbn14v7gYyVYPjZzygUQhTk3bSTYnfA48vCM1rmWY7zWL3j1EVKmEy']}},
+         'id': 4}
+        """  # noqa: E501 # pylint: disable=line-too-long
+        args = self._get_transaction_args(tx_sig, encoding)
+        return await self._provider.make_request(*args)
+
     async def get_epoch_info(self, commitment: Optional[Commitment] = None) -> types.RPCResponse:
         """Returns information about the current epoch.
 

--- a/src/solana/rpc/core.py
+++ b/src/solana/rpc/core.py
@@ -94,6 +94,12 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         return types.RPCMethod("getConfirmedBlocks"), start_slot
 
     @staticmethod
+    def _get_blocks_args(start_slot: int, end_slot: Optional[int]) -> Tuple:
+        if end_slot:
+            return types.RPCMethod("getBlocks"), start_slot, end_slot
+        return types.RPCMethod("getBlocks"), start_slot
+
+    @staticmethod
     def _get_confirmed_signature_for_address2_args(
         account: Union[str, Keypair, PublicKey], before: Optional[str], until: Optional[str], limit: Optional[int]
     ) -> Tuple[types.RPCMethod, str, Dict[str, Union[int, str]]]:

--- a/src/solana/rpc/core.py
+++ b/src/solana/rpc/core.py
@@ -144,6 +144,10 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
     def _get_confirmed_transaction_args(tx_sig: str, encoding: str = "json") -> Tuple[types.RPCMethod, str, str]:
         return types.RPCMethod("getConfirmedTransaction"), tx_sig, encoding
 
+    @staticmethod
+    def _get_transaction_args(tx_sig: str, encoding: str = "json") -> Tuple[types.RPCMethod, str, str]:
+        return types.RPCMethod("getTransaction"), tx_sig, encoding
+
     def _get_epoch_info_args(self, commitment: Optional[Commitment]) -> Tuple[types.RPCMethod, Dict[str, Commitment]]:
         return types.RPCMethod("getEpochInfo"), {self._comm_key: commitment or self._commitment}
 

--- a/src/solana/rpc/core.py
+++ b/src/solana/rpc/core.py
@@ -84,6 +84,10 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         return types.RPCMethod("getConfirmedBlock"), slot, encoding
 
     @staticmethod
+    def _get_block_args(slot: int, encoding: str) -> Tuple[types.RPCMethod, int, str]:
+        return types.RPCMethod("getBlock"), slot, encoding
+
+    @staticmethod
     def _get_confirmed_blocks_args(start_slot: int, end_slot: Optional[int]) -> Tuple:
         if end_slot:
             return types.RPCMethod("getConfirmedBlocks"), start_slot, end_slot

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -307,15 +307,14 @@ async def test_get_confirmed_signature_for_address2(test_http_client_async):
     assert_valid_response(resp)
 
 
-# TODO(michael): This RPC call is only available in solana-core v1.7 or newer.
-# @pytest.mark.integration
-# @pytest.mark.asyncio
-# async def test_get_signatures_for_address(test_http_client_async_async):
-#     """Test get signatures for addresses."""
-#     resp = await test_http_client_async_async.get_signatures_for_address(
-#         "Vote111111111111111111111111111111111111111", limit=1
-#     )
-#     assert_valid_response(resp)
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_signatures_for_address(test_http_client_async_async):
+    """Test get signatures for addresses."""
+    resp = await test_http_client_async_async.get_signatures_for_address(
+        "Vote111111111111111111111111111111111111111", limit=1
+    )
+    assert_valid_response(resp)
 
 
 @pytest.mark.integration

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -267,6 +267,22 @@ async def test_get_confirmed_block_with_encoding(test_http_client_async):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_get_block(test_http_client_async):
+    """Test get block."""
+    resp = await test_http_client_async.get_block(1)
+    assert_valid_response(resp)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_block_with_encoding(test_http_client_async):
+    """Test get block with encoding."""
+    resp = await test_http_client_async.get_block(1, encoding="base64")
+    assert_valid_response(resp)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_get_confirmed_blocks(test_http_client_async):
     """Test get confirmed blocks."""
     resp = await test_http_client_async.get_confirmed_blocks(5, 10)

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -291,6 +291,14 @@ async def test_get_confirmed_blocks(test_http_client_async):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_get_blocks(test_http_client_async):
+    """Test get blocks."""
+    resp = await test_http_client_async.get_blocks(5, 10)
+    assert_valid_response(resp)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_get_confirmed_signature_for_address2(test_http_client_async):
     """Test get confirmed signature for address2."""
     resp = await test_http_client_async.get_confirmed_signature_for_address2(

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -309,9 +309,9 @@ async def test_get_confirmed_signature_for_address2(test_http_client_async):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_get_signatures_for_address(test_http_client_async_async):
+async def test_get_signatures_for_address(test_http_client_async):
     """Test get signatures for addresses."""
-    resp = await test_http_client_async_async.get_signatures_for_address(
+    resp = await test_http_client_async.get_signatures_for_address(
         "Vote111111111111111111111111111111111111111", limit=1
     )
     assert_valid_response(resp)

--- a/tests/integration/test_http_client.py
+++ b/tests/integration/test_http_client.py
@@ -254,6 +254,13 @@ def test_get_confirmed_blocks(test_http_client):
 
 
 @pytest.mark.integration
+def test_get_blocks(test_http_client):
+    """Test get blocks."""
+    resp = test_http_client.get_blocks(5, 10)
+    assert_valid_response(resp)
+
+
+@pytest.mark.integration
 def test_get_confirmed_signature_for_address2(test_http_client):
     """Test get confirmed signature for address2."""
     resp = test_http_client.get_confirmed_signature_for_address2("Vote111111111111111111111111111111111111111", limit=1)

--- a/tests/integration/test_http_client.py
+++ b/tests/integration/test_http_client.py
@@ -233,6 +233,20 @@ def test_get_confirmed_block_with_encoding(test_http_client):
 
 
 @pytest.mark.integration
+def test_get_block(test_http_client):
+    """Test get block."""
+    resp = test_http_client.get_block(1)
+    assert_valid_response(resp)
+
+
+@pytest.mark.integration
+def test_get_block_with_encoding(test_http_client):
+    """Test get block with encoding."""
+    resp = test_http_client.get_block(1, encoding="base64")
+    assert_valid_response(resp)
+
+
+@pytest.mark.integration
 def test_get_confirmed_blocks(test_http_client):
     """Test get confirmed blocks."""
     resp = test_http_client.get_confirmed_blocks(5, 10)

--- a/tests/integration/test_http_client.py
+++ b/tests/integration/test_http_client.py
@@ -267,12 +267,11 @@ def test_get_confirmed_signature_for_address2(test_http_client):
     assert_valid_response(resp)
 
 
-# TODO(michael): This RPC call is only available in solana-core v1.7 or newer.
-# @pytest.mark.integration
-# def test_get_signatures_for_address(test_http_client):
-#     """Test get signatures for addresses."""
-#     resp = test_http_client.get_signatures_for_address("Vote111111111111111111111111111111111111111", limit=1)
-#     assert_valid_response(resp)
+@pytest.mark.integration
+def test_get_signatures_for_address(test_http_client):
+    """Test get signatures for addresses."""
+    resp = test_http_client.get_signatures_for_address("Vote111111111111111111111111111111111111111", limit=1)
+    assert_valid_response(resp)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Adding functionality for nondeprecated functions getBlock, getBlocks, getTransaction. These correspond to the deprecated functions getConfirmedBlock, getConfirmedBlocks, getConfirmedTransaction.

The new functions have identical params as the deprecated functions. In some cases, the new functions contain additional details in the returned object. The documentation reflects this.

I have not added tests for getTransaction because I didn't find any existing tests for getConfirmedTransaction.

Question: I see that the tests for getSignaturesForAddress are commented out. Why is this? Do the tests not run on solana v1.7+ ?