### PR TITLE
Add max_retries option to sendTransaction and commitment option to get_transaction

### DIFF
--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -443,7 +443,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
 
     def get_transaction(
         self, tx_sig: str, encoding: str = "json", commitment: Optional[Commitment] = None
-        ) -> types.RPCResponse:
+    ) -> types.RPCResponse:
         """Returns transaction details for a confirmed transaction.
 
         :param tx_sig: Transaction signature as base-58 encoded string N encoding attempts to use program-specific

--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -441,7 +441,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         args = self._get_confirmed_transaction_args(tx_sig, encoding)
         return self._provider.make_request(*args)
 
-    def get_transaction(self, tx_sig: str, encoding: str = "json", commitment: Optional[Commitment] = Finalized) -> types.RPCResponse:
+    def get_transaction(self, tx_sig: str, encoding: str = "json", commitment: Optional[Commitment] = None) -> types.RPCResponse:
         """Returns transaction details for a confirmed transaction.
 
         :param tx_sig: Transaction signature as base-58 encoded string N encoding attempts to use program-specific
@@ -449,7 +449,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
             `transaction.message.instructions` list.
         :param encoding: (optional) Encoding for the returned Transaction, either "json", "jsonParsed",
             "base58" (slow), or "base64". If parameter not provided, the default encoding is JSON.
-        :param commitment: (optional) "processed" is not supported. If parameter not provided, the default is "finalized"
+        :param commitment: Bank state to query. It can be either "finalized", "confirmed" or "processed".
 
         >>> solana_client = Client("http://localhost:8899")
         >>> solana_client.get_transaction("3PtGYH77LhhQqTXP4SmDVJ85hmDieWsgXCUbn14v7gYyVYPjZzygUQhTk3bSTYnfA48vCM1rmWY7zWL3j1EVKmEy") # doctest: +SKIP

--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -441,7 +441,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         args = self._get_confirmed_transaction_args(tx_sig, encoding)
         return self._provider.make_request(*args)
 
-    def get_transaction(self, tx_sig: str, encoding: str = "json") -> types.RPCResponse:
+    def get_transaction(self, tx_sig: str, encoding: str = "json", commitment: Optional[Commitment] = Finalized) -> types.RPCResponse:
         """Returns transaction details for a confirmed transaction.
 
         :param tx_sig: Transaction signature as base-58 encoded string N encoding attempts to use program-specific
@@ -449,6 +449,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
             `transaction.message.instructions` list.
         :param encoding: (optional) Encoding for the returned Transaction, either "json", "jsonParsed",
             "base58" (slow), or "base64". If parameter not provided, the default encoding is JSON.
+        :param commitment: (optional) "processed" is not supported. If parameter not provided, the default is "finalized"
 
         >>> solana_client = Client("http://localhost:8899")
         >>> solana_client.get_transaction("3PtGYH77LhhQqTXP4SmDVJ85hmDieWsgXCUbn14v7gYyVYPjZzygUQhTk3bSTYnfA48vCM1rmWY7zWL3j1EVKmEy") # doctest: +SKIP
@@ -472,7 +473,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
            'signatures': ['3PtGYH77LhhQqTXP4SmDVJ85hmDieWsgXCUbn14v7gYyVYPjZzygUQhTk3bSTYnfA48vCM1rmWY7zWL3j1EVKmEy']}},
          'id': 4}
         """  # noqa: E501 # pylint: disable=line-too-long
-        args = self._get_transaction_args(tx_sig, encoding)
+        args = self._get_transaction_args(tx_sig, encoding, commitment)
         return self._provider.make_request(*args)
 
     def get_epoch_info(self, commitment: Optional[Commitment] = None) -> types.RPCResponse:

--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -441,7 +441,9 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         args = self._get_confirmed_transaction_args(tx_sig, encoding)
         return self._provider.make_request(*args)
 
