### PR TITLE
Fix: added getInflationReward method

### DIFF
--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -26,6 +26,7 @@ from solders.rpc.responses import (
     GetIdentityResp,
     GetInflationGovernorResp,
     GetInflationRateResp,
+    GetInflationRewardResp,
     GetLargestAccountsResp,
     GetLatestBlockhashResp,
     GetLeaderScheduleResp,
@@ -475,6 +476,24 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
             1
         """
         return self._provider.make_request(self._get_inflation_rate, GetInflationRateResp)
+
+    def get_inflation_reward(
+        self, pubkeys: List[Pubkey], epoch: Optional[int] = None, commitment: Optional[Commitment] = None
+    ) -> GetInflationRewardResp:
+        """Returns the inflation / staking reward for a list of addresses for an epoch.
+
+        Args:
+            pubkeys: An array of addresses to query, as base-58 encoded strings
+            epoch: (optional) An epoch for which the reward occurs. If omitted, the previous epoch will be used
+            commitment: Bank state to query. It can be either "finalized" or "confirmed".
+
+        Example:
+            >>> solana_client = Client("http://localhost:8899")
+            >>> solana_client.get_inflation_reward().value.amount # doctest: +SKIP
+            2500
+        """
+        body = self._get_inflation_reward_body(pubkeys, epoch, commitment)
+        return self._provider.make_request(body, GetInflationRewardResp)
 
     def get_largest_accounts(
         self, filter_opt: Optional[str] = None, commitment: Optional[Commitment] = None

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -25,6 +25,7 @@ from solders.rpc.responses import (
     GetIdentityResp,
     GetInflationGovernorResp,
     GetInflationRateResp,
+    GetInflationRewardResp,
     GetLargestAccountsResp,
     GetLatestBlockhashResp,
     GetLeaderScheduleResp,
@@ -487,6 +488,24 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
             1
         """
         return await self._provider.make_request(self._get_inflation_rate, GetInflationRateResp)
+
+    async def get_inflation_reward(
+        self, pubkeys: List[Pubkey], epoch: Optional[int] = None, commitment: Optional[Commitment] = None
+    ) -> GetInflationRewardResp:
+        """Returns the inflation / staking reward for a list of addresses for an epoch.
+
+        Args:
+            pubkeys: An array of addresses to query, as base-58 encoded strings
+            epoch: (optional) An epoch for which the reward occurs. If omitted, the previous epoch will be used
+            commitment: Bank state to query. It can be either "finalized" or "confirmed".
+
+        Example:
+            >>> solana_client = AsyncClient("http://localhost:8899")
+            >>> (await solana_client.get_inflation_reward()).value.amount # doctest: +SKIP
+            2500
+        """
+        body = self._get_inflation_reward_body(pubkeys, epoch, commitment)
+        return await self._provider.make_request(body, GetInflationRewardResp)
 
     async def get_largest_accounts(
         self, filter_opt: Optional[str] = None, commitment: Optional[Commitment] = None

--- a/src/solana/rpc/core.py
+++ b/src/solana/rpc/core.py
@@ -45,6 +45,7 @@ from solders.rpc.requests import (
     GetIdentity,
     GetInflationGovernor,
     GetInflationRate,
+    GetInflationReward,
     GetLargestAccounts,
     GetLatestBlockhash,
     GetLeaderSchedule,
@@ -346,6 +347,15 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
     ) -> GetStakeActivation:
         commitment_to_use = _COMMITMENT_TO_SOLDERS[commitment or self._commitment]
         return GetStakeActivation(pubkey, RpcEpochConfig(epoch, commitment_to_use))
+
+    def _get_inflation_reward_body(
+        self,
+        pubkeys: List[Pubkey],
+        epoch: Optional[int],
+        commitment: Optional[Commitment],
+    ) -> GetInflationReward:
+        commitment_to_use = _COMMITMENT_TO_SOLDERS[commitment or self._commitment]
+        return GetInflationReward(pubkeys, RpcEpochConfig(epoch, commitment_to_use))
 
     def _get_supply_body(self, commitment: Optional[Commitment]) -> GetSupply:
         commitment_to_use = _COMMITMENT_TO_SOLDERS[commitment or self._commitment]

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -431,6 +431,8 @@ async def test_get_inflation_rate(test_http_client_async):
     assert_valid_response(resp)
 
 
+# XXX: Block not available for slot on local cluster
+@pytest.mark.skip
 @pytest.mark.integration
 async def test_get_inflation_reward(stubbed_sender, test_http_client_async):
     """Test get inflation reward."""

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -432,6 +432,13 @@ async def test_get_inflation_rate(test_http_client_async):
 
 
 @pytest.mark.integration
+async def test_get_inflation_reward(stubbed_sender, test_http_client_async):
+    """Test get inflation reward."""
+    resp = await test_http_client_async.get_inflation_reward([stubbed_sender.pubkey()], commitment=Confirmed)
+    assert_valid_response(resp)
+
+
+@pytest.mark.integration
 async def test_get_largest_accounts(test_http_client_async):
     """Test get largest accounts."""
     resp = await test_http_client_async.get_largest_accounts()

--- a/tests/integration/test_http_client.py
+++ b/tests/integration/test_http_client.py
@@ -415,6 +415,8 @@ def test_get_inflation_rate(test_http_client: Client):
     assert_valid_response(resp)
 
 
+# XXX: Block not available for slot on local cluster
+@pytest.mark.skip
 @pytest.mark.integration
 def test_get_inflation_reward(stubbed_sender, test_http_client: Client):
     """Test get inflation reward."""

--- a/tests/integration/test_http_client.py
+++ b/tests/integration/test_http_client.py
@@ -416,6 +416,13 @@ def test_get_inflation_rate(test_http_client: Client):
 
 
 @pytest.mark.integration
+def test_get_inflation_reward(stubbed_sender, test_http_client: Client):
+    """Test get inflation reward."""
+    resp = test_http_client.get_inflation_reward([stubbed_sender.pubkey()], commitment=Confirmed)
+    assert_valid_response(resp)
+
+
+@pytest.mark.integration
 def test_get_largest_accounts(test_http_client: Client):
     """Test get largest accounts."""
     resp = test_http_client.get_largest_accounts()


### PR DESCRIPTION
Fixes https://github.com/michaelhly/solana-py/issues/316

Updated this PR https://github.com/michaelhly/solana-py/pull/317

Added tests, however, got the same problem as in the above PR. It seems like a problem in RPC itself because testing with **curl** yields the same results:
```
raw = '{"jsonrpc":"2.0","error":{"code":-32004,"message":"Block not available for slot 8192"},"id":0}\n'
parser = <class 'solders.rpc.responses.GetInflationRewardResp'>
```
