### PR TITLE
Make transaction message compilation consistent with @solana/web3.js

### DIFF
--- a/src/solana/transaction.py
+++ b/src/solana/transaction.py
@@ -213,22 +213,23 @@ class Transaction:
         num_readonly_unsigned_accounts: int = len([x for x in joined_am if (not x.is_writable and not x.is_signer)])
 
         # Initialize signature array, if needed
+        account_keys = [(str(x.pubkey), x.is_signer) for x in joined_am]
+
         self.signatures = [] if not self.signatures else self.signatures
         exiting_signature_pubkeys: List[str] = [str(x.pubkey) for x in self.signatures]
 
         # Append missing signatures
-        signer_pubkeys = [str(x.pubkey) for x in joined_am if x.is_signer]
+        signer_pubkeys = [k for (k, is_signer) in account_keys if is_signer]
         for signer_pubkey in signer_pubkeys:
             if signer_pubkey not in exiting_signature_pubkeys:
                 self.signatures.append(SigPubkeyPair(pubkey=PublicKey(signer_pubkey), signature=None))
 
         # Ensure fee_payer signature is first
-        fee_payer_signature = [x for x in self.signatures if str(x.pubkey) == str(fee_payer)]
-        other_signatures = [x for x in self.signatures if str(x.pubkey) != str(fee_payer)]
+        fee_payer_signature = [x for x in self.signatures if x.pubkey == fee_payer]
+        other_signatures = [x for x in self.signatures if x.pubkey != fee_payer]
         self.signatures = fee_payer_signature + other_signatures
 
-        account_keys = [str(x.pubkey) for x in joined_am]
-        account_indices: Dict[str, int] = {str(key): idx for idx, key in enumerate(account_keys)}
+        account_indices: Dict[str, int] = {k: idx for idx, (k, _) in enumerate(account_keys)}
 
         compiled_instructions: List[CompiledInstruction] = [
             CompiledInstruction(

--- a/src/solana/transaction.py
+++ b/src/solana/transaction.py
@@ -191,16 +191,10 @@ class Transaction:
         else:
             fee_payer_am = AccountMeta(fee_payer, True, True)
 
-        remaining_am = account_metas.values()
-        signer_am = sorted(
-            [x for x in remaining_am if x.is_signer], key=lambda x: (not x.is_writable, str(x.pubkey).lower())
-        )
-        writable_am = sorted(
-            [x for x in remaining_am if (not x.is_signer and x.is_writable)], key=lambda x: str(x.pubkey).lower()
-        )
-        rest_am = sorted(
-            [x for x in remaining_am if (not x.is_signer and not x.is_writable)], key=lambda x: str(x.pubkey).lower()
-        )
+        sorted_account_metas = sorted(account_metas.values(), key=lambda am: (str(am.pubkey).lower())
+        signer_am = sorted([x for x in sorted_account_metas if x.is_signer], key=lambda am: not am.is_writable)
+        writable_am = [x for x in sorted_account_metas if (not x.is_signer and x.is_writable)]
+        rest_am = [x for x in sorted_account_metas if (not x.is_signer and not x.is_writable)]
 
         joined_am = [fee_payer_am] + signer_am + writable_am + rest_am
 

--- a/src/solana/transaction.py
+++ b/src/solana/transaction.py
@@ -184,9 +184,12 @@ class Transaction:
         # 1. is_signer, with `is_writable`=False ordered last
         # 2. is_writable
         # 3. PublicKey
-        fee_payer_am = account_metas.pop(str(fee_payer))
-        fee_payer_am.is_signer = True
-        fee_payer_am.is_writable = True
+        fee_payer_am = account_metas.pop(str(fee_payer), None)
+        if fee_payer_am:
+            fee_payer_am.is_signer = True
+            fee_payer_am.is_writable = True
+        else:
+            fee_payer_am = AccountMeta(fee_payer, True, True)
 
         remaining_am = account_metas.values()
         signer_am = sorted(

--- a/src/solana/transaction.py
+++ b/src/solana/transaction.py
@@ -195,13 +195,13 @@ class Transaction:
         remaining_am = account_metas.values()
         signer_am = sorted(\
             [x for x in remaining_am if x.is_signer], 
-            key=lambda x: (not x.is_writable, str(x).lower()))
+            key=lambda x: (not x.is_writable, str(x.pubkey).lower()))
         writable_am = sorted(\
             [x for x in remaining_am if (not x.is_signer and x.is_writable)], 
-            key=lambda x: str(x).lower())
+            key=lambda x: str(x.pubkey).lower())
         rest_am = sorted(\
             [x for x in remaining_am if (not x.is_signer and not x.is_writable)], 
-            key=lambda x: str(x).lower())
+            key=lambda x: str(x.pubkey).lower())
         
         joined_am = [fee_payer_am] + signer_am + writable_am + rest_am
         

--- a/src/solana/transaction.py
+++ b/src/solana/transaction.py
@@ -216,12 +216,12 @@ class Transaction:
         account_keys = [(str(x.pubkey), x.is_signer) for x in joined_am]
 
         self.signatures = [] if not self.signatures else self.signatures
-        exiting_signature_pubkeys: List[str] = [str(x.pubkey) for x in self.signatures]
+        existing_signature_pubkeys: List[str] = [str(x.pubkey) for x in self.signatures]
 
         # Append missing signatures
         signer_pubkeys = [k for (k, is_signer) in account_keys if is_signer]
         for signer_pubkey in signer_pubkeys:
-            if signer_pubkey not in exiting_signature_pubkeys:
+            if signer_pubkey not in existing_signature_pubkeys:
                 self.signatures.append(SigPubkeyPair(pubkey=PublicKey(signer_pubkey), signature=None))
 
         # Ensure fee_payer signature is first

--- a/src/solana/transaction.py
+++ b/src/solana/transaction.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from sys import maxsize
 from typing import Any, Dict, List, NamedTuple, NewType, Optional, Union
 
 from based58 import b58decode, b58encode

--- a/src/solana/transaction.py
+++ b/src/solana/transaction.py
@@ -248,7 +248,7 @@ class Transaction:
                     num_readonly_signed_accounts=num_readonly_signed_accounts,
                     num_readonly_unsigned_accounts=num_readonly_unsigned_accounts,
                 ),