-    def get_transaction(self, tx_sig: str, encoding: str = "json", commitment: Optional[Commitment] = None) -> types.RPCResponse:
+    def get_transaction(
+        self, tx_sig: str, encoding: str = "json", commitment: Optional[Commitment] = None
+        ) -> types.RPCResponse:
         """Returns transaction details for a confirmed transaction.
 
         :param tx_sig: Transaction signature as base-58 encoded string N encoding attempts to use program-specific

--- a/src/solana/rpc/core.py
+++ b/src/solana/rpc/core.py
@@ -163,8 +163,8 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         return types.RPCMethod("getConfirmedTransaction"), tx_sig, encoding
 
     @staticmethod
-    def _get_transaction_args(tx_sig: str, encoding: str = "json") -> Tuple[types.RPCMethod, str, str]:
-        return types.RPCMethod("getTransaction"), tx_sig, encoding
+    def _get_transaction_args(tx_sig: str, encoding: str = "json", commitment: Commitment = Finalized) -> Tuple[types.RPCMethod, str, str, str]:
+        return types.RPCMethod("getTransaction"), tx_sig, encoding, commitment
 
     def _get_epoch_info_args(self, commitment: Optional[Commitment]) -> Tuple[types.RPCMethod, Dict[str, Commitment]]:
         return types.RPCMethod("getEpochInfo"), {self._comm_key: commitment or self._commitment}

--- a/src/solana/rpc/core.py
+++ b/src/solana/rpc/core.py
@@ -162,12 +162,14 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
     def _get_confirmed_transaction_args(tx_sig: str, encoding: str = "json") -> Tuple[types.RPCMethod, str, str]:
         return types.RPCMethod("getConfirmedTransaction"), tx_sig, encoding
 
-    def _get_transaction_args(self, tx_sig: str, encoding: str = "json", commitment: Commitment = None) -> Tuple[types.RPCMethod, str, Dict[str, Union[str, Commitment]]]:
+    def _get_transaction_args(
+        self, tx_sig: str, encoding: str = "json", commitment: Commitment = None
+        ) -> Tuple[types.RPCMethod, str, Dict[str, Union[str, Commitment]]]:
 
         return (
-            types.RPCMethod("getTransaction"), 
-            tx_sig, 
-            {self._encoding_key: encoding, self._comm_key: commitment or self._commitment}
+            types.RPCMethod("getTransaction"),
+            tx_sig,
+            {self._encoding_key: encoding, self._comm_key: commitment or self._commitment},
         )
 
     def _get_epoch_info_args(self, commitment: Optional[Commitment]) -> Tuple[types.RPCMethod, Dict[str, Commitment]]:
@@ -362,10 +364,10 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         if isinstance(txn, bytes):
             txn = b64encode(txn).decode("utf-8")
         params = {
-                self._skip_preflight_key: opts.skip_preflight,
-                self._preflight_comm_key: opts.preflight_commitment,
-                self._encoding_key: "base64",  
-            }
+            self._skip_preflight_key: opts.skip_preflight,
+            self._preflight_comm_key: opts.preflight_commitment,
+            self._encoding_key: "base64",
+        }
         if opts.max_retries is not None:
             params[self._max_retries] = opts.max_retries        
         return (

--- a/src/solana/rpc/core.py
+++ b/src/solana/rpc/core.py
@@ -35,6 +35,7 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
     _data_slice_key = "dataSlice"
     _skip_preflight_key = "skipPreflight"
     _preflight_comm_key = "preflightCommitment"
+    _max_retries = "maxRetries"
     _before_rpc_config_key = "before"
     _limit_rpc_config_key = "limit"
     _until_rpc_config_key = "until"
@@ -356,15 +357,17 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
 
         if isinstance(txn, bytes):
             txn = b64encode(txn).decode("utf-8")
-
+        params = {
+                self._skip_preflight_key: opts.skip_preflight,
+                self._preflight_comm_key: opts.preflight_commitment,
+                self._encoding_key: "base64",  
+            }
+        if opts.max_retries is not None:
+            params[self._max_retries] = opts.max_retries        
         return (
             types.RPCMethod("sendTransaction"),
             txn,
-            {
-                self._skip_preflight_key: opts.skip_preflight,
-                self._preflight_comm_key: opts.preflight_commitment,
-                self._encoding_key: "base64",
-            },
+            params,
         )
 
     @staticmethod

--- a/src/solana/rpc/core.py
+++ b/src/solana/rpc/core.py
@@ -164,7 +164,7 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
 
     def _get_transaction_args(
         self, tx_sig: str, encoding: str = "json", commitment: Commitment = None
-        ) -> Tuple[types.RPCMethod, str, Dict[str, Union[str, Commitment]]]:
+    ) -> Tuple[types.RPCMethod, str, Dict[str, Union[str, Commitment]]]:
 
         return (
             types.RPCMethod("getTransaction"),
@@ -369,7 +369,7 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
             self._encoding_key: "base64",
         }
         if opts.max_retries is not None:
-            params[self._max_retries] = opts.max_retries        
+            params[self._max_retries] = opts.max_retries
         return (
             types.RPCMethod("sendTransaction"),
             txn,

--- a/src/solana/rpc/core.py
+++ b/src/solana/rpc/core.py
@@ -359,11 +359,11 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
 
     def _send_raw_transaction_args(
         self, txn: Union[bytes, str], opts: types.TxOpts
-    ) -> Tuple[types.RPCMethod, str, Dict[str, Union[bool, Commitment, str]]]:
+    ) -> Tuple[types.RPCMethod, str, Dict[str, Union[bool, Commitment, str, int]]]:
 
         if isinstance(txn, bytes):
             txn = b64encode(txn).decode("utf-8")
-        params = {
+        params: Dict[str, Union[bool, Commitment, str, int]] = {
             self._skip_preflight_key: opts.skip_preflight,
             self._preflight_comm_key: opts.preflight_commitment,
             self._encoding_key: "base64",

--- a/src/solana/rpc/core.py
+++ b/src/solana/rpc/core.py
@@ -162,9 +162,13 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
     def _get_confirmed_transaction_args(tx_sig: str, encoding: str = "json") -> Tuple[types.RPCMethod, str, str]:
         return types.RPCMethod("getConfirmedTransaction"), tx_sig, encoding
 
-    @staticmethod
-    def _get_transaction_args(tx_sig: str, encoding: str = "json", commitment: Commitment = Finalized) -> Tuple[types.RPCMethod, str, str, str]:
-        return types.RPCMethod("getTransaction"), tx_sig, encoding, commitment
+    def _get_transaction_args(self, tx_sig: str, encoding: str = "json", commitment: Commitment = None) -> Tuple[types.RPCMethod, str, Dict[str, Union[str, Commitment]]]:
+
+        return (
+            types.RPCMethod("getTransaction"), 
+            tx_sig, 
+            {self._encoding_key: encoding, self._comm_key: commitment or self._commitment}
+        )
 
     def _get_epoch_info_args(self, commitment: Optional[Commitment]) -> Tuple[types.RPCMethod, Dict[str, Commitment]]:
         return types.RPCMethod("getEpochInfo"), {self._comm_key: commitment or self._commitment}

--- a/src/solana/rpc/types.py
+++ b/src/solana/rpc/types.py
@@ -90,7 +90,7 @@ class TxOpts(NamedTuple):
     preflight_commitment: Commitment = Finalized
     """Commitment level to use for preflight."""
     max_retries: int = None
-    """Maximum number of times for the RPC node to retry sending the transaction to the leader. 
-    If this parameter not provided, the RPC node will retry the transaction until it is finalized or until the blockhash expires
+    """Maximum number of times for the RPC node to retry sending the transaction to the leader.
+    If this parameter not provided, the RPC node will retry the transaction until it is finalized
+    or until the blockhash expires
     """
-

--- a/src/solana/rpc/types.py
+++ b/src/solana/rpc/types.py
@@ -89,3 +89,8 @@ class TxOpts(NamedTuple):
     """If true, skip the preflight transaction checks."""
     preflight_commitment: Commitment = Finalized
     """Commitment level to use for preflight."""
+    max_retries: int = None
+    """Maximum number of times for the RPC node to retry sending the transaction to the leader. 
+    If this parameter not provided, the RPC node will retry the transaction until it is finalized or until the blockhash expires
+    """
+

--- a/src/solana/rpc/types.py
+++ b/src/solana/rpc/types.py
@@ -89,7 +89,7 @@ class TxOpts(NamedTuple):
     """If true, skip the preflight transaction checks."""
     preflight_commitment: Commitment = Finalized
     """Commitment level to use for preflight."""
-    max_retries: int = None
+    max_retries: Optional[int] = None
     """Maximum number of times for the RPC node to retry sending the transaction to the leader.
     If this parameter not provided, the RPC node will retry the transaction until it is finalized
     or until the blockhash expires


### PR DESCRIPTION
the sendTransaction method in json rpc API has 4 params that: skipPreflight, preflightCommitment, encoding, maxRetries, but the master has only 3 params, I have add the last maxRetries param to the master