### PR TITLE
default to RPC client commitment in token client

### DIFF
--- a/src/spl/token/async_client.py
+++ b/src/spl/token/async_client.py
@@ -9,7 +9,7 @@ from solana.blockhash import Blockhash
 from solana.keypair import Keypair
 from solana.publickey import PublicKey
 from solana.rpc.async_api import AsyncClient
-from solana.rpc.commitment import Commitment, Confirmed
+from solana.rpc.commitment import Commitment
 from solana.rpc.types import RPCResponse, TxOpts
 from spl.token._layouts import ACCOUNT_LAYOUT, MINT_LAYOUT, MULTISIG_LAYOUT
 from spl.token.core import AccountInfo, MintInfo, _TokenCore
@@ -57,7 +57,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         self,
         owner: PublicKey,
         is_delegate: bool = False,
-        commitment: Commitment = Confirmed,
+        commitment: Optional[Commitment] = None,
         encoding: str = "jsonParsed",
     ) -> RPCResponse:
         """Get token accounts of the provided owner by the token's mint.
@@ -72,14 +72,16 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         valid mint cannot be found for a particular account, that account will be filtered out
         from results. jsonParsed encoding is UNSTABLE.
         """
-        args = self._get_accounts_args(owner, commitment, encoding)
+        args = self._get_accounts_args(
+            owner, commitment, encoding, self._conn._commitment  # pylint: disable=protected-access
+        )
         return (
             await self._conn.get_token_accounts_by_delegate(*args)
             if is_delegate
             else await self._conn.get_token_accounts_by_owner(*args)
         )
 
-    async def get_balance(self, pubkey: PublicKey, commitment: Commitment = Confirmed) -> RPCResponse:
+    async def get_balance(self, pubkey: PublicKey, commitment: Optional[Commitment] = None) -> RPCResponse:
         """Get the balance of the provided token account.
 
         :param pubkey: Public Key of the token account.

--- a/src/spl/token/client.py
+++ b/src/spl/token/client.py
@@ -9,7 +9,7 @@ from solana.blockhash import Blockhash
 from solana.keypair import Keypair
 from solana.publickey import PublicKey
 from solana.rpc.api import Client
-from solana.rpc.commitment import Commitment, Confirmed
+from solana.rpc.commitment import Commitment
 from solana.rpc.types import RPCResponse, TxOpts
 from spl.token._layouts import ACCOUNT_LAYOUT, MINT_LAYOUT, MULTISIG_LAYOUT
 from spl.token.core import AccountInfo, MintInfo, _TokenCore
@@ -57,7 +57,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         self,
         owner: PublicKey,
         is_delegate: bool = False,
-        commitment: Commitment = Confirmed,
+        commitment: Optional[Commitment] = None,
         encoding: str = "jsonParsed",
     ) -> RPCResponse:
         """Get token accounts of the provided owner by the token's mint.
@@ -72,14 +72,16 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         valid mint cannot be found for a particular account, that account will be filtered out
         from results. jsonParsed encoding is UNSTABLE.
         """
-        args = self._get_accounts_args(owner, commitment, encoding)
+        args = self._get_accounts_args(
+            owner, commitment, encoding, self._conn._commitment  # pylint: disable=protected-access
+        )
         return (
             self._conn.get_token_accounts_by_delegate(*args)
             if is_delegate
             else self._conn.get_token_accounts_by_owner(*args)
         )
 
-    def get_balance(self, pubkey: PublicKey, commitment: Commitment = Confirmed) -> RPCResponse:
+    def get_balance(self, pubkey: PublicKey, commitment: Optional[Commitment] = None) -> RPCResponse:
         """Get the balance of the provided token account.
 
         :param pubkey: Public Key of the token account.

--- a/src/spl/token/core.py
+++ b/src/spl/token/core.py
@@ -10,7 +10,7 @@ from solana.keypair import Keypair
 from solana.publickey import PublicKey
 from solana.rpc.api import Client
 from solana.rpc.async_api import AsyncClient
-from solana.rpc.commitment import Commitment, Confirmed
+from solana.rpc.commitment import Commitment
 from solana.rpc.types import RPCResponse, TokenAccountOpts, TxOpts
 from solana.transaction import Transaction
 from solana.utils.helpers import decode_byte_string
@@ -89,10 +89,12 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
     def _get_accounts_args(
         self,
         owner: PublicKey,
-        commitment: Commitment = Confirmed,
-        encoding: str = "jsonParsed",
+        commitment: Optional[Commitment],
+        encoding,
+        default_commitment: Commitment,
     ) -> Tuple[PublicKey, TokenAccountOpts, Commitment]:
-        return owner, TokenAccountOpts(mint=self.pubkey, encoding=encoding), commitment
+        commitment_to_use = default_commitment if commitment is None else commitment
+        return owner, TokenAccountOpts(mint=self.pubkey, encoding=encoding), commitment_to_use
 
     @staticmethod
     def _create_mint_args(


### PR DESCRIPTION
For methods that take a `commitment` arg, default to using the RPC client commitment if this arg is None