-                account_keys=[k for (k, is_signer) in account_keys],
+                account_keys=[k for (k, _) in account_keys],
                 instructions=compiled_instructions,
                 recent_blockhash=self.recent_blockhash,
             )

--- a/src/solana/transaction.py
+++ b/src/solana/transaction.py
@@ -248,7 +248,7 @@ class Transaction:
                     num_readonly_signed_accounts=num_readonly_signed_accounts,
                     num_readonly_unsigned_accounts=num_readonly_unsigned_accounts,
                 ),
-                account_keys=account_keys,
+                account_keys=[k for (k, is_signer) in account_keys],
                 instructions=compiled_instructions,
                 recent_blockhash=self.recent_blockhash,
             )

--- a/src/solana/transaction.py
+++ b/src/solana/transaction.py
@@ -172,8 +172,9 @@ class Transaction:
                     account_metas[pubkey].is_writable = True if key.is_writable else account_metas[pubkey].is_writable
 
             # Add program_id to account_metas
-            if str(instruction.program_id) not in account_metas:
-                account_metas[str(instruction.program_id)] = AccountMeta(
+            instruction_program_id = str(instruction.program_id)
+            if instruction_program_id not in account_metas:
+                account_metas[instruction_program_id] = AccountMeta(
                     pubkey=instruction.program_id,
                     is_signer=False,
                     is_writable=False,

--- a/src/solana/transaction.py
+++ b/src/solana/transaction.py
@@ -192,16 +192,10 @@ class Transaction:
         else:
             fee_payer_am = AccountMeta(fee_payer, True, True)
 
-        remaining_am = account_metas.values()
-        signer_am = sorted(
-            [x for x in remaining_am if x.is_signer], key=lambda x: (not x.is_writable, str(x.pubkey).lower())
-        )
-        writable_am = sorted(
-            [x for x in remaining_am if (not x.is_signer and x.is_writable)], key=lambda x: str(x.pubkey).lower()
-        )
-        rest_am = sorted(
-            [x for x in remaining_am if (not x.is_signer and not x.is_writable)], key=lambda x: str(x.pubkey).lower()
-        )
+        sorted_account_metas = sorted(account_metas.values(), key=lambda am: (str(am.pubkey).lower()))
+        signer_am = sorted([x for x in sorted_account_metas if x.is_signer], key=lambda am: not am.is_writable)
+        writable_am = [x for x in sorted_account_metas if (not x.is_signer and x.is_writable)]
+        rest_am = [x for x in sorted_account_metas if (not x.is_signer and not x.is_writable)]
 
         joined_am = [fee_payer_am] + signer_am + writable_am + rest_am
 
@@ -220,22 +214,23 @@ class Transaction:
         num_readonly_unsigned_accounts: int = len([x for x in joined_am if (not x.is_writable and not x.is_signer)])
 
         # Initialize signature array, if needed
+        account_keys = [(str(x.pubkey), x.is_signer) for x in joined_am]
+
         self.signatures = [] if not self.signatures else self.signatures
-        exiting_signature_pubkeys: List[str] = [str(x.pubkey) for x in self.signatures]
+        existing_signature_pubkeys: List[str] = [str(x.pubkey) for x in self.signatures]
 
         # Append missing signatures
-        signer_pubkeys = [str(x.pubkey) for x in joined_am if x.is_signer]
+        signer_pubkeys = [k for (k, is_signer) in account_keys if is_signer]
         for signer_pubkey in signer_pubkeys:
-            if signer_pubkey not in exiting_signature_pubkeys:
+            if signer_pubkey not in existing_signature_pubkeys:
                 self.signatures.append(SigPubkeyPair(pubkey=PublicKey(signer_pubkey), signature=None))
 
         # Ensure fee_payer signature is first
-        fee_payer_signature = [x for x in self.signatures if str(x.pubkey) == str(fee_payer)]
-        other_signatures = [x for x in self.signatures if str(x.pubkey) != str(fee_payer)]
+        fee_payer_signature = [x for x in self.signatures if x.pubkey == fee_payer]
+        other_signatures = [x for x in self.signatures if x.pubkey != fee_payer]
         self.signatures = fee_payer_signature + other_signatures
 
-        account_keys = [str(x.pubkey) for x in joined_am]
-        account_indices: Dict[str, int] = {str(key): idx for idx, key in enumerate(account_keys)}
+        account_indices: Dict[str, int] = {k: idx for idx, (k, _) in enumerate(account_keys)}
 
         compiled_instructions: List[CompiledInstruction] = [
             CompiledInstruction(

--- a/tests/unit/test_system_program.py
+++ b/tests/unit/test_system_program.py
@@ -491,4 +491,6 @@ def test_advance_nonce_and_transfer():
 
     txn.add_signature(from_keypair.public_key, from_keypair.sign(txn_hash).signature)
 
-    assert txn in [cli_expected_txn, js_expected_txn]
+    assert txn == js_expected_txn
+    # XXX:  Cli message serialization do not sort on account metas producing discrepency 
+    # assert txn == cli_expected_txn

--- a/tests/unit/test_system_program.py
+++ b/tests/unit/test_system_program.py
@@ -240,7 +240,9 @@ def test_create_nonce_account():
     create_account_txn.add_signature(from_keypair.public_key, from_keypair.sign(create_account_hash).signature)
     create_account_txn.add_signature(nonce_keypair.public_key, nonce_keypair.sign(create_account_hash).signature)
 
-    assert create_account_txn in [js_expected_txn, cli_expected_txn]
+    assert create_account_txn == js_expected_txn
+    # XXX:  Cli message serialization do not sort on account metas producing discrepency 
+    # assert create_account_txn == cli_expected_txn
 
 
 def test_advance_nonce_and_transfer():

--- a/tests/unit/test_system_program.py
+++ b/tests/unit/test_system_program.py
@@ -222,7 +222,7 @@ def test_create_nonce_account():
     js_wire_txn = base64.b64decode(
         b"AkBAiPTJfOYZRLOZUpH7vIxyJQovMxO7X8FxXyRzae8CECBZ9LS5G8hxZVMdVL6uSIzLHb/0aLYhO5FEVmfhwguY5ZtOCOGqjwyAOVr8L2eBXgX482L/rcmF6ELORIcD1GdAFBQ/1Hc/LByer9TbJfNqzjesdzTJEHohnStduU4OAgADBTqF5SfUR/5I9i2gnIHHEr01j2JItmpFHSaRd74NaZ1wvICzr4gFWblct6+DODXkCxQiipQzG81MS5S4IkqB7uEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAan1RcZLFaO4IqEX3PSl4jPA1wxRbIas0TYBi6pQAAABqfVFxksXFEhjMlMPUrxf1ja7gibof1E49vZigAAAABXbYHxIfw3Z5Qq1LH8aj6Sj6LuqbCuwFhAmo21XevlfwICAgABNAAAAACAhB4AAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAwEDBCQGAAAAOoXlJ9RH/kj2LaCcgccSvTWPYki2akUdJpF3vg1pnXA="  # noqa: E501 pylint: disable=line-too-long
     )
-    cli_expected_txn = txlib.Transaction.deserialize(cli_wire_txn)
+    cli_expected_txn = txlib.Transaction.deserialize(cli_wire_txn)  # noqa: F841
     js_expected_txn = txlib.Transaction.deserialize(js_wire_txn)
 
     create_account_txn = sp.create_nonce_account(
@@ -240,7 +240,9 @@ def test_create_nonce_account():
     create_account_txn.add_signature(from_keypair.public_key, from_keypair.sign(create_account_hash).signature)
     create_account_txn.add_signature(nonce_keypair.public_key, nonce_keypair.sign(create_account_hash).signature)
 
-    assert create_account_txn in [js_expected_txn, cli_expected_txn]
+    assert create_account_txn == js_expected_txn
+    # XXX:  Cli message serialization do not sort on account metas producing discrepency
+    # assert create_account_txn == cli_expected_txn
 
 
 def test_advance_nonce_and_transfer():
@@ -466,7 +468,7 @@ def test_advance_nonce_and_transfer():
         b"Af67rLfP5WxsOgvZWndq34S2KbQq++x03eZkZagzbVQ2tRyfFyn6OWByp8q3P2a03HDeVtpUWhq1y1a6R0DcPAIBAAIFOoXlJ9RH/kj2LaCcgccSvTWPYki2akUdJpF3vg1pnXC8gLOviAVZuVy3r4M4NeQLFCKKlDMbzUxLlLgiSoHu4fx8NgMSbd8b4Rw7yjH49BGlIWU72U/q2ftVCQYoAN0KAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGp9UXGSxWjuCKhF9z0peIzwNcMUWyGrNE2AYuqUAAAE13Mu8zaQSpG0zzGHpG62nK56DbGhuS4kXMF/ChHY1jAgMDAQQABAQAAAADAgACDAIAAACAhB4AAAAAAA=="  # noqa: E501 pylint: disable=line-too-long
     )
 
-    cli_expected_txn = txlib.Transaction.deserialize(cli_wire_txn)
+    cli_expected_txn = txlib.Transaction.deserialize(cli_wire_txn)  # noqa: F841
     js_expected_txn = txlib.Transaction.deserialize(js_wire_txn)
 
     txn = txlib.Transaction(fee_payer=from_keypair.public_key)
@@ -491,4 +493,6 @@ def test_advance_nonce_and_transfer():
 
     txn.add_signature(from_keypair.public_key, from_keypair.sign(txn_hash).signature)
 
-    assert txn in [cli_expected_txn, js_expected_txn]
+    assert txn == js_expected_txn
+    # XXX:  Cli message serialization do not sort on account metas producing discrepency
+    # assert txn == cli_expected_txn

--- a/tests/unit/test_system_program.py
+++ b/tests/unit/test_system_program.py
@@ -240,9 +240,7 @@ def test_create_nonce_account():
     create_account_txn.add_signature(from_keypair.public_key, from_keypair.sign(create_account_hash).signature)
     create_account_txn.add_signature(nonce_keypair.public_key, nonce_keypair.sign(create_account_hash).signature)
 
-    assert create_account_txn == js_expected_txn
-    # XXX:  Cli message serialization do not sort on account metas producing discrepency 
-    # assert create_account_txn == cli_expected_txn
+    assert create_account_txn in [js_expected_txn, cli_expected_txn]
 
 
 def test_advance_nonce_and_transfer():
@@ -493,6 +491,4 @@ def test_advance_nonce_and_transfer():
 
     txn.add_signature(from_keypair.public_key, from_keypair.sign(txn_hash).signature)
 
-    assert txn == js_expected_txn
-    # XXX:  Cli message serialization do not sort on account metas producing discrepency 
-    # assert txn == cli_expected_txn
+    assert txn in [cli_expected_txn, js_expected_txn]

--- a/tests/unit/test_system_program.py
+++ b/tests/unit/test_system_program.py
@@ -211,7 +211,7 @@ def test_create_nonce_account():
         )
     )
 
-    wire_txn = base64.b64decode(
+    cli_wire_txn = base64.b64decode(
         b"AtZYPHSaLIQsFnHm4O7Lk0YdQRzovtsp0eKbKRPknDvZINd62tZaLPRzhm6N1LeINLzy31iHY6QE0bGW5c9aegu9g9SQqwsj"
         b"dKfNTYI0JLmzQd98HCUczjMM5H/gvGx+4k+sM/SreWkC3y1X+I1yh4rXehtVW5Sqo5nyyl7z88wOAgADBTqF5SfUR/5I9i2g"
         b"nIHHEr01j2JItmpFHSaRd74NaZ1wvICzr4gFWblct6+DODXkCxQiipQzG81MS5S4IkqB7uEGp9UXGSxWjuCKhF9z0peIzwNc"
@@ -219,7 +219,11 @@ def test_create_nonce_account():
         b"AAAAAABXbYHxIfw3Z5Qq1LH8aj6Sj6LuqbCuwFhAmo21XevlfwIEAgABNAAAAACAhB4AAAAAAFAAAAAAAAAAAAAAAAAAAAAA"
         b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAwECAyQGAAAAOoXlJ9RH/kj2LaCcgccSvTWPYki2akUdJpF3vg1pnXA="
     )
-    expected_txn = txlib.Transaction.deserialize(wire_txn)
+    js_wire_txn = base64.b64decode(
+        b"AkBAiPTJfOYZRLOZUpH7vIxyJQovMxO7X8FxXyRzae8CECBZ9LS5G8hxZVMdVL6uSIzLHb/0aLYhO5FEVmfhwguY5ZtOCOGqjwyAOVr8L2eBXgX482L/rcmF6ELORIcD1GdAFBQ/1Hc/LByer9TbJfNqzjesdzTJEHohnStduU4OAgADBTqF5SfUR/5I9i2gnIHHEr01j2JItmpFHSaRd74NaZ1wvICzr4gFWblct6+DODXkCxQiipQzG81MS5S4IkqB7uEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAan1RcZLFaO4IqEX3PSl4jPA1wxRbIas0TYBi6pQAAABqfVFxksXFEhjMlMPUrxf1ja7gibof1E49vZigAAAABXbYHxIfw3Z5Qq1LH8aj6Sj6LuqbCuwFhAmo21XevlfwICAgABNAAAAACAhB4AAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAwEDBCQGAAAAOoXlJ9RH/kj2LaCcgccSvTWPYki2akUdJpF3vg1pnXA="  # noqa: E501 pylint: disable=line-too-long
+    )
+    cli_expected_txn = txlib.Transaction.deserialize(cli_wire_txn)
+    js_expected_txn = txlib.Transaction.deserialize(js_wire_txn)
 
     create_account_txn = sp.create_nonce_account(
         sp.CreateNonceAccountParams(
@@ -236,7 +240,7 @@ def test_create_nonce_account():
     create_account_txn.add_signature(from_keypair.public_key, from_keypair.sign(create_account_hash).signature)
     create_account_txn.add_signature(nonce_keypair.public_key, nonce_keypair.sign(create_account_hash).signature)
 
-    assert create_account_txn == expected_txn
+    assert create_account_txn in [js_expected_txn, cli_expected_txn]
 
 
 def test_advance_nonce_and_transfer():
@@ -451,15 +455,19 @@ def test_advance_nonce_and_transfer():
         )
     )
 
-    wire_txn = base64.b64decode(
+    cli_wire_txn = base64.b64decode(
         b"Abh4hJNaP/IUJlHGpQttaGNWkjOZx71uLEnVpT0SBaedmThsTogjsh87FW+EHeuJrsZii+tJbrq3oJ5UYXPzXwwBAAIFOoXl"
         b"J9RH/kj2LaCcgccSvTWPYki2akUdJpF3vg1pnXC8gLOviAVZuVy3r4M4NeQLFCKKlDMbzUxLlLgiSoHu4fx8NgMSbd8b4Rw7"
         b"yjH49BGlIWU72U/q2ftVCQYoAN0KBqfVFxksVo7gioRfc9KXiM8DXDFFshqzRNgGLqlAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
         b"AAAAAAAAAAAAAAAAAE13Mu8zaQSpG0zzGHpG62nK56DbGhuS4kXMF/ChHY1jAgQDAQMABAQAAAAEAgACDAIAAACAhB4AAAAA"
         b"AA=="
     )
+    js_wire_txn = base64.b64decode(
+        b"Af67rLfP5WxsOgvZWndq34S2KbQq++x03eZkZagzbVQ2tRyfFyn6OWByp8q3P2a03HDeVtpUWhq1y1a6R0DcPAIBAAIFOoXlJ9RH/kj2LaCcgccSvTWPYki2akUdJpF3vg1pnXC8gLOviAVZuVy3r4M4NeQLFCKKlDMbzUxLlLgiSoHu4fx8NgMSbd8b4Rw7yjH49BGlIWU72U/q2ftVCQYoAN0KAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGp9UXGSxWjuCKhF9z0peIzwNcMUWyGrNE2AYuqUAAAE13Mu8zaQSpG0zzGHpG62nK56DbGhuS4kXMF/ChHY1jAgMDAQQABAQAAAADAgACDAIAAACAhB4AAAAAAA=="  # noqa: E501 pylint: disable=line-too-long
+    )
 
-    expected_txn = txlib.Transaction.deserialize(wire_txn)
+    cli_expected_txn = txlib.Transaction.deserialize(cli_wire_txn)
+    js_expected_txn = txlib.Transaction.deserialize(js_wire_txn)
 
     txn = txlib.Transaction(fee_payer=from_keypair.public_key)
     txn.recent_blockhash = "6DPp9aRRX6cLBqj5FepEvoccHFs3s8gUhd9t9ftTwAta"
@@ -483,4 +491,4 @@ def test_advance_nonce_and_transfer():
 
     txn.add_signature(from_keypair.public_key, from_keypair.sign(txn_hash).signature)
 
-    assert txn == expected_txn
+    assert txn in [cli_expected_txn, js_expected_txn]

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -14,7 +14,6 @@ from solana.publickey import PublicKey
 def test_sign_partial(stubbed_blockhash):
     """Test paritally sigining a transaction."""
     kp1, kp2 = Keypair(), Keypair()
-    kp1.public_key
     transfer = sp.transfer(sp.TransferParams(from_pubkey=kp1.public_key, to_pubkey=kp2.public_key, lamports=123))
     partial_txn = txlib.Transaction(recent_blockhash=stubbed_blockhash).add(transfer)
     partial_txn.sign_partial(kp1, kp2.public_key)

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -371,7 +371,9 @@ def test_sort_account_metas(stubbed_blockhash):
     fee_payer = signer_one
     sorted_signers = sorted([x.public_key for x in [signer_one, signer_two, signer_three]], key=lambda x: str(x))
     sorted_signers_excluding_fee_payer = [x for x in sorted_signers if str(x) != str(fee_payer.public_key)]
-    sorted_receivers = sorted([x.public_key for x in [receiver_one, receiver_two, receiver_three]], key=lambda x: str(x))
+    sorted_receivers = sorted(
+        [x.public_key for x in [receiver_one, receiver_two, receiver_three]], key=lambda x: str(x)
+    )
 
     txn = txlib.Transaction(recent_blockhash=stubbed_blockhash)
     txn.fee_payer = fee_payer.public_key

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -121,3 +121,296 @@ def test_serialize_unsigned_transaction(stubbed_blockhash, stubbed_receiver, stu
     )
     assert txn.serialize() == expected_serialization
     assert len(txn.signatures) == 1
+
+
+def test_sort_account_metas(stubbed_blockhash):
+    """
+    Test AccountMeta sorting after calling Transaction.compile_message()
+    """
+
+    # S6EA7XsNyxg4yx4DJRMm7fP21jgZb1fuzBAUGhgVtkP
+    signer_one = Keypair.from_seed(
+        bytes(
+            [
+                216,
+                214,
+                184,
+                213,
+                199,
+                75,
+                129,
+                160,
+                237,
+                96,
+                96,
+                228,
+                46,
+                251,
+                146,
+                3,
+                71,
+                162,
+                37,
+                117,
+                121,
+                70,
+                143,
+                16,
+                128,
+                78,
+                53,
+                189,
+                222,
+                230,
+                165,
+                249,
+            ]
+        )
+    )
+
+    # BKdt9U6V922P17ui81dzLoqgSY2B5ds1UD13rpwFB2zi
+    receiver_one = Keypair.from_seed(
+        bytes(
+            [
+                3,
+                140,
+                94,
+                243,
+                0,
+                38,
+                92,
+                138,
+                52,
+                79,
+                153,
+                83,
+                42,
+                236,
+                220,
+                82,
+                227,
+                187,
+                101,
+                104,
+                126,
+                159,
+                103,
+                100,
+                29,
+                183,
+                242,
+                68,
+                144,
+                184,
+                114,
+                211,
+            ]
+        )
+    )
+
+    # DtDZCnXEN69n5W6rN5SdJFgedrWdK8NV9bsMiJekNRyu
+    signer_two = Keypair.from_seed(
+        bytes(
+            [
+                177,
+                182,
+                154,
+                154,
+                5,
+                145,
+                253,
+                138,
+                211,
+                126,
+                222,
+                195,
+                21,
+                64,
+                117,
+                211,
+                225,
+                47,
+                115,
+                31,
+                247,
+                242,
+                80,
+                195,
+                38,
+                8,
+                236,
+                155,
+                255,
+                27,
+                20,
+                142,
+            ]
+        )
+    )
+
+    # FXgds3n6SNCoVVV4oELSumv8nKzAfqSgmeu7cNPikKFT
+    receiver_two = Keypair.from_seed(
+        bytes(
+            [
+                180,
+                204,
+                139,
+                131,
+                244,
+                6,
+                180,
+                121,
+                191,
+                193,
+                45,
+                109,
+                198,
+                50,
+                163,
+                140,
+                34,
+                4,
+                172,
+                76,
+                129,
+                45,
+                194,
+                83,
+                192,
+                112,
+                76,
+                58,
+                32,
+                174,
+                49,
+                248,
+            ]
+        )
+    )
+
+    # C2UwQHqJ3BmEJHSMVmrtZDQGS2fGv8fZrWYGi18nHF5k
+    signer_three = Keypair.from_seed(
+        bytes(
+            [
+                29,
+                79,
+                73,
+                16,
+                137,
+                117,
+                183,
+                2,
+                131,
+                0,
+                209,
+                142,
+                134,
+                100,
+                190,
+                35,
+                95,
+                220,
+                200,
+                163,
+                247,
+                237,
+                161,
+                70,
+                226,
+                223,
+                100,
+                148,
+                49,
+                202,
+                154,
+                180,
+            ]
+        )
+    )
+
+    # 8YPqwYXZtWPd31puVLEUPamS4wTv6F89n8nXDA5Ce2Bg
+    receiver_three = Keypair.from_seed(
+        bytes(
+            [
+                167,
+                102,
+                49,
+                166,
+                202,
+                0,
+                132,
+                182,
+                239,
+                182,
+                252,
+                59,
+                25,
+                103,
+                76,
+                217,
+                65,
+                215,
+                210,
+                159,
+                168,
+                50,
+                10,
+                229,
+                144,
+                231,
+                221,
+                74,
+                182,
+                161,
+                52,
+                193,
+            ]
+        )
+    )
+
+    fee_payer = signer_one
+    sorted_signers = sorted([x.public_key for x in [signer_one, signer_two, signer_three]], key=lambda x: str(x))
+    sorted_signers_excluding_fee_payer = [x for x in sorted_signers if str(x) != str(fee_payer.public_key)]
+    sorted_receivers = sorted([x.public_key for x in [receiver_one, receiver_two, receiver_three]], key=lambda x: str(x))
+
+    txn = txlib.Transaction(recent_blockhash=stubbed_blockhash)
+    txn.fee_payer = fee_payer.public_key
+
+    # Add three transfer transactions
+    txn.add(
+        sp.transfer(
+            sp.TransferParams(
+                from_pubkey=signer_one.public_key,
+                to_pubkey=receiver_one.public_key,
+                lamports=1_000,
+            )
+        )
+    )
+    txn.add(
+        sp.transfer(
+            sp.TransferParams(
+                from_pubkey=signer_two.public_key,
+                to_pubkey=receiver_two.public_key,
+                lamports=1_000,
+            )
+        )
+    )
+    txn.add(
+        sp.transfer(
+            sp.TransferParams(
+                from_pubkey=signer_three.public_key,
+                to_pubkey=receiver_three.public_key,
+                lamports=1_000,
+            )
+        )
+    )
+
+    tx_msg = txn.compile_message()
+
+    # Transaction should organize AccountMetas by PublicKey
+    assert tx_msg.account_keys[0] == fee_payer.public_key
+    assert tx_msg.account_keys[1] == sorted_signers_excluding_fee_payer[0]
+    assert tx_msg.account_keys[2] == sorted_signers_excluding_fee_payer[1]
+    assert tx_msg.account_keys[3] == sorted_receivers[0]
+    assert tx_msg.account_keys[4] == sorted_receivers[1]
+    assert tx_msg.account_keys[5] == sorted_receivers[2]

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -14,6 +14,7 @@ from solana.publickey import PublicKey
 def test_sign_partial(stubbed_blockhash):
     """Test paritally sigining a transaction."""
     kp1, kp2 = Keypair(), Keypair()
+    kp1.public_key
     transfer = sp.transfer(sp.TransferParams(from_pubkey=kp1.public_key, to_pubkey=kp2.public_key, lamports=123))
     partial_txn = txlib.Transaction(recent_blockhash=stubbed_blockhash).add(transfer)
     partial_txn.sign_partial(kp1, kp2.public_key)
@@ -384,7 +385,7 @@ def test_sort_account_metas(stubbed_blockhash):
             sp.TransferParams(
                 from_pubkey=signer_one.public_key,
                 to_pubkey=receiver_one.public_key,
-                lamports=1_000,
+                lamports=2_000_000,
             )
         )
     )
@@ -393,7 +394,7 @@ def test_sort_account_metas(stubbed_blockhash):
             sp.TransferParams(
                 from_pubkey=signer_two.public_key,
                 to_pubkey=receiver_two.public_key,
-                lamports=1_000,
+                lamports=2_000_000,
             )
         )
     )
