### PR TITLE
Add Compute Budget Instructions

### DIFF
--- a/src/spl/compute_budget/__init__.py
+++ b/src/spl/compute_budget/__init__.py
@@ -1,0 +1,1 @@
+"""Client code for interacting with the compute budget program."""

--- a/src/spl/compute_budget/_layouts.py
+++ b/src/spl/compute_budget/_layouts.py
@@ -1,0 +1,42 @@
+"""Token instruction layouts."""
+from enum import IntEnum
+
+from construct import Bytes, Int8ul, Int32ul, Int64ul, Switch
+from construct import Struct as cStruct
+
+PUBLIC_KEY_LAYOUT = Bytes(32)
+
+
+class InstructionType(IntEnum):
+    """Token instruction types."""
+
+    REQUEST_UNITS = 0
+    REQUEST_HEAP_FRAME = 1
+    SET_COMPUTE_UNIT_LIMIT = 2
+    SET_COMPUTE_UNIT_PRICE = 3
+
+
+_REQUEST_UNITS_LAYOUT = cStruct(
+    "units" / Int32ul,
+    "additional_fee" / Int32ul,
+)
+
+_REQUEST_HEAP_FRAME_LAYOUT = cStruct("bytes" / Int32ul)
+
+_SET_COMPUTE_UNIT_LIMIT_LAYOUT = cStruct("units" / Int32ul)
+
+_SET_COMPUTE_UNIT_PRICE_LAYOUT = cStruct("micro_lamports" / Int64ul)
+
+INSTRUCTIONS_LAYOUT = cStruct(
+    "instruction_type" / Int8ul,
+    "args"
+    / Switch(
+        lambda this: this.instruction_type,
+        {
+            InstructionType.REQUEST_UNITS: _REQUEST_UNITS_LAYOUT,
+            InstructionType.REQUEST_HEAP_FRAME: _REQUEST_HEAP_FRAME_LAYOUT,
+            InstructionType.SET_COMPUTE_UNIT_LIMIT: _SET_COMPUTE_UNIT_LIMIT_LAYOUT,
+            InstructionType.SET_COMPUTE_UNIT_PRICE: _SET_COMPUTE_UNIT_PRICE_LAYOUT,
+        },
+    ),
+)

--- a/src/spl/compute_budget/constants.py
+++ b/src/spl/compute_budget/constants.py
@@ -1,0 +1,6 @@
+"""Compute Budget token constants."""
+
+from solders.pubkey import Pubkey
+
+COMPUTE_BUDGET_PROGRAM_ID: Pubkey = Pubkey.from_string("ComputeBudget111111111111111111111111111111")
+"""Public key that identifies the Compute Budget program."""

