### PR TITLE
Fixes #145, add optional Commitment param to get_signatures_for_address

### DIFF
--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -349,6 +349,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         before: Optional[str] = None,
         until: Optional[str] = None,
         limit: Optional[int] = None,
+        commitment: Optional[Commitment] = None,
     ) -> types.RPCResponse:
         """Returns confirmed signatures for transactions involving an address.
 
@@ -360,6 +361,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
             If not provided the search starts from the top of the highest max confirmed block.
         :param until: (optional) Search until this transaction signature, if found before limit reached.
         :param limit: (optoinal) Maximum transaction signatures to return (between 1 and 1,000, default: 1,000).
+        :param commitment: (optional) Bank state to query. It can be either "finalized", "confirmed" or "processed".
 
         >>> solana_client = Client("http://localhost:8899")
         >>> solana_client.get_confirmed_signature_for_address2("Vote111111111111111111111111111111111111111", limit=1) # doctest: +SKIP
@@ -370,7 +372,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
            'slot': 4290}],
          'id': 2}
         """  # noqa: E501 # pylint: disable=line-too-long
-        args = self._get_confirmed_signature_for_address2_args(account, before, until, limit)
+        args = self._get_confirmed_signature_for_address2_args(account, before, until, limit, commitment)
         return self._provider.make_request(*args)
 
     def get_signatures_for_address(
@@ -379,6 +381,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         before: Optional[str] = None,
         until: Optional[str] = None,
         limit: Optional[int] = None,
+        commitment: Optional[Commitment] = None,
     ) -> types.RPCResponse:
         """Returns confirmed signatures for transactions involving an address.
 
@@ -390,6 +393,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
             If not provided the search starts from the top of the highest max confirmed block.
         :param until: (optional) Search until this transaction signature, if found before limit reached.
         :param limit: (optional) Maximum transaction signatures to return (between 1 and 1,000, default: 1,000).
+        :param commitment: (optional) Bank state to query. It can be either "finalized", "confirmed" or "processed".
 
         >>> solana_client = Client("http://localhost:8899")
         >>> solana_client.get_signatures_for_address("Vote111111111111111111111111111111111111111", limit=1) # doctest: +SKIP
@@ -400,7 +404,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
            'slot': 4290}],
          'id': 2}
         """  # noqa: E501 # pylint: disable=line-too-long
-        args = self._get_signatures_for_address_args(account, before, until, limit)
+        args = self._get_signatures_for_address_args(account, before, until, limit, commitment)
         return self._provider.make_request(*args)
 
     def get_confirmed_transaction(self, tx_sig: str, encoding: str = "json") -> types.RPCResponse:

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -346,6 +346,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         before: Optional[str] = None,
         until: Optional[str] = None,
         limit: Optional[int] = None,
+        commitment: Optional[Commitment] = None,
     ) -> types.RPCResponse:
         """Returns confirmed signatures for transactions involving an address.
 
@@ -357,6 +358,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
             If not provided the search starts from the top of the highest max confirmed block.
         :param until: (optional) Search until this transaction signature, if found before limit reached.
         :param limit: (optoinal) Maximum transaction signatures to return (between 1 and 1,000, default: 1,000).
+        :param commitment: (optional) Bank state to query. It can be either "finalized", "confirmed" or "processed".
 
         >>> solana_client = AsyncClient("http://localhost:8899")
         >>> asyncio.run(solana_client.get_confirmed_signature_for_address2("Vote111111111111111111111111111111111111111", limit=1)) # doctest: +SKIP
@@ -367,7 +369,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
            'slot': 4290}],
          'id': 2}
         """  # noqa: E501 # pylint: disable=line-too-long
-        args = self._get_confirmed_signature_for_address2_args(account, before, until, limit)
+        args = self._get_confirmed_signature_for_address2_args(account, before, until, limit, commitment)
         return await self._provider.make_request(*args)
 
     async def get_signatures_for_address(
@@ -376,6 +378,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         before: Optional[str] = None,
         until: Optional[str] = None,
         limit: Optional[int] = None,
+        commitment: Optional[Commitment] = None,
     ) -> types.RPCResponse:
         """Returns confirmed signatures for transactions involving an address.
 
@@ -387,6 +390,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
             If not provided the search starts from the top of the highest max confirmed block.
         :param until: (optional) Search until this transaction signature, if found before limit reached.
         :param limit: (optional) Maximum transaction signatures to return (between 1 and 1,000, default: 1,000).
+        :param commitment: (optional) Bank state to query. It can be either "finalized", "confirmed" or "processed".
 
         >>> solana_client = AsyncClient("http://localhost:8899")
         >>> asyncio.run(solana_client.get_signatures_for_address("Vote111111111111111111111111111111111111111", limit=1)) # doctest: +SKIP
@@ -397,7 +401,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
            'slot': 4290}],
          'id': 2}
         """  # noqa: E501 # pylint: disable=line-too-long
-        args = self._get_signatures_for_address_args(account, before, until, limit)
+        args = self._get_signatures_for_address_args(account, before, until, limit, commitment)
         return await self._provider.make_request(*args)
 
     async def get_confirmed_transaction(self, tx_sig: str, encoding: str = "json") -> types.RPCResponse:

