### PR TITLE
Bump test docker image to Solana 1.9.14

### DIFF
--- a/src/solana/rpc/responses.py
+++ b/src/solana/rpc/responses.py
@@ -238,6 +238,7 @@ class SlotsUpdatesNotification(SubscriptionNotificationBase):
 class VoteItem:
     """Vote data."""
 
+    vote_pubkey: str = field(metadata=alias("votePubkey"))
     hash: str
     slots: List[int]
     timestamp: Optional[int]

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   localnet:
-    image: "solanalabs/solana:v1.8.3"
+    image: "solanalabs/solana:v1.9.14"
     ports:
       - "8899:8899"
       - "8900:8900"

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -16,19 +16,31 @@ from .utils import AIRDROP_AMOUNT, assert_valid_response
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_request_air_drop(async_stubbed_sender: Keypair, test_http_client_async: AsyncClient):
-    """Test air drop to async_stubbed_sender."""
+async def test_request_air_drop(
+    async_stubbed_sender: Keypair, async_stubbed_receiver: Keypair, test_http_client_async: AsyncClient
+):
+    """Test air drop to async_stubbed_sender and async_stubbed_receiver."""
+    # Airdrop to stubbed_sender
     resp = await test_http_client_async.request_airdrop(async_stubbed_sender.public_key, AIRDROP_AMOUNT)
     assert_valid_response(resp)
     await test_http_client_async.confirm_transaction(resp["result"])
     balance = await test_http_client_async.get_balance(async_stubbed_sender.public_key)
     assert balance["result"]["value"] == AIRDROP_AMOUNT
+    # Airdrop to stubbed_receiver
+    resp = await test_http_client_async.request_airdrop(async_stubbed_receiver, AIRDROP_AMOUNT)
+    assert_valid_response(resp)
+    await test_http_client_async.confirm_transaction(resp["result"])
+    balance = await test_http_client_async.get_balance(async_stubbed_receiver)
+    assert balance["result"]["value"] == AIRDROP_AMOUNT
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_request_air_drop_prefetched_blockhash(async_stubbed_sender_prefetched_blockhash, test_http_client_async):
-    """Test air drop to async_stubbed_sender."""
+async def test_request_air_drop_prefetched_blockhash(
+    async_stubbed_sender_prefetched_blockhash, async_stubbed_receiver_prefetched_blockhash, test_http_client_async
+):
+    """Test air drop to async_stubbed_sender and async_stubbed_receiver."""
+    # Airdrop to stubbed_sender
     resp = await test_http_client_async.request_airdrop(
         async_stubbed_sender_prefetched_blockhash.public_key, AIRDROP_AMOUNT
     )