--- a/src/spl/compute_budget/instructions.py
+++ b/src/spl/compute_budget/instructions.py
@@ -1,0 +1,264 @@
+"""Instructions for the Compute Budget program."""
+from typing import NamedTuple, Any
+
+from solders.instruction import Instruction
+from typing_extensions import deprecated
+
+from solana.utils.validate import validate_instruction_keys, validate_instruction_type
+from spl.compute_budget.constants import COMPUTE_BUDGET_PROGRAM_ID
+from spl.compute_budget._layouts import (
+    InstructionType,
+    INSTRUCTIONS_LAYOUT,
+)
+
+"""
+
+class InstructionType(IntEnum):
+    REQUEST_UNITS = 0
+    REQUEST_HEAP_FRAME = 1
+    SET_COMPUTE_UNIT_LIMIT = 2
+    SET_COMPUTE_UNIT_PRICE = 3
+
+_REQUEST_UNITS_LAYOUT = cStruct(
+    "instruction" / Int8ul,
+    "units" / Int32ul,
+    "additional_fee" / Int32ul,
+)
+
+_REQUEST_HEAP_FRAME_LAYOUT = cStruct("instruction" / Int8ul, "bytes" / Int32ul)
+
+_SET_COMPUTE_UNIT_LIMIT_LAYOUT = cStruct("instruction" / Int8ul, "units" / Int32ul)
+
+_SET_COMPUTE_UNIT_PRICE_LAYOUT = cStruct("instruction" / Int8ul, "micro_lamports" / Int64ul)
+
+INSTRUCTIONS_LAYOUT = cStruct(
+    "instruction_type" / Int8ul,
+    "args"
+    / Switch(
+        lambda this: this.instruction_type,
+        {
+            InstructionType.REQUEST_UNITS: _REQUEST_UNITS_LAYOUT,
+            InstructionType.REQUEST_HEAP_FRAME: _REQUEST_HEAP_FRAME_LAYOUT,
+            InstructionType.SET_COMPUTE_UNIT_LIMIT: _SET_COMPUTE_UNIT_LIMIT_LAYOUT,
+            InstructionType.SET_COMPUTE_UNIT_PRICE: _SET_COMPUTE_UNIT_PRICE_LAYOUT,
+        },
+    ),
+)
+
+"""
+
+
+@deprecated("Use SetComputeUnitLimitParams instead.")
+class RequestUnitsParams(NamedTuple):
+    """Request units transaction params."""
+
+    units: int
+    """Units."""
+    additional_fee: int
+    """Additional fee."""
+
+
+class RequestHeapFrameParams(NamedTuple):
+    """Request heap frame transaction params."""
+
+    bytes: int  # noqa: A003
+    """The amount of heap frame bytes to additionally request. 32K = 8 Compute Units."""
+
+
+class SetComputeUnitLimitParams(NamedTuple):
+    """Set compute unit limit transaction params."""
+
+    units: int
+    """Maximum compute units."""
+
+
+class SetComputeUnitPriceParams(NamedTuple):
+    """Set compute unit price transaction params."""
+
+    micro_lamports: int
+    """Priority fee of one compute unit in micro Lamports. 1 micro Lamport = 0.000001 Lamport = 10^-15 SOL."""
+
+
+def __parse_and_validate_instruction(
+    instruction: Instruction,
+    expected_keys: int,
+    expected_type: InstructionType,
+) -> Any:  # Returns a Construct container.
+    validate_instruction_keys(instruction, expected_keys)
+    data = INSTRUCTIONS_LAYOUT.parse(instruction.data)
+    validate_instruction_type(data, expected_type)
+    return data
+
+
+@deprecated("Use SetComputeUnitLimit instruction instead.")
+def decode_request_units(instruction: Instruction) -> RequestUnitsParams:
+    """Decode a request_units instruction and retrieve the instruction params.
+
+    Args:
+        instruction: The instruction to decode.
+
+    Returns:
+        The decoded instruction.
+    """
+    parsed_data = __parse_and_validate_instruction(instruction, 0, InstructionType.REQUEST_UNITS)
+    return RequestUnitsParams(
+        units=parsed_data.args.units,
+        additional_fee=parsed_data.args.additional_fee,
+    )
+
+
+def decode_request_heap_frame(instruction: Instruction) -> RequestHeapFrameParams:
+    """Decode a request_heap_frame instruction and retrieve the instruction params.
+
+    Args:
+        instruction: The instruction to decode.
+
+    Returns:
+        The decoded instruction.
+    """
+    parsed_data = __parse_and_validate_instruction(instruction, 0, InstructionType.REQUEST_HEAP_FRAME)
+    return RequestHeapFrameParams(
+        bytes=parsed_data.args.bytes,
+    )
+
+
+def decode_set_compute_unit_limit(instruction: Instruction) -> SetComputeUnitLimitParams:
+    """Decode a set_compute_unit_limit instruction and retrieve the instruction params.
+
+    Args:
+        instruction: The instruction to decode.
+
+    Returns:
+        The decoded instruction.
+    """
+    parsed_data = __parse_and_validate_instruction(instruction, 0, InstructionType.SET_COMPUTE_UNIT_LIMIT)
+    return SetComputeUnitLimitParams(
+        units=parsed_data.args.units,
+    )
+
+
+def decode_set_compute_unit_price(instruction: Instruction) -> SetComputeUnitPriceParams:
+    """Decode a set_compute_unit_price instruction and retrieve the instruction params.
+
+    Args:
+        instruction: The instruction to decode.
+
+    Returns:
+        The decoded instruction.
+    """
+    parsed_data = __parse_and_validate_instruction(instruction, 0, InstructionType.SET_COMPUTE_UNIT_PRICE)
+    return SetComputeUnitPriceParams(
+        micro_lamports=parsed_data.args.micro_lamports,
+    )
+
+
+@deprecated("Use set_compute_unit_limit instead.")
+def request_units(params: RequestUnitsParams) -> Instruction:
+    """Creates a transaction instruction that requests units.
+
+    Example:
+        >>> params = RequestUnitsParams(units=150_000, additional_fee=0)
+        >>> type(request_units(params))
+        <class 'solders.instruction.Instruction'>
+
+    Returns:
+        The instruction to request units.
+    """
+    data = INSTRUCTIONS_LAYOUT.build(
+        {
+            "instruction_type": InstructionType.REQUEST_UNITS,
+            "args": {
+                "units": params.units,
+                "additional_fee": params.additional_fee,
+            },
+        }
+    )
+    return Instruction(
+        accounts=[],
+        program_id=COMPUTE_BUDGET_PROGRAM_ID,
+        data=data,
+    )
+
+
+def request_heap_frame(params: RequestHeapFrameParams) -> Instruction:
+    """Creates a transaction instruction that requests heap frame.
+
+    Example:
+        >>> params = RequestHeapFrameParams(bytes=32_000 * 100) # 100 * 32K = 800 Compute Units
+        >>> type(request_heap_frame(params))
+        <class 'solders.instruction.Instruction'>
+
+    Returns:
+        The instruction to request heap frame.
+    """
+    data = INSTRUCTIONS_LAYOUT.build(
+        {
+            "instruction_type": InstructionType.REQUEST_HEAP_FRAME,
+            "args": {
+                "bytes": params.bytes,
+            },
+        }
+    )
+    return Instruction(
+        accounts=[],
+        program_id=COMPUTE_BUDGET_PROGRAM_ID,
+        data=data,
+    )
+
+
+def set_compute_unit_limit(params: SetComputeUnitLimitParams) -> Instruction:
+    """Creates a transaction instruction that sets the compute unit limit.
+
+    By default, the compute budget is the product of 200,000 Compute Units (CU) * number of instructions,
+    with a max of 1.4M CU.
+
+    Example:
+        >>> params = SetComputeUnitLimitParams(units=1_000_000)
+        >>> type(set_compute_unit_limit(params))
+        <class 'solders.instruction.Instruction'>
+
+    Returns:
+        The instruction to set the compute unit limit.
+    """
+    data = INSTRUCTIONS_LAYOUT.build(
+        {
+            "instruction_type": InstructionType.SET_COMPUTE_UNIT_LIMIT,
+            "args": {
+                "units": params.units,
+            },
+        }
+    )
+    return Instruction(
+        accounts=[],
+        program_id=COMPUTE_BUDGET_PROGRAM_ID,
+        data=data,
+    )
+
+
+def set_compute_unit_price(params: SetComputeUnitPriceParams) -> Instruction:
+    """Creates a transaction instruction that sets the compute unit price.
+
+    For example: 1000 micro Lamports = 10^-12 SOL, so for an instruction that uses 150_000 compute units,
+    the additional priority fee would be 150_000 * 1000 = 150_000_000 micro Lamports = 150 Lamports = 150 * 10^-9 SOL.
+
+    Example:
+        >>> params = SetComputeUnitPriceParams(micro_lamports=1_000)
+        >>> type(set_compute_unit_price(params))
+        <class 'solders.instruction.Instruction'>
+
+    Returns:
+        The instruction to set the compute unit price.
+    """
+    data = INSTRUCTIONS_LAYOUT.build(
+        {
+            "instruction_type": InstructionType.SET_COMPUTE_UNIT_PRICE,
+            "args": {
+                "micro_lamports": params.micro_lamports,
+            },
+        }
+    )
+    return Instruction(
+        accounts=[],
+        program_id=COMPUTE_BUDGET_PROGRAM_ID,
+        data=data,
+    )

