### PR TITLE
Making the keypair hashable, and moving setters out of property functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ dist
 
 # solana validator logs
 test-ledger/
+
+#IDE Files
+.idea/

--- a/src/solana/keypair.py
+++ b/src/solana/keypair.py
@@ -25,8 +25,10 @@ class Keypair:
     """
 
     def __init__(self, keypair: Optional[nacl.public.PrivateKey] = None) -> None:
-        """Create a new keypair instance. Generate random keypair if no keypair is provided.
-        Initialize class variables."""
+        """Create a new keypair instance.
+
+        Generate random keypair if no keypair is provided. Initialize class variables.
+        """
         if keypair is None:
             # the PrivateKey object comes with a public key too
             self._keypair = nacl.public.PrivateKey.generate()

--- a/src/solana/keypair.py
+++ b/src/solana/keypair.py
@@ -26,7 +26,7 @@ class Keypair:
 
     def __init__(self, keypair: Optional[nacl.public.PrivateKey] = None) -> None:
         """Create a new keypair instance. Generate random keypair if no keypair is provided.
-        Initialize class variables. """
+        Initialize class variables."""
         if keypair is None:
             # the PrivateKey object comes with a public key too
             self._keypair = nacl.public.PrivateKey.generate()

--- a/src/solana/keypair.py
+++ b/src/solana/keypair.py
@@ -25,12 +25,17 @@ class Keypair:
     """
 
     def __init__(self, keypair: Optional[nacl.public.PrivateKey] = None) -> None:
-        """Create a new keypair instance. Generate random keypair if no keypair is provided."""
+        """Create a new keypair instance. Generate random keypair if no keypair is provided.
+        Initialize class variables. """
         if keypair is None:
             # the PrivateKey object comes with a public key too
             self._keypair = nacl.public.PrivateKey.generate()
         else:
             self._keypair = keypair
+
+        verify_key = signing.SigningKey(bytes(self._keypair)).verify_key
+
+        self._public_key = solana.publickey.PublicKey(verify_key)
 
     @classmethod
     def generate(cls) -> Keypair:
@@ -88,8 +93,7 @@ class Keypair:
     @property
     def public_key(self) -> solana.publickey.PublicKey:
         """The public key for this keypair."""
-        verify_key = signing.SigningKey(self.seed).verify_key
-        return solana.publickey.PublicKey(verify_key)
+        return self._public_key
 
     @property
     def secret_key(self) -> bytes:
@@ -105,3 +109,7 @@ class Keypair:
     def __ne__(self, other) -> bool:
         """Implemented by negating __eq__."""
         return not (self == other)  # pylint: disable=superfluous-parens
+
+    def __hash__(self):
+        """Returns a unique hash for set operations."""
+        return hash(self._keypair)

--- a/tests/unit/test_keypair.py
+++ b/tests/unit/test_keypair.py
@@ -34,3 +34,14 @@ def test_create_from_seed() -> None:
     keypair = Keypair.from_seed(seed)
     assert str(keypair.public_key) == "2KW2XRd9kwqet15Aha2oK3tYvd3nWbTFH1MBiRAv1BE1"
     assert keypair.seed == seed
+
+
+def test_set_operations() -> None:
+    """Tests that a keypair is now hashable with the appropriate set operations."""
+    keypair_primary = Keypair.generate()
+    keypair_secondary = Keypair.generate()
+    keypair_duplicate = keypair_secondary
+    keypair_set = {keypair_primary, keypair_secondary, keypair_duplicate}
+    assert keypair_primary.__hash__() != keypair_secondary.__hash__()
+    assert keypair_secondary.__hash__() == keypair_duplicate.__hash__()
+    assert len(keypair_set) == 2


### PR DESCRIPTION
This pull requests makes keypairs hashable, that way the keypair objects can be used in set operations. It also fixes an issue related to keypairs and properties, where the public_key is not generated when the property is accessed. It is far and away better to use a setter, and set properties during class initialization. 