### PR TITLE
a way to overwrite req params with kwargs

### DIFF
--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -420,6 +420,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         until: Optional[str] = None,
         limit: Optional[int] = None,
         commitment: Optional[Commitment] = None,
+        **kwargs,
     ) -> types.RPCResponse:
         """Returns confirmed signatures for transactions involving an address.
 
@@ -445,7 +446,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
              'id': 2}
         """  # noqa: E501 # pylint: disable=line-too-long
         args = self._get_signatures_for_address_args(account, before, until, limit, commitment)
-        return self._provider.make_request(*args)
+        return self._provider.make_request(*args, **kwargs)
 
     def get_confirmed_transaction(self, tx_sig: str, encoding: str = "json") -> types.RPCResponse:
         """Returns transaction details for a confirmed transaction.
@@ -484,7 +485,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         return self._provider.make_request(*args)
 
     def get_transaction(
-        self, tx_sig: str, encoding: str = "json", commitment: Optional[Commitment] = None
+        self, tx_sig: str, encoding: str = "json", commitment: Optional[Commitment] = None, **kwargs
     ) -> types.RPCResponse:
         """Returns transaction details for a confirmed transaction.
 
@@ -520,7 +521,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
                  'id': 4}
         """  # noqa: E501 # pylint: disable=line-too-long
         args = self._get_transaction_args(tx_sig, encoding, commitment)
-        return self._provider.make_request(*args)
+        return self._provider.make_request(*args, **kwargs)
 
     def get_epoch_info(self, commitment: Optional[Commitment] = None) -> types.RPCResponse:
         """Returns information about the current epoch.

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -416,6 +416,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         until: Optional[str] = None,
         limit: Optional[int] = None,
         commitment: Optional[Commitment] = None,
+        **kwargs,
     ) -> types.RPCResponse:
         """Returns confirmed signatures for transactions involving an address.
 
@@ -441,7 +442,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
              'id': 2}
         """  # noqa: E501 # pylint: disable=line-too-long
         args = self._get_signatures_for_address_args(account, before, until, limit, commitment)
-        return await self._provider.make_request(*args)
+        return await self._provider.make_request(*args, **kwargs)
 
     async def get_confirmed_transaction(self, tx_sig: str, encoding: str = "json") -> types.RPCResponse:
         """Returns transaction details for a confirmed transaction.
@@ -479,7 +480,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         args = self._get_confirmed_transaction_args(tx_sig, encoding)
         return await self._provider.make_request(*args)
 
-    async def get_transaction(self, tx_sig: str, encoding: str = "json") -> types.RPCResponse:
+    async def get_transaction(self, tx_sig: str, encoding: str = "json", **kwargs) -> types.RPCResponse:
         """Returns transaction details for a confirmed transaction.
 
         Args:
@@ -513,7 +514,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
              'id': 4}
         """  # noqa: E501 # pylint: disable=line-too-long
         args = self._get_transaction_args(tx_sig, encoding)
-        return await self._provider.make_request(*args)
+        return await self._provider.make_request(*args, **kwargs)
 
     async def get_epoch_info(self, commitment: Optional[Commitment] = None) -> types.RPCResponse:
         """Returns information about the current epoch.

--- a/src/solana/rpc/providers/async_http.py
+++ b/src/solana/rpc/providers/async_http.py
@@ -22,9 +22,9 @@ class AsyncHTTPProvider(AsyncBaseProvider, _HTTPProviderCore):
         return f"Async HTTP RPC connection {self.endpoint_uri}"
 
     @handle_async_exceptions(SolanaRpcException, Exception)
-    async def make_request(self, method: RPCMethod, *params: Any) -> RPCResponse:
+    async def make_request(self, method: RPCMethod, *params: Any, **kwargs) -> RPCResponse:
         """Make an async HTTP request to an http rpc endpoint."""
-        request_kwargs = self._before_request(method=method, params=params, is_async=True)
+        request_kwargs = self._before_request(method=method, params=params, is_async=True, **kwargs)
         raw_response = await self.session.post(**request_kwargs)
         return self._after_request(raw_response=raw_response, method=method)
 

--- a/src/solana/rpc/providers/http.py
+++ b/src/solana/rpc/providers/http.py
@@ -17,9 +17,9 @@ class HTTPProvider(BaseProvider, _HTTPProviderCore):
         return f"HTTP RPC connection {self.endpoint_uri}"
 
     @handle_exceptions(SolanaRpcException, requests.exceptions.RequestException)
-    def make_request(self, method: RPCMethod, *params: Any) -> RPCResponse:
+    def make_request(self, method: RPCMethod, *params: Any, **kwargs) -> RPCResponse:
         """Make an HTTP request to an http rpc endpoint."""
-        request_kwargs = self._before_request(method=method, params=params, is_async=False)
+        request_kwargs = self._before_request(method=method, params=params, is_async=False, **kwargs)
         raw_response = requests.post(**request_kwargs, timeout=self.timeout)
         return self._after_request(raw_response=raw_response, method=method)
 

--- a/src/solana/utils/helpers.py
+++ b/src/solana/utils/helpers.py
@@ -1,6 +1,7 @@
 """Helper functions."""
 
 from base64 import b64decode
+from typing import Dict, Union
 
 from based58 import b58decode
 
@@ -24,3 +25,17 @@ def decode_byte_string(byte_string: str, encoding: str = "base64") -> bytes:
         return b58decode(b_str)
 
     raise NotImplementedError(f"{encoding} decoding not currently supported.")
+
+
+def merge_keep_latter(dict_1: Dict[str, Union[str, Dict]], dict_2: Dict[str, Union[str, Dict]]):
+    """Deep-merges 2 dicts, preferring values from latter on conflict"""
+    res = dict_1.copy()
+    for (key, val) in dict_2.items():
+        if isinstance(val, dict):
+            if isinstance(res[key], dict):
+                res[key] = merge_keep_latter(res[key], val)
+            else:
+                res[key] = val
+        else:
+            res[key] = val
+    return res


### PR DESCRIPTION
As per this issue - https://github.com/michaelhly/solana-py/issues/221 - it's currently not possible to pass custom request params into RPC calls.

This PR would enable the caller to pass a custom `**kwargs` which would necessarily overwrite existing request params built by the library. In our case this helped us solve the issue of adding authorization headers.

I only added the **kwargs to a few methods in api/async_api - but if you think this is valid I'm happy to add to the rest.

@michaelhly 