@@ -36,14 +48,23 @@ async def test_request_air_drop_prefetched_blockhash(async_stubbed_sender_prefet
     await test_http_client_async.confirm_transaction(resp["result"])
     balance = await test_http_client_async.get_balance(async_stubbed_sender_prefetched_blockhash.public_key)
     assert balance["result"]["value"] == AIRDROP_AMOUNT
+    # Airdrop to stubbed_receiver
+    resp = await test_http_client_async.request_airdrop(async_stubbed_receiver_prefetched_blockhash, AIRDROP_AMOUNT)
+    assert_valid_response(resp)
+    await test_http_client_async.confirm_transaction(resp["result"])
+    balance = await test_http_client_async.get_balance(async_stubbed_receiver_prefetched_blockhash)
+    assert balance["result"]["value"] == AIRDROP_AMOUNT
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_request_air_drop_cached_blockhash(
-    async_stubbed_sender_cached_blockhash, test_http_client_async_cached_blockhash
+    async_stubbed_sender_cached_blockhash,
+    async_stubbed_receiver_cached_blockhash,
+    test_http_client_async_cached_blockhash,
 ):
-    """Test air drop to async_stubbed_sender."""
+    """Test air drop to async_stubbed_sender and async_stubbed_receiver."""
+    # Airdrop to stubbed_sender
     resp = await test_http_client_async_cached_blockhash.request_airdrop(
         async_stubbed_sender_cached_blockhash.public_key, AIRDROP_AMOUNT
     )
@@ -52,6 +73,14 @@ async def test_request_air_drop_cached_blockhash(
     balance = await test_http_client_async_cached_blockhash.get_balance(
         async_stubbed_sender_cached_blockhash.public_key
     )
+    assert balance["result"]["value"] == AIRDROP_AMOUNT
+    # Airdrop to stubbed_receiver
+    resp = await test_http_client_async_cached_blockhash.request_airdrop(
+        async_stubbed_receiver_cached_blockhash, AIRDROP_AMOUNT
+    )
+    assert_valid_response(resp)
+    await test_http_client_async_cached_blockhash.confirm_transaction(resp["result"])
+    balance = await test_http_client_async_cached_blockhash.get_balance(async_stubbed_receiver_cached_blockhash)
     assert balance["result"]["value"] == AIRDROP_AMOUNT
 
 
@@ -87,7 +116,7 @@ async def test_send_transaction_and_get_balance(async_stubbed_sender, async_stub
     assert resp["result"]["value"] == 9999994000
     resp = await test_http_client_async.get_balance(async_stubbed_receiver)
     assert_valid_response(resp)
-    assert resp["result"]["value"] == 954
+    assert resp["result"]["value"] == 10000001000
 
 
 @pytest.mark.integration
@@ -116,7 +145,7 @@ async def test_send_transaction_prefetched_blockhash(
     assert resp["result"]["value"] == 9999994000
     resp = await test_http_client_async.get_balance(async_stubbed_receiver_prefetched_blockhash)
     assert_valid_response(resp)
-    assert resp["result"]["value"] == 954
+    assert resp["result"]["value"] == 10000001000
 
 
 @pytest.mark.integration
@@ -165,7 +194,7 @@ async def test_send_transaction_cached_blockhash(
     )
     resp = await test_http_client_async_cached_blockhash.get_balance(async_stubbed_receiver_cached_blockhash)
     assert_valid_response(resp)
-    assert resp["result"]["value"] == 954
+    assert resp["result"]["value"] == 10000001000
     resp = await test_http_client_async_cached_blockhash.send_transaction(
         transfer_tx, async_stubbed_sender_cached_blockhash
     )
@@ -212,7 +241,7 @@ async def test_send_raw_transaction_and_get_balance(
     assert resp["result"]["value"] == 9999988000
     resp = await test_http_client_async.get_balance(async_stubbed_receiver)
     assert_valid_response(resp)
-    assert resp["result"]["value"] == 1954
+    assert resp["result"]["value"] == 10000002000
 
 
 @pytest.mark.integration

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -253,7 +253,7 @@ async def test_get_cluster_nodes(test_http_client_async):
 @pytest.mark.asyncio
 async def test_get_confirmed_block(test_http_client_async):
     """Test get confirmed block."""
-    resp = await test_http_client_async.get_confirmed_block(1)
+    resp = await test_http_client_async.get_confirmed_block(2)
     assert_valid_response(resp)
 
 
@@ -261,7 +261,7 @@ async def test_get_confirmed_block(test_http_client_async):
 @pytest.mark.asyncio
 async def test_get_confirmed_block_with_encoding(test_http_client_async):
     """Test get confrimed block with encoding."""
-    resp = await test_http_client_async.get_confirmed_block(1, encoding="base64")
+    resp = await test_http_client_async.get_confirmed_block(2, encoding="base64")
     assert_valid_response(resp)
 
 
@@ -269,7 +269,7 @@ async def test_get_confirmed_block_with_encoding(test_http_client_async):
 @pytest.mark.asyncio
 async def test_get_block(test_http_client_async):
     """Test get block."""
-    resp = await test_http_client_async.get_block(1)
+    resp = await test_http_client_async.get_block(2)
     assert_valid_response(resp)
 
 
@@ -285,7 +285,7 @@ async def test_get_block_height(test_http_client_async):
 @pytest.mark.asyncio
 async def test_get_block_with_encoding(test_http_client_async):
     """Test get block with encoding."""
-    resp = await test_http_client_async.get_block(1, encoding="base64")
+    resp = await test_http_client_async.get_block(2, encoding="base64")
     assert_valid_response(resp)
 
 

--- a/tests/integration/test_http_client.py
+++ b/tests/integration/test_http_client.py
@@ -14,33 +14,59 @@ from .utils import AIRDROP_AMOUNT, assert_valid_response
 
 
 @pytest.mark.integration
-def test_request_air_drop(stubbed_sender: Keypair, test_http_client: Client):
-    """Test air drop to stubbed_sender."""
+def test_request_air_drop(stubbed_sender: Keypair, stubbed_receiver: Keypair, test_http_client: Client):
+    """Test air drop to stubbed_sender and stubbed_receiver."""
+    # Airdrop to stubbed_sender
     resp = test_http_client.request_airdrop(stubbed_sender.public_key, AIRDROP_AMOUNT)
     assert_valid_response(resp)
     test_http_client.confirm_transaction(resp["result"])
     balance = test_http_client.get_balance(stubbed_sender.public_key)
     assert balance["result"]["value"] == AIRDROP_AMOUNT
+    # Airdrop to stubbed_receiver
+    resp = test_http_client.request_airdrop(stubbed_receiver, AIRDROP_AMOUNT)
+    assert_valid_response(resp)
+    test_http_client.confirm_transaction(resp["result"])
+    balance = test_http_client.get_balance(stubbed_receiver)
+    assert balance["result"]["value"] == AIRDROP_AMOUNT
 
 
 @pytest.mark.integration
-def test_request_air_drop_prefetched_blockhash(stubbed_sender_prefetched_blockhash, test_http_client):
-    """Test air drop to stubbed_sender."""
+def test_request_air_drop_prefetched_blockhash(
+    stubbed_sender_prefetched_blockhash, stubbed_receiver_prefetched_blockhash, test_http_client
+):
+    """Test air drop to stubbed_sender and stubbed_receiver."""
+    # Airdrop to stubbed_sender
     resp = test_http_client.request_airdrop(stubbed_sender_prefetched_blockhash.public_key, AIRDROP_AMOUNT)
     assert_valid_response(resp)
     test_http_client.confirm_transaction(resp["result"])
     balance = test_http_client.get_balance(stubbed_sender_prefetched_blockhash.public_key)
     assert balance["result"]["value"] == AIRDROP_AMOUNT
+    # Airdrop to stubbed_receiver
+    resp = test_http_client.request_airdrop(stubbed_receiver_prefetched_blockhash, AIRDROP_AMOUNT)
+    assert_valid_response(resp)
+    test_http_client.confirm_transaction(resp["result"])
+    balance = test_http_client.get_balance(stubbed_receiver_prefetched_blockhash)
+    assert balance["result"]["value"] == AIRDROP_AMOUNT
 
 
 @pytest.mark.integration
-def test_request_air_drop_cached_blockhash(stubbed_sender_cached_blockhash, test_http_client):
-    """Test air drop to stubbed_sender."""
+def test_request_air_drop_cached_blockhash(
+    stubbed_sender_cached_blockhash, stubbed_receiver_cached_blockhash, test_http_client
+):
+    """Test air drop to stubbed_sender and stubbed_receiver."""
+    # Airdrop to stubbed_sender
     resp = test_http_client.request_airdrop(stubbed_sender_cached_blockhash.public_key, AIRDROP_AMOUNT)
     assert_valid_response(resp)
     test_http_client.confirm_transaction(resp["result"])
     assert_valid_response(resp)
     balance = test_http_client.get_balance(stubbed_sender_cached_blockhash.public_key)
+    assert balance["result"]["value"] == AIRDROP_AMOUNT
+    # Airdrop to stubbed_receiver
+    resp = test_http_client.request_airdrop(stubbed_receiver_cached_blockhash, AIRDROP_AMOUNT)
+    assert_valid_response(resp)
+    test_http_client.confirm_transaction(resp["result"])
+    assert_valid_response(resp)
+    balance = test_http_client.get_balance(stubbed_receiver_cached_blockhash)
     assert balance["result"]["value"] == AIRDROP_AMOUNT
 
 
@@ -70,7 +96,7 @@ def test_send_transaction_and_get_balance(stubbed_sender, stubbed_receiver, test
     assert resp["result"]["value"] == 9999994000
     resp = test_http_client.get_balance(stubbed_receiver)
     assert_valid_response(resp)
-    assert resp["result"]["value"] == 954
+    assert resp["result"]["value"] == 10000001000
 
 
 @pytest.mark.integration
@@ -101,7 +127,7 @@ def test_send_transaction_prefetched_blockhash(
     assert resp["result"]["value"] == 9999994000
     resp = test_http_client.get_balance(stubbed_receiver_prefetched_blockhash)
     assert_valid_response(resp)
-    assert resp["result"]["value"] == 954
+    assert resp["result"]["value"] == 10000001000
 
 
 @pytest.mark.integration
@@ -145,7 +171,7 @@ def test_send_transaction_cached_blockhash(
     )
     resp = test_http_client_cached_blockhash.get_balance(stubbed_receiver_cached_blockhash)
     assert_valid_response(resp)
-    assert resp["result"]["value"] == 954
+    assert resp["result"]["value"] == 10000001000
     resp = test_http_client_cached_blockhash.send_transaction(transfer_tx, stubbed_sender_cached_blockhash)
     # we could have got a new blockhash or not depending on network latency and luck
     assert len(test_http_client_cached_blockhash.blockhash_cache.unused_blockhashes) in (0, 1)
@@ -185,7 +211,7 @@ def test_send_raw_transaction_and_get_balance(stubbed_sender, stubbed_receiver, 
     assert resp["result"]["value"] == 9999988000
     resp = test_http_client.get_balance(stubbed_receiver)
     assert_valid_response(resp)
-    assert resp["result"]["value"] == 1954
+    assert resp["result"]["value"] == 10000002000
 
 
 @pytest.mark.integration

--- a/tests/integration/test_http_client.py
+++ b/tests/integration/test_http_client.py
@@ -221,28 +221,28 @@ def test_get_cluster_nodes(test_http_client):
 @pytest.mark.integration
 def test_get_confirmed_block(test_http_client):
     """Test get confirmed block."""
-    resp = test_http_client.get_confirmed_block(1)
+    resp = test_http_client.get_confirmed_block(2)
     assert_valid_response(resp)
 
 
 @pytest.mark.integration
 def test_get_confirmed_block_with_encoding(test_http_client):
     """Test get confrimed block with encoding."""
-    resp = test_http_client.get_confirmed_block(1, encoding="base64")
+    resp = test_http_client.get_confirmed_block(2, encoding="base64")
     assert_valid_response(resp)
 
 
 @pytest.mark.integration
 def test_get_block(test_http_client):
     """Test get block."""
-    resp = test_http_client.get_block(1)
+    resp = test_http_client.get_block(2)
     assert_valid_response(resp)
 
 
 @pytest.mark.integration
 def test_get_block_with_encoding(test_http_client):
     """Test get block with encoding."""
-    resp = test_http_client.get_block(1, encoding="base64")
+    resp = test_http_client.get_block(2, encoding="base64")
     assert_valid_response(resp)
 
 


### PR DESCRIPTION
Issue: #210 
Bumping to 1.9.14 causes two main problems:

1. Since 1.9.10, the local test validator has been changed so that blocks 0 and 1 are in accessible. 
(see https://github.com/solana-labs/solana/issues/23853 ). 
The solana-py tests which tried to access block 1 now access block 2 instead.
2. https://github.com/solana-labs/solana/pull/22292 requires accounts to be rent exempt. There are transaction tests in ``test_async_http_client.py`` and ``test_http_client.py`` that send sol from an account that got an airdrop to an empty account (which is not rent exempt but now needs to be). This PR fixes the tests to airdrop the receiver account as well so that it is rent exempt.

``rpc/responses.py`` is also updated as the vote subscription response now expects the vote account address.