### PR TITLE
Fix str seed input for sp.create_account_with_seed

### DIFF
--- a/src/solana/system_program.py
+++ b/src/solana/system_program.py
@@ -488,12 +488,13 @@ def create_account_with_seed(
     Returns:
         The instruction to create the account.
     """
+    seed = {"length": len(s), "chars": s} if isinstance(params.seed, str) else params.seed
     data = SYSTEM_INSTRUCTIONS_LAYOUT.build(
         dict(
             instruction_type=InstructionType.CREATE_ACCOUNT_WITH_SEED,
             args=dict(
                 base=bytes(params.base_pubkey),
-                seed=params.seed,
+                seed=seed,
                 lamports=params.lamports,
                 space=params.space,
                 program_id=bytes(params.program_id),

--- a/src/solana/system_program.py
+++ b/src/solana/system_program.py
@@ -178,7 +178,8 @@ class AssignWithSeedParams(NamedTuple):
 
 
 def __check_program_id(program_id: PublicKey) -> None:
-    if program_id != SYS_PROGRAM_ID:
+    if program_id !
+    YS_PROGRAM_ID:
         raise ValueError("invalid instruction: programId is not SystemProgram")
 
 
@@ -488,7 +489,7 @@ def create_account_with_seed(
     Returns:
         The instruction to create the account.
     """
-    seed = {"length": len(s), "chars": s} if isinstance(params.seed, str) else params.seed
+    seed = {"length": len(params.seed), "chars": params.seed} if isinstance(params.seed, str) else params.seed
     data = SYSTEM_INSTRUCTIONS_LAYOUT.build(
         dict(
             instruction_type=InstructionType.CREATE_ACCOUNT_WITH_SEED,

--- a/src/solana/system_program.py
+++ b/src/solana/system_program.py
@@ -178,8 +178,7 @@ class AssignWithSeedParams(NamedTuple):
 
 
 def __check_program_id(program_id: PublicKey) -> None:
-    if program_id !
-    YS_PROGRAM_ID:
+    if program_id ! SYS_PROGRAM_ID:
         raise ValueError("invalid instruction: programId is not SystemProgram")
 
 

--- a/src/solana/system_program.py
+++ b/src/solana/system_program.py
@@ -178,7 +178,7 @@ class AssignWithSeedParams(NamedTuple):
 
 
 def __check_program_id(program_id: PublicKey) -> None:
-    if program_id ! SYS_PROGRAM_ID:
+    if program_id != SYS_PROGRAM_ID:
         raise ValueError("invalid instruction: programId is not SystemProgram")
 
 


### PR DESCRIPTION
Previously a str was documented, but actually an object of {"length": int, "chars": str} is needed.
This commit detects if a str was passed in and transforms it into the
required object

fixes: https://github.com/michaelhly/solana-py/issues/172
@paul2234