--- a/tests/unit/test_async_client.py
+++ b/tests/unit/test_async_client.py
@@ -24,32 +24,44 @@ async def test_async_client_http_exception(unit_test_http_client_async):
 
 
 def test_client_address2_sig_args_no_commitmment(unit_test_http_client_async):
-    expected = ("getConfirmedSignaturesForAddress2", "11111111111111111111111111111111", {
-        "before": "before", "until": "until", "limit": 5
-    })
-    actual = unit_test_http_client_async._get_confirmed_signature_for_address2_args(PublicKey(0), "before", "until", 5, None)
+    expected = (
+        "getConfirmedSignaturesForAddress2",
+        "11111111111111111111111111111111",
+        {"before": "before", "until": "until", "limit": 5},
+    )
+    actual = unit_test_http_client_async._get_confirmed_signature_for_address2_args(
+        PublicKey(0), "before", "until", 5, None
+    )
     assert expected == actual
 
 
 def test_client_address_sig_args_no_commitment(unit_test_http_client_async):
-    expected = ("getSignaturesForAddress", "11111111111111111111111111111111", {
-        "before": "before", "until": "until", "limit": 5
-    })
+    expected = (
+        "getSignaturesForAddress",
+        "11111111111111111111111111111111",
+        {"before": "before", "until": "until", "limit": 5},
+    )
     actual = unit_test_http_client_async._get_signatures_for_address_args(PublicKey(0), "before", "until", 5, None)
     assert expected == actual
 
 
-def test_client_address_sig_args_with_commitment(unit_test_http_client_async):
-    expected = ("getSignaturesForAddress", "11111111111111111111111111111111", {
-        "limit": 5, "commitment": "finalized"
-    })
-    actual = unit_test_http_client_async._get_signatures_for_address_args(PublicKey(0), None, None, 5, Finalized)
+def test_client_address2_sig_args_with_commitmment(unit_test_http_client_async):
+    expected = (
+        "getConfirmedSignaturesForAddress2",
+        "11111111111111111111111111111111",
+        {"limit": 5, "commitment": "finalized"},
+    )
+    actual = unit_test_http_client_async._get_confirmed_signature_for_address2_args(
+        PublicKey(0), None, None, 5, Finalized
+    )
     assert expected == actual
 
 
-def test_client_address2_sig_args_with_commitmment(unit_test_http_client_async):
-    expected = ("getConfirmedSignaturesForAddress2", "11111111111111111111111111111111", {
-        "limit": 5, "commitment": "finalized"
-    })
-    actual = unit_test_http_client_async._get_confirmed_signature_for_address2_args(PublicKey(0), None, None, 5, Finalized)
+def test_client_address_sig_args_with_commitment(unit_test_http_client_async):
+    expected = (
+        "getSignaturesForAddress",
+        "11111111111111111111111111111111",
+        {"limit": 5, "commitment": "finalized"},
+    )
+    actual = unit_test_http_client_async._get_signatures_for_address_args(PublicKey(0), None, None, 5, Finalized)
     assert expected == actual

--- a/tests/unit/test_async_client.py
+++ b/tests/unit/test_async_client.py
@@ -4,6 +4,8 @@ from requests.exceptions import ReadTimeout
 import pytest
 
 from solana.exceptions import SolanaRpcException
+from solana.publickey import PublicKey
+from solana.rpc.commitment import Finalized
 
 
 @pytest.mark.asyncio
@@ -19,3 +21,35 @@ async def test_async_client_http_exception(unit_test_http_client_async):
             exc_info.value.error_msg
             == "<class 'requests.exceptions.ReadTimeout'> raised in \"getEpochInfo\" endpoint request"
         )
+
+
+def test_client_address2_sig_args_no_commitmment(unit_test_http_client_async):
+    expected = ("getConfirmedSignaturesForAddress2", "11111111111111111111111111111111", {
+        "before": "before", "until": "until", "limit": 5
+    })
+    actual = unit_test_http_client_async._get_confirmed_signature_for_address2_args(PublicKey(0), "before", "until", 5, None)
+    assert expected == actual
+
+
+def test_client_address_sig_args_no_commitment(unit_test_http_client_async):
+    expected = ("getSignaturesForAddress", "11111111111111111111111111111111", {
+        "before": "before", "until": "until", "limit": 5
+    })
+    actual = unit_test_http_client_async._get_signatures_for_address_args(PublicKey(0), "before", "until", 5, None)
+    assert expected == actual
+
+
+def test_client_address_sig_args_with_commitment(unit_test_http_client_async):
+    expected = ("getSignaturesForAddress", "11111111111111111111111111111111", {
+        "limit": 5, "commitment": "finalized"
+    })
+    actual = unit_test_http_client_async._get_signatures_for_address_args(PublicKey(0), None, None, 5, Finalized)
+    assert expected == actual
+
+
+def test_client_address2_sig_args_with_commitmment(unit_test_http_client_async):
+    expected = ("getConfirmedSignaturesForAddress2", "11111111111111111111111111111111", {
+        "limit": 5, "commitment": "finalized"
+    })
+    actual = unit_test_http_client_async._get_confirmed_signature_for_address2_args(PublicKey(0), None, None, 5, Finalized)
+    assert expected == actual

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -22,32 +22,40 @@ def test_client_http_exception(unit_test_http_client):
 
 
 def test_client_address2_sig_args_no_commitmment(unit_test_http_client):