@@ -402,12 +403,16 @@ def test_sort_account_metas(stubbed_blockhash):
             sp.TransferParams(
                 from_pubkey=signer_three.public_key,
                 to_pubkey=receiver_three.public_key,
-                lamports=1_000,
+                lamports=2_000_000,
             )
         )
     )
 
     tx_msg = txn.compile_message()
+
+    js_msg_b64_check = b"AwABBwZtbiRMvgQjcE2kVx9yon8XqPSO5hwc2ApflnOZMu0Qo9G5/xbhB0sp8/03Rv9x4MKSkQ+k4LB6lNLvCgKZ/ju/aw+EyQpTObVa3Xm+NA1gSTzutgFCTfkDto/0KtuIHHAMpKRb92NImxKeWQJ2/291j6nTzFj1D6nW25p7TofHmVsGt8uFnTv7+8vsWZ0uN7azdxa+jCIIm4WzKK+4uKfX39t5UA7S1soBQaJkTGOQkSbBo39gIjDkbW0TrevslgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxJrndgN4IFTxep3s6kO0ROug7bEsbx0xxuDkqEvwUusDBgIABAwCAAAAgIQeAAAAAAAGAgIFDAIAAACAhB4AAAAAAAYCAQMMAgAAAICEHgAAAAAA"  # noqa: E501 pylint: disable=line-too-long
+
+    assert b64encode(tx_msg.serialize()) == js_msg_b64_check
 
     # Transaction should organize AccountMetas by PublicKey
     assert tx_msg.account_keys[0] == fee_payer.public_key

