### PR TITLE
WIP: add commitment parameter to get_signatures_for_address (Fixes #145)

### DIFF
--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -349,6 +349,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         before: Optional[str] = None,
         until: Optional[str] = None,
         limit: Optional[int] = None,
+        commitment: Optional[Commitment] = None,
     ) -> types.RPCResponse:
         """Returns confirmed signatures for transactions involving an address.
 
@@ -360,6 +361,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
             If not provided the search starts from the top of the highest max confirmed block.
         :param until: (optional) Search until this transaction signature, if found before limit reached.
         :param limit: (optoinal) Maximum transaction signatures to return (between 1 and 1,000, default: 1,000).
+        :param commitment: (optional) Bank state to query. It can be either "finalized", "confirmed" or "processed".
 
         >>> solana_client = Client("http://localhost:8899")
         >>> solana_client.get_confirmed_signature_for_address2("Vote111111111111111111111111111111111111111", limit=1) # doctest: +SKIP
@@ -370,7 +372,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
            'slot': 4290}],
          'id': 2}
         """  # noqa: E501 # pylint: disable=line-too-long
-        args = self._get_confirmed_signature_for_address2_args(account, before, until, limit)
+        args = self._get_confirmed_signature_for_address2_args(account, before, until, limit, commitment)
         return self._provider.make_request(*args)
 
     def get_signatures_for_address(
@@ -379,6 +381,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         before: Optional[str] = None,
         until: Optional[str] = None,
         limit: Optional[int] = None,
+        commitment: Optional[Commitment] = None,
     ) -> types.RPCResponse:
         """Returns confirmed signatures for transactions involving an address.
 
@@ -390,6 +393,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
             If not provided the search starts from the top of the highest max confirmed block.
         :param until: (optional) Search until this transaction signature, if found before limit reached.
         :param limit: (optional) Maximum transaction signatures to return (between 1 and 1,000, default: 1,000).
+        :param commitment: (optional) Bank state to query. It can be either "finalized", "confirmed" or "processed".
 
         >>> solana_client = Client("http://localhost:8899")
         >>> solana_client.get_signatures_for_address("Vote111111111111111111111111111111111111111", limit=1) # doctest: +SKIP
@@ -400,7 +404,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
            'slot': 4290}],
          'id': 2}
         """  # noqa: E501 # pylint: disable=line-too-long
-        args = self._get_signatures_for_address_args(account, before, until, limit)
+        args = self._get_signatures_for_address_args(account, before, until, limit, commitment)
         return self._provider.make_request(*args)
 
     def get_confirmed_transaction(self, tx_sig: str, encoding: str = "json") -> types.RPCResponse:

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -346,6 +346,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         before: Optional[str] = None,
         until: Optional[str] = None,
         limit: Optional[int] = None,
+        commitment: Optional[Commitment] = None,
     ) -> types.RPCResponse:
         """Returns confirmed signatures for transactions involving an address.
 
@@ -357,6 +358,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
             If not provided the search starts from the top of the highest max confirmed block.
         :param until: (optional) Search until this transaction signature, if found before limit reached.
         :param limit: (optoinal) Maximum transaction signatures to return (between 1 and 1,000, default: 1,000).
+        :param commitment: (optional) Bank state to query. It can be either "finalized", "confirmed" or "processed".
 
         >>> solana_client = AsyncClient("http://localhost:8899")
         >>> asyncio.run(solana_client.get_confirmed_signature_for_address2("Vote111111111111111111111111111111111111111", limit=1)) # doctest: +SKIP
@@ -367,7 +369,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
            'slot': 4290}],
          'id': 2}
         """  # noqa: E501 # pylint: disable=line-too-long
-        args = self._get_confirmed_signature_for_address2_args(account, before, until, limit)
+        args = self._get_confirmed_signature_for_address2_args(account, before, until, limit, commitment)
         return await self._provider.make_request(*args)
 
     async def get_signatures_for_address(
@@ -376,6 +378,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         before: Optional[str] = None,
         until: Optional[str] = None,
         limit: Optional[int] = None,
+        commitment: Optional[Commitment] = None,
     ) -> types.RPCResponse:
         """Returns confirmed signatures for transactions involving an address.
 
@@ -387,6 +390,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
             If not provided the search starts from the top of the highest max confirmed block.
         :param until: (optional) Search until this transaction signature, if found before limit reached.
         :param limit: (optional) Maximum transaction signatures to return (between 1 and 1,000, default: 1,000).
+        :param commitment: (optional) Bank state to query. It can be either "finalized", "confirmed" or "processed".
 
         >>> solana_client = AsyncClient("http://localhost:8899")
         >>> asyncio.run(solana_client.get_signatures_for_address("Vote111111111111111111111111111111111111111", limit=1)) # doctest: +SKIP
@@ -397,7 +401,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
            'slot': 4290}],
          'id': 2}
         """  # noqa: E501 # pylint: disable=line-too-long
-        args = self._get_signatures_for_address_args(account, before, until, limit)
+        args = self._get_signatures_for_address_args(account, before, until, limit, commitment)
         return await self._provider.make_request(*args)
 
     async def get_confirmed_transaction(self, tx_sig: str, encoding: str = "json") -> types.RPCResponse:


### PR DESCRIPTION
Commit: add commitment parameter to get_signatures_for_address, also get_confirmed_signature_for_address2 as that is still suppported

Hey @michaelhly. I have added some general helpers for getting the signature RPC arguments shared between these two client methods, and I think these source changes are ready to merge. However, I would like to add unit tests for this logic. Seems there is not unit tests for argument logic, just integration tests for the client.

My idea for this is to add a pytest fixture which is a unit test client, and add a test_client_rpc_args module under tests/unit/. Probably a good practice to get unit tests going for this argument logic in general. What do you think?