-    expected = ("getConfirmedSignaturesForAddress2", "11111111111111111111111111111111", {
-        "before": "before", "until": "until", "limit": 5
-    })
+    expected = (
+        "getConfirmedSignaturesForAddress2",
+        "11111111111111111111111111111111",
+        {"before": "before", "until": "until", "limit": 5},
+    )
     actual = unit_test_http_client._get_confirmed_signature_for_address2_args(PublicKey(0), "before", "until", 5, None)
     assert expected == actual
 
 
 def test_client_address_sig_args_no_commitment(unit_test_http_client):
-    expected = ("getSignaturesForAddress", "11111111111111111111111111111111", {
-        "before": "before", "until": "until", "limit": 5
-    })
+    expected = (
+        "getSignaturesForAddress",
+        "11111111111111111111111111111111",
+        {"before": "before", "until": "until", "limit": 5},
+    )
     actual = unit_test_http_client._get_signatures_for_address_args(PublicKey(0), "before", "until", 5, None)
     assert expected == actual
 
 
-def test_client_address_sig_args_with_commitment(unit_test_http_client):
-    expected = ("getSignaturesForAddress", "11111111111111111111111111111111", {
-        "limit": 5, "commitment": "finalized"
-    })
-    actual = unit_test_http_client._get_signatures_for_address_args(PublicKey(0), None, None, 5, Finalized)
+def test_client_address2_sig_args_with_commitmment(unit_test_http_client):
+    expected = (
+        "getConfirmedSignaturesForAddress2",
+        "11111111111111111111111111111111",
+        {"limit": 5, "commitment": "finalized"},
+    )
+    actual = unit_test_http_client._get_confirmed_signature_for_address2_args(PublicKey(0), None, None, 5, Finalized)
     assert expected == actual
 
 
-def test_client_address2_sig_args_with_commitmment(unit_test_http_client):
-    expected = ("getConfirmedSignaturesForAddress2", "11111111111111111111111111111111", {
-        "limit": 5, "commitment": "finalized"
-    })
-    actual = unit_test_http_client._get_confirmed_signature_for_address2_args(PublicKey(0), None, None, 5, Finalized)
+def test_client_address_sig_args_with_commitment(unit_test_http_client):
+    expected = (
+        "getSignaturesForAddress",
+        "11111111111111111111111111111111",
+        {"limit": 5, "commitment": "finalized"},
+    )
+    actual = unit_test_http_client._get_signatures_for_address_args(PublicKey(0), None, None, 5, Finalized)
     assert expected == actual

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -3,6 +3,8 @@ from requests.exceptions import ReadTimeout
 import pytest
 
 from solana.exceptions import SolanaRpcException
+from solana.publickey import PublicKey
+from solana.rpc.commitment import Finalized
 
 
 def test_client_http_exception(unit_test_http_client):
@@ -17,3 +19,35 @@ def test_client_http_exception(unit_test_http_client):
             exc_info.value.error_msg
             == "<class 'requests.exceptions.ReadTimeout'> raised in \"getEpochInfo\" endpoint request"
         )
+
+
+def test_client_address2_sig_args_no_commitmment(unit_test_http_client):
+    expected = ("getConfirmedSignaturesForAddress2", "11111111111111111111111111111111", {
+        "before": "before", "until": "until", "limit": 5
+    })
+    actual = unit_test_http_client._get_confirmed_signature_for_address2_args(PublicKey(0), "before", "until", 5, None)
+    assert expected == actual
+
+
+def test_client_address_sig_args_no_commitment(unit_test_http_client):
+    expected = ("getSignaturesForAddress", "11111111111111111111111111111111", {
+        "before": "before", "until": "until", "limit": 5
+    })
+    actual = unit_test_http_client._get_signatures_for_address_args(PublicKey(0), "before", "until", 5, None)
+    assert expected == actual
+
+
+def test_client_address_sig_args_with_commitment(unit_test_http_client):
+    expected = ("getSignaturesForAddress", "11111111111111111111111111111111", {
+        "limit": 5, "commitment": "finalized"
+    })
+    actual = unit_test_http_client._get_signatures_for_address_args(PublicKey(0), None, None, 5, Finalized)
+    assert expected == actual
+
+
+def test_client_address2_sig_args_with_commitmment(unit_test_http_client):
+    expected = ("getConfirmedSignaturesForAddress2", "11111111111111111111111111111111", {
+        "limit": 5, "commitment": "finalized"
+    })
+    actual = unit_test_http_client._get_confirmed_signature_for_address2_args(PublicKey(0), None, None, 5, Finalized)
+    assert expected == actual


### PR DESCRIPTION
Added Commitment parameter to getSignaturesForAddress. For consistency, extended it to getConfirmedSignaturesForAddress2 even though that is/will be deprecated