--- a/tests/unit/test_vote_program.py
+++ b/tests/unit/test_vote_program.py
@@ -112,5 +112,4 @@ def test_withdraw_from_vote_account():
 
     assert serialized_message == js_wire_msg
     # XXX:  Cli message serialization do not sort on account metas producing discrepency
-
     # serialized_message txn == cli_wire_msg

--- a/tests/unit/test_vote_program.py
+++ b/tests/unit/test_vote_program.py
@@ -110,6 +110,4 @@ def test_withdraw_from_vote_account():
 
     serialized_message = txn.serialize_message()
 
-    assert serialized_message == js_wire_msg
-    # XXX:  Cli message serialization do not sort on account metas producing discrepency 
-    # serialized_message txn == cli_wire_msg
+    assert serialized_message in [cli_wire_msg, js_wire_msg]

--- a/tests/unit/test_vote_program.py
+++ b/tests/unit/test_vote_program.py
@@ -110,4 +110,6 @@ def test_withdraw_from_vote_account():
 
     serialized_message = txn.serialize_message()
 
-    assert serialized_message in [cli_wire_msg, js_wire_msg]
+    assert serialized_message == js_wire_msg
+    # XXX:  Cli message serialization do not sort on account metas producing discrepency 
+    # serialized_message txn == cli_wire_msg

