### PR TITLE
Increase confirmation timeout to 90 seconds

### DIFF
--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -1139,7 +1139,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
             sleep_seconds: The number of seconds to sleep when polling the signature status.
             last_valid_block_height: The block height by which the transaction would become invalid.
         """
-        timeout = time() + 30
+        timeout = time() + 90
         commitment_to_use = _COMMITMENT_TO_SOLDERS[commitment or self._commitment]
         commitment_rank = int(commitment_to_use)
         if last_valid_block_height:  # pylint: disable=no-else-return

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -1167,7 +1167,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
                 raise TransactionExpiredBlockheightExceededError(f"{tx_sig} has expired: block height exceeded")
             return resp
         else:
-            timeout = time() + 30
+            timeout = time() + 90
             while time() < timeout:
                 resp = await self.get_signature_statuses([tx_sig])
                 resp_value = resp.value[0]


### PR DESCRIPTION
#380 

Increase transaction confirmation timeout from 30 to 90.
Reference: https://docs.solana.com/developing/transaction_confirmation#how-does-transaction-expiration-work
