### PR TITLE
Update getBlock and getTransaction to Support Versioned Transactions

### DIFF
--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -396,7 +396,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
             encoding: (optional) Encoding for the returned Transaction, either "json", "jsonParsed",
                 "base58" (slow), or "base64". If parameter not provided, the default encoding is JSON.
             commitment: Bank state to query. It can be either "finalized", "confirmed" or "processed".
-            max_supported_transaction_version: The max transaction version to return in responses.
+            max_supported_transaction_version: (optional) The max transaction version to return in responses.
                 If the requested transaction is a higher version, an error will be returned
 
         Example:

--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 from time import sleep, time
-from typing import Dict, List, Optional, Union, Sequence
+from typing import Dict, List, Optional, Sequence, Union
+
 from solders.signature import Signature
 
 from solana.blockhash import Blockhash, BlockhashCache
@@ -380,7 +381,11 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         return self._provider.make_request(body)
 
     def get_transaction(
-        self, tx_sig: Signature, encoding: str = "json", commitment: Optional[Commitment] = None
+        self,
+        tx_sig: Signature,
+        encoding: str = "json",
+        commitment: Optional[Commitment] = None,
+        max_supported_transaction_version: Optional[int] = None,
     ) -> types.RPCResponse:
         """Returns transaction details for a confirmed transaction.
 
@@ -391,6 +396,8 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
             encoding: (optional) Encoding for the returned Transaction, either "json", "jsonParsed",
                 "base58" (slow), or "base64". If parameter not provided, the default encoding is JSON.
             commitment: Bank state to query. It can be either "finalized", "confirmed" or "processed".
+            max_supported_transaction_version: The max transaction version to return in responses.
+                If the requested transaction is a higher version, an error will be returned
 
         Example:
             >>> solana_client = Client("http://localhost:8899")
@@ -415,7 +422,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
                    'signatures': ['3PtGYH77LhhQqTXP4SmDVJ85hmDieWsgXCUbn14v7gYyVYPjZzygUQhTk3bSTYnfA48vCM1rmWY7zWL3j1EVKmEy']}},
                  'id': 4}
         """  # noqa: E501 # pylint: disable=line-too-long
-        body = self._get_transaction_body(tx_sig, encoding, commitment)
+        body = self._get_transaction_body(tx_sig, encoding, commitment, max_supported_transaction_version)
         return self._provider.make_request(body)
 
     def get_epoch_info(self, commitment: Optional[Commitment] = None) -> types.RPCResponse:

--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -215,6 +215,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         self,
         slot: int,
         encoding: str = "json",
+        max_supported_transaction_version: int = None,
     ) -> types.RPCResponse:
         """Returns identity and transaction information about a confirmed block in the ledger.
 
@@ -222,6 +223,8 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
             slot: Slot, as u64 integer.
             encoding: (optional) Encoding for the returned Transaction, either "json", "jsonParsed",
                 "base58" (slow), or "base64". If parameter not provided, the default encoding is JSON.
+            max_supported_transaction_version: (optional) The max transaction version to return in
+                responses. If the requested transaction is a higher version, an error will be returned
 
         Example:
             >>> solana_client = Client("http://localhost:8899")
@@ -267,7 +270,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
                  'base64']}]},
              'id': 10}
         """  # noqa: E501 # pylint: disable=line-too-long
-        body = self._get_block_body(slot, encoding)
+        body = self._get_block_body(slot, encoding, max_supported_transaction_version)
         return self._provider.make_request(body)
 
     def get_recent_performance_samples(self, limit: Optional[int] = None) -> types.RPCResponse:

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -406,7 +406,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
             encoding: (optional) Encoding for the returned Transaction, either "json", "jsonParsed",
                 "base58" (slow), or "base64". If parameter not provided, the default encoding is JSON.
             commitment: Bank state to query. It can be either "finalized", "confirmed" or "processed".
-            max_supported_transaction_version: The max transaction version to return in responses.
+            max_supported_transaction_version: (optional) The max transaction version to return in responses.
                 If the requested transaction is a higher version, an error will be returned
 
         Example:

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -225,6 +225,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         self,
         slot: int,
         encoding: str = "json",