--- a/tests/unit/test_vote_program.py
+++ b/tests/unit/test_vote_program.py
@@ -101,8 +101,8 @@ def test_withdraw_from_vote_account():
     # 2 \
     # --blockhash Add1tV7kJgNHhTtx3Dgs6dhC7kyXrGJQZ2tJGW15tLDH \
     # --sign-only -k withdrawer.json
-    cli_wire_msg = base64.b64decode(
-        b"AQABBDqF5SfUR/5I9i2gnIHHEr01j2JItmpFHSaRd74NaZ1wqxUGDtH5ah3TqEKWjcTmfHkpZC1h57NJL8Sx7Q6Olm2F2O70oOvzt1HgIVu+nySaSrWtJiK1eDacPPDWRxCwFgdhSB01dHS7fE12JOvTvbPYNV5z0RBD/A2jU4AAAAAAjxrQaMS7FjmaR++mvFr3XE6XbzMUTMJUIpITrUWBzGwBAwMBAgAMAwAAAACUNXcAAAAA"  # noqa: E501 pylint: disable=line-too-long
+    cli_wire_msg = base64.b64decode(  # noqa: F841
+        b"AQABBDqF5SfUR/5I9i2gnIHHEr01j2JItmpFHSaRd74NaZ1wqxUGDtH5ah3TqEKWjcTmfHkpZC1h57NJL8Sx7Q6Olm2F2O70oOvzt1HgIVu+nySaSrWtJiK1eDacPPDWRxCwFgdhSB01dHS7fE12JOvTvbPYNV5z0RBD/A2jU4AAAAAAjxrQaMS7FjmaR++mvFr3XE6XbzMUTMJUIpITrUWBzGwBAwMBAgAMAwAAAACUNXcAAAAA"  # noqa: E501  pylint: disable=line-too-long
     )
     js_wire_msg = base64.b64decode(
         b"AQABBDqF5SfUR/5I9i2gnIHHEr01j2JItmpFHSaRd74NaZ1whdju9KDr87dR4CFbvp8kmkq1rSYitXg2nDzw1kcQsBarFQYO0flqHdOoQpaNxOZ8eSlkLWHns0kvxLHtDo6WbQdhSB01dHS7fE12JOvTvbPYNV5z0RBD/A2jU4AAAAAAjxrQaMS7FjmaR++mvFr3XE6XbzMUTMJUIpITrUWBzGwBAwMCAQAMAwAAAACUNXcAAAAA"  # noqa: E501 pylint: disable=line-too-long
@@ -110,4 +110,7 @@ def test_withdraw_from_vote_account():
 
     serialized_message = txn.serialize_message()
 
-    assert serialized_message in [cli_wire_msg, js_wire_msg]
+    assert serialized_message == js_wire_msg
+    # XXX:  Cli message serialization do not sort on account metas producing discrepency
+
+    # serialized_message txn == cli_wire_msg

--- a/tests/unit/test_vote_program.py
+++ b/tests/unit/test_vote_program.py
@@ -1,8 +1,8 @@
 """Unit tests for solana.vote_program."""
 import base64
 
-import solana.vote_program as vp
 import solana.transaction as txlib
+import solana.vote_program as vp
 from solana.keypair import Keypair
 from solana.publickey import PublicKey
 
@@ -81,16 +81,6 @@ def test_withdraw_from_vote_account():
     vote_account_pubkey = PublicKey("CWqJy1JpmBcx7awpeANfrPk6AsQKkmego8ujjaYPGFEk")
     receiver_account_pubkey = PublicKey("A1V5gsis39WY42djdTKUFsgE5oamk4nrtg16WnKTuzZK")
 
-    # solana withdraw-from-vote-account --dump-transaction-message \
-    #   CWqJy1JpmBcx7awpeANfrPk6AsQKkmego8ujjaYPGFEk A1V5gsis39WY42djdTKUFsgE5oamk4nrtg16WnKTuzZK \
-    # --authorized-withdrawer withdrawer.json \
-    # 2 \
-    # --blockhash Add1tV7kJgNHhTtx3Dgs6dhC7kyXrGJQZ2tJGW15tLDH \
-    # --sign-only -k withdrawer.json
-    wire_msg = base64.b64decode(
-        b"AQABBDqF5SfUR/5I9i2gnIHHEr01j2JItmpFHSaRd74NaZ1wqxUGDtH5ah3TqEKWjcTmfHkpZC1h57NJL8Sx7Q6Olm2F2O70oOvzt1HgIVu+nySaSrWtJiK1eDacPPDWRxCwFgdhSB01dHS7fE12JOvTvbPYNV5z0RBD/A2jU4AAAAAAjxrQaMS7FjmaR++mvFr3XE6XbzMUTMJUIpITrUWBzGwBAwMBAgAMAwAAAACUNXcAAAAA"  # noqa: E501 pylint: disable=line-too-long
-    )
-
     txn = txlib.Transaction(fee_payer=withdrawer_keypair.public_key)
     txn.recent_blockhash = "Add1tV7kJgNHhTtx3Dgs6dhC7kyXrGJQZ2tJGW15tLDH"
 
@@ -105,5 +95,19 @@ def test_withdraw_from_vote_account():
         )
     )
 
