### PR TITLE
Correctly filter by program_id in _get_token_accounts_convert

### DIFF
--- a/src/solana/rpc/core.py
+++ b/src/solana/rpc/core.py
@@ -364,7 +364,7 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         if maybe_mint is not None:
             filter_to_use = RpcTokenAccountsFilterMint(maybe_mint.to_solders())
         elif maybe_program_id is not None:
-            filter_to_use = RpcTokenAccountsFilterMint(maybe_program_id.to_solders())
+            filter_to_use = RpcTokenAccountsFilterProgramId(maybe_program_id.to_solders())
         else:
             raise ValueError("Please provide one of mint or program_id")
         config = RpcAccountInfoConfig(

--- a/src/solana/rpc/core.py
+++ b/src/solana/rpc/core.py
@@ -361,6 +361,7 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         )
         maybe_mint = opts.mint
         maybe_program_id = opts.program_id
+        filter_to_use: Union[RpcTokenAccountsFilterMint, RpcTokenAccountsFilterProgramId]
         if maybe_mint is not None:
             filter_to_use = RpcTokenAccountsFilterMint(maybe_mint.to_solders())
         elif maybe_program_id is not None:


### PR DESCRIPTION
Solves #301: if `program_id` is passed, the correct filter on program ID should be used.