### PR TITLE
Expose Exception Attributes on SolanaRpcException

### DIFF
--- a/src/solana/exceptions.py
+++ b/src/solana/exceptions.py
@@ -20,11 +20,16 @@ class SolanaExceptionBase(Exception):
         return f"{type(exc)} raised in {func} invokation"
 
 
-class SolanaRpcException(SolanaExceptionBase):
+class SolanaRpcException:
     """Class for Solana-py RPC exceptions."""
 
+    def __init__(self, exc: Exception, func: Callable[[Any], Any], *args: Any, **kwargs: Any) -> None:
+        """Init."""
+        self.error_msg = self._build_error_message(exc, func, *args, **kwargs)
+    
     @staticmethod
     def _build_error_message(
+        self, 
         exc: Exception,
         func: Callable[[Any], Any],  # noqa: ARG004
         *args: Any,


### PR DESCRIPTION
The current implementation of SolanaRpcException only takes in the Exception `exc` but does not expose it to the user. They cannot access its attributes and diagnose further when there are problems. 

Sending this as a draft pull request until I figure out how this works properly.

```
class SolanaRpcException(SolanaExceptionBase):
    """Class for Solana-py RPC exceptions."""

    @staticmethod
    def _build_error_message(
        exc: Exception,
        func: Callable[[Any], Any],  # noqa: ARG004
        *args: Any,
        **kwargs: Any,  # noqa: ARG004
    ) -> str:
        rpc_method = args[1].__class__.__name__
        return f'{type(exc)} raised in "{rpc_method}" endpoint request'
```