+    # solana withdraw-from-vote-account --dump-transaction-message \
+    #   CWqJy1JpmBcx7awpeANfrPk6AsQKkmego8ujjaYPGFEk A1V5gsis39WY42djdTKUFsgE5oamk4nrtg16WnKTuzZK \
+    # --authorized-withdrawer withdrawer.json \
+    # 2 \
+    # --blockhash Add1tV7kJgNHhTtx3Dgs6dhC7kyXrGJQZ2tJGW15tLDH \
+    # --sign-only -k withdrawer.json
+    cli_wire_msg = base64.b64decode(
+        b"AQABBDqF5SfUR/5I9i2gnIHHEr01j2JItmpFHSaRd74NaZ1wqxUGDtH5ah3TqEKWjcTmfHkpZC1h57NJL8Sx7Q6Olm2F2O70oOvzt1HgIVu+nySaSrWtJiK1eDacPPDWRxCwFgdhSB01dHS7fE12JOvTvbPYNV5z0RBD/A2jU4AAAAAAjxrQaMS7FjmaR++mvFr3XE6XbzMUTMJUIpITrUWBzGwBAwMBAgAMAwAAAACUNXcAAAAA"  # noqa: E501 pylint: disable=line-too-long
+    )
+    js_wire_msg = base64.b64decode(
+        b"AQABBDqF5SfUR/5I9i2gnIHHEr01j2JItmpFHSaRd74NaZ1whdju9KDr87dR4CFbvp8kmkq1rSYitXg2nDzw1kcQsBarFQYO0flqHdOoQpaNxOZ8eSlkLWHns0kvxLHtDo6WbQdhSB01dHS7fE12JOvTvbPYNV5z0RBD/A2jU4AAAAAAjxrQaMS7FjmaR++mvFr3XE6XbzMUTMJUIpITrUWBzGwBAwMCAQAMAwAAAACUNXcAAAAA"  # noqa: E501 pylint: disable=line-too-long
+    )
+
     serialized_message = txn.serialize_message()
-    assert serialized_message == wire_msg
+
+    assert serialized_message in [cli_wire_msg, js_wire_msg]


### PR DESCRIPTION
### Note
Hi, I noticed an issue when serializing transactions - identical transactions had different compiled message bytes using JavaScript and Python. The primary issue stemmed from differences in sorting AccountMetas, which can result in different account index references and serialized bytes. The JavaScript package includes a third sort key that references the AccountMeta PublicKey (https://github.com/solana-labs/solana-web3.js/blob/master/src/transaction.ts, also https://docs.rs/solana-program/1.6.8/src/solana_program/message.rs.html). 

### Changes

Three primary changes:
1. Updated AccountMeta sorting to match solana/web3.js package. The sorting was a bit different, which resulted in different account key indexes and serialized messages (identical transaction had different serialized output vs js package). The js package has a third sort key that references the AccountMeta PublicKey.
2. Updated the way signatures are added. Previously it added signer signatures if none were present - now it iterates through signers to see if any are missing.
3. Simplified the way AccountMetas are culled
  