+        max_supported_transaction_version: int = None,
     ) -> types.RPCResponse:
         """Returns identity and transaction information about a confirmed block in the ledger.
 
@@ -232,6 +233,8 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
             slot: Slot, as u64 integer.
             encoding: (optional) Encoding for the returned Transaction, either "json", "jsonParsed",
                     "base58" (slow), or "base64". If parameter not provided, the default encoding is JSON.
+            max_supported_transaction_version: (optional) The max transaction version to return in
+                responses. If the requested transaction is a higher version, an error will be returned
 
         Example:
             >>> solana_client = AsyncClient("http://localhost:8899")
@@ -277,7 +280,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
                  'base64']}]},
              'id': 10}
         """  # noqa: E501 # pylint: disable=line-too-long
-        body = self._get_block_body(slot, encoding)
+        body = self._get_block_body(slot, encoding, max_supported_transaction_version)
         return await self._provider.make_request(body)
 
     async def get_recent_performance_samples(self, limit: Optional[int] = None) -> types.RPCResponse:

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -1,7 +1,8 @@
 """Async API client to interact with the Solana JSON RPC Endpoint."""  # pylint: disable=too-many-lines
 import asyncio
 from time import time
-from typing import Dict, List, Optional, Union, Sequence
+from typing import Dict, List, Optional, Sequence, Union
+
 from solders.signature import Signature
 
 from solana.blockhash import Blockhash, BlockhashCache
@@ -390,7 +391,11 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         return await self._provider.make_request(body)
 
     async def get_transaction(
-        self, tx_sig: Signature, encoding: str = "json", commitment: Optional[Commitment] = None
+        self,
+        tx_sig: Signature,
+        encoding: str = "json",
+        commitment: Optional[Commitment] = None,
+        max_supported_transaction_version: Optional[int] = None,
     ) -> types.RPCResponse:
         """Returns transaction details for a confirmed transaction.
 
@@ -401,6 +406,8 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
             encoding: (optional) Encoding for the returned Transaction, either "json", "jsonParsed",
                 "base58" (slow), or "base64". If parameter not provided, the default encoding is JSON.
             commitment: Bank state to query. It can be either "finalized", "confirmed" or "processed".
+            max_supported_transaction_version: The max transaction version to return in responses.
+                If the requested transaction is a higher version, an error will be returned
 
         Example:
             >>> solana_client = AsyncClient("http://localhost:8899")
@@ -425,7 +432,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
                'signatures': ['3PtGYH77LhhQqTXP4SmDVJ85hmDieWsgXCUbn14v7gYyVYPjZzygUQhTk3bSTYnfA48vCM1rmWY7zWL3j1EVKmEy']}},
              'id': 4}
         """  # noqa: E501 # pylint: disable=line-too-long
-        body = self._get_transaction_body(tx_sig, encoding, commitment)
+        body = self._get_transaction_body(tx_sig, encoding, commitment, max_supported_transaction_version)
         return await self._provider.make_request(body)
 
     async def get_epoch_info(self, commitment: Optional[Commitment] = None) -> types.RPCResponse:

--- a/src/solana/rpc/core.py
+++ b/src/solana/rpc/core.py
@@ -195,9 +195,11 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         return GetBlockTime(slot)
 
     @staticmethod
-    def _get_block_body(slot: int, encoding: str) -> GetBlock:
+    def _get_block_body(slot: int, encoding: str, max_supported_transaction_version: Optional[int]) -> GetBlock:
         encoding_to_use = _TX_ENCODING_TO_SOLDERS[encoding]
-        config = RpcBlockConfig(encoding=encoding_to_use)
+        config = RpcBlockConfig(
+            encoding=encoding_to_use, max_supported_transaction_version=max_supported_transaction_version
+        )
         return GetBlock(slot=slot, config=config)
 
     def _get_block_height_body(self, commitment: Optional[Commitment]) -> GetBlockHeight:


### PR DESCRIPTION
This pull request implements versioned transaction support for the `get_block` and `get_transaction` methods ( issue #295  ) by allowing users to pass `max_supported_transaction_version` when calling these functions, which are then used for the corresponding RPC configs from `solders`: `RpcBlockConfig ` and `RpcTransactionConfig` .

I've run the recommended [dev setup steps](https://github.com/michaelhly/solana-py#-development) including `make format` and `make lint`, which explains why there are some formatting changes included in the PR.

Happy to make changes based on any feedback!