--- a/tests/integration/test_compute_budget.py
+++ b/tests/integration/test_compute_budget.py
@@ -1,0 +1,100 @@
+"""Tests for the Memo program."""
+import pytest
+from solders.keypair import Keypair
+from solders.transaction_status import ParsedInstruction
+from spl.compute_budget.constants import COMPUTE_BUDGET_PROGRAM_ID
+from spl.compute_budget.instructions import (
+    RequestHeapFrameParams,
+    SetComputeUnitLimitParams,
+    SetComputeUnitPriceParams,
+    request_heap_frame,
+    set_compute_unit_limit,
+    set_compute_unit_price,
+)
+from solana.rpc.api import Client
+from solana.rpc.commitment import Finalized
+from solana.transaction import Transaction
+
+from ..utils import AIRDROP_AMOUNT, assert_valid_response
+
+
+@pytest.mark.integration
+def test_request_heap_frame(stubbed_sender: Keypair, test_http_client: Client):
+    """Test sending a memo instruction to localnet."""
+    airdrop_resp = test_http_client.request_airdrop(stubbed_sender.pubkey(), AIRDROP_AMOUNT)
+    assert_valid_response(airdrop_resp)
+    test_http_client.confirm_transaction(airdrop_resp.value)
+    # Create tx to request heap frame for stubbed sender
+    heap_frame_params = RequestHeapFrameParams(bytes=32_000 * 1024)
+    tx = Transaction().add(request_heap_frame(heap_frame_params))
+    resp = test_http_client.send_transaction(tx, stubbed_sender)
+    assert_valid_response(resp)
+    txn_id = resp.value
+    # Txn needs to be finalized in order to parse the logs.
+    test_http_client.confirm_transaction(txn_id, commitment=Finalized)
+    resp2_val = test_http_client.get_transaction(txn_id, commitment=Finalized, encoding="jsonParsed").value
+    assert resp2_val is not None
+    resp2_transaction = resp2_val.transaction
+    meta = resp2_transaction.meta
+    assert meta is not None
+    messages = meta.log_messages
+    assert messages is not None
+    ixn = resp2_transaction.transaction.message.instructions[0]
+    assert isinstance(ixn, ParsedInstruction)
+    print(ixn.parsed)
+    assert ixn.program_id == COMPUTE_BUDGET_PROGRAM_ID
+
+
+@pytest.mark.integration
+def test_set_compute_unit_limit(stubbed_sender: Keypair, test_http_client: Client):
+    """Test sending a memo instruction to localnet."""
+    airdrop_resp = test_http_client.request_airdrop(stubbed_sender.pubkey(), AIRDROP_AMOUNT)
+    assert_valid_response(airdrop_resp)
+    test_http_client.confirm_transaction(airdrop_resp.value)
+    # Create tx to set compute unit limit for stubbed sender
+    compute_unit_limit_params = SetComputeUnitLimitParams(units=150_000)
+    tx = Transaction().add(set_compute_unit_limit(compute_unit_limit_params))
+    resp = test_http_client.send_transaction(tx, stubbed_sender)
+    assert_valid_response(resp)
+    txn_id = resp.value
+    # Txn needs to be finalized in order to parse the logs.
+    test_http_client.confirm_transaction(txn_id, commitment=Finalized)
+    resp2_val = test_http_client.get_transaction(txn_id, commitment=Finalized, encoding="jsonParsed").value
+    assert resp2_val is not None
+    resp2_transaction = resp2_val.transaction
+    meta = resp2_transaction.meta
+    assert meta is not None
+    messages = meta.log_messages
+    assert messages is not None
+    ixn = resp2_transaction.transaction.message.instructions[0]
+    assert isinstance(ixn, ParsedInstruction)
+    print(ixn.parsed)
+    assert ixn.program_id == COMPUTE_BUDGET_PROGRAM_ID
+
+
+@pytest.mark.integration
+def test_set_compute_unit_price(stubbed_sender: Keypair, test_http_client: Client):
+    """Test sending a memo instruction to localnet."""
+    airdrop_resp = test_http_client.request_airdrop(stubbed_sender.pubkey(), AIRDROP_AMOUNT)
+    assert_valid_response(airdrop_resp)
+    test_http_client.confirm_transaction(airdrop_resp.value)
+    # Create tx to set compute unit price for stubbed sender
+    compute_unit_price_params = SetComputeUnitPriceParams(micro_lamports=1500)
+    tx = Transaction().add(set_compute_unit_price(compute_unit_price_params))
+    resp = test_http_client.send_transaction(tx, stubbed_sender)
+    assert_valid_response(resp)
+    txn_id = resp.value
+    # Txn needs to be finalized in order to parse the logs.
+    test_http_client.confirm_transaction(txn_id, commitment=Finalized)
+    resp2_val = test_http_client.get_transaction(txn_id, commitment=Finalized, encoding="jsonParsed").value
+    assert resp2_val is not None
+    resp2_transaction = resp2_val.transaction
+    meta = resp2_transaction.meta
+    assert meta is not None
+    messages = meta.log_messages
+    assert messages is not None
+    ixn = resp2_transaction.transaction.message.instructions[0]
+    assert isinstance(ixn, ParsedInstruction)
+    print(ixn.parsed)
+    assert ixn.program_id == COMPUTE_BUDGET_PROGRAM_ID
+

