### PR TITLE
FIX simulate_transaction add parameters from new RPC API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ typing-extensions = ">=4.2.0"
 cachetools = "^4.2.2"
 types-cachetools = "^4.2.4"
 websockets = ">=9.0,<12.0"
-solders = "^0.19.0"
+solders = ">=0.18"
 
 [tool.poetry.dev-dependencies]
 black = "^22.3"

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -7,6 +7,7 @@ from solders.hash import Hash as Blockhash
 from solders.keypair import Keypair
 from solders.message import VersionedMessage
 from solders.pubkey import Pubkey
+from solders.rpc.config import RpcSimulateTransactionAccountsConfig
 from solders.rpc.responses import (
     GetAccountInfoMaybeJsonParsedResp,
     GetAccountInfoResp,
@@ -58,6 +59,7 @@ from solders.rpc.responses import (
     ValidatorExitResp,
 )
 from solders.signature import Signature
+from solders.transaction import Transaction as SoldersTransaction
 from solders.transaction import VersionedTransaction
 
 from solana.blockhash import BlockhashCache
@@ -620,7 +622,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
             encoding="jsonParsed",
             data_slice=None,
         )
-        return await self._provider.make_request(body, GetMultipleAccountsResp)
+        return await self._provider.make_request(body, GetMultipleAccountsMaybeJsonParsedResp)
 
     async def get_program_accounts(  # pylint: disable=too-many-arguments
         self,
@@ -1081,9 +1083,12 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
 
     async def simulate_transaction(
         self,
-        txn: Union[Transaction, VersionedTransaction],
+        txn: Union[SoldersTransaction, VersionedTransaction],
         sig_verify: bool = False,
+        replace_recent_blockhash: bool = False,
         commitment: Optional[Commitment] = None,
+        accounts: Optional[RpcSimulateTransactionAccountsConfig] = None,
+        min_context_slot: Optional[int] = None,
     ) -> SimulateTransactionResp:
         """Simulate sending a transaction.
 
@@ -1091,7 +1096,12 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
             txn: A Transaction object, a transaction in wire format, or a transaction as base-64 encoded string
                 The transaction must have a valid blockhash, but is not required to be signed.
             sig_verify: If true the transaction signatures will be verified (default: false).
+            replace_recent_blockhash: if `true` the transaction recent blockhash will be replaced with the
+                most recent blockhash (default: false, conflicts with `sigVerify`).
             commitment: Bank state to query. It can be either "finalized", "confirmed" or "processed".
+            accounts: List of accounts to be returned.
+                RpcSimulateTransactionAccountsConfig object containing `addresses` and `encoding` fields.
+            min_context_slot: the minimum slot that the request can be evaluated at
 
         Example:
             >>> solana_client = AsyncClient("http://localhost:8899")
@@ -1106,7 +1116,14 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
             >>> (await solana_client.simulate_transaction(tx)).value.logs  # doctest: +SKIP
             ['BPF program 83astBRguLMdt2h5U1Tpdq5tjFoJ6noeGwaY3mDLVcri success']
         """
-        body = self._simulate_transaction_body(txn, sig_verify, commitment)
+        body = self._simulate_transaction_body(
+            txn,
+            sig_verify,
+            replace_recent_blockhash,
+            commitment,
+            accounts,
+            min_context_slot,
+        )
         return await self._provider.make_request(body, SimulateTransactionResp)
 
     async def validator_exit(self) -> ValidatorExitResp:


### PR DESCRIPTION
Incorporate new parameters from RPC API (https://docs.solana.com/api/http#simulatetransaction): replace_recent_blockhash, min_context_slot, and accounts.