--- a/tests/unit/test_compute_budget_program.py
+++ b/tests/unit/test_compute_budget_program.py
@@ -1,0 +1,38 @@
+from spl.compute_budget.instructions import (
+    RequestUnitsParams,
+    RequestHeapFrameParams,
+    SetComputeUnitLimitParams,
+    SetComputeUnitPriceParams,
+    decode_request_units,
+    decode_request_heap_frame,
+    decode_set_compute_unit_limit,
+    decode_set_compute_unit_price,
+    request_units,
+    request_heap_frame,
+    set_compute_unit_limit,
+    set_compute_unit_price,
+)
+
+
+def test_request_units():
+    """Test creating a request_units instruction."""
+    params = RequestUnitsParams(units=150_000, additional_fee=0)
+    assert decode_request_units(request_units(params)) == params
+
+
+def test_request_heap_frame():
+    """Test creating a request_heap_frame instruction."""
+    params = RequestHeapFrameParams(bytes=32_000 * 1024)
+    assert decode_request_heap_frame(request_heap_frame(params)) == params
+
+
+def test_set_compute_unit_limit():
+    """Test creating a set_compute_unit_limit instruction."""
+    params = SetComputeUnitLimitParams(units=150_000)
+    assert decode_set_compute_unit_limit(set_compute_unit_limit(params)) == params
+
+
+def test_set_compute_unit_price():
+    """Test creating a set_compute_unit_price instruction."""
+    params = SetComputeUnitPriceParams(micro_lamports=1500)
+    assert decode_set_compute_unit_price(set_compute_unit_price(params)) == params


### PR DESCRIPTION
GM!

Due to the dire need for priority fees to have any chance at landing transactions, I decided to implement the Compute Budget program's instructions for solder.

I added them under the `spl` module, even though that is not technically correct, but I assume that is where people would be looking for those instructions.

For some reason regarding docker, I couldn't run the integration tests directly on my machne. Maybe the CI/CD of this repo can catch the errors I might have made.

I based this implementation and its layouts on the Typescript implementation of [solana-labs/solana-web3.js](https://github.com/solana-labs/solana-web3.js/blob/71d404f/packages/library-legacy/src/programs/compute-budget.ts#L256).

Suggestions welcome!