### PR TITLE
Add NATIVE_DECIMALS & LAMPORTS_PER_SOL constants

### DIFF
--- a/src/solana/constants.py
+++ b/src/solana/constants.py
@@ -1,0 +1,7 @@
+"""Solana constants"""
+
+NATIVE_DECIMALS: int = 9
+"""Standard number of decimals for SOL and wrapped SOL."""
+
+LAMPORTS_PER_SOL: int = 1_000_000_000
+"""Number of lamports per SOL, where 1 SOL equals 1 billion lamports."""

--- a/src/spl/token/constants.py
+++ b/src/spl/token/constants.py
@@ -11,6 +11,12 @@ ACCOUNT_LEN: int = 165
 MULTISIG_LEN: int = 355
 """Data length of a multisig token account."""
 
+DEFAULT_DECIMALS: int = 9
+"""Standard number of decimals for SOL and wrapped SOL."""
+
+LAMPORTS_PER_SOL: int = 1_000_000_000
+"""Number of lamports per SOL, where 1 SOL equals 1 billion lamports."""
+
 ASSOCIATED_TOKEN_PROGRAM_ID = Pubkey.from_string("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL")
 """Program ID for the associated token account program."""
 

--- a/src/spl/token/constants.py
+++ b/src/spl/token/constants.py
@@ -11,12 +11,6 @@ ACCOUNT_LEN: int = 165
 MULTISIG_LEN: int = 355
 """Data length of a multisig token account."""
 
-DEFAULT_DECIMALS: int = 9
-"""Standard number of decimals for SOL and wrapped SOL."""
-
-LAMPORTS_PER_SOL: int = 1_000_000_000
-"""Number of lamports per SOL, where 1 SOL equals 1 billion lamports."""
-
 ASSOCIATED_TOKEN_PROGRAM_ID = Pubkey.from_string("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL")
 """Program ID for the associated token account program."""
 


### PR DESCRIPTION
Hello @michaelhly!

I've added the LAMPORTS_PER_SOL and DEFAULT_DECIMALS constants to the library. 

Given the popularity of this library and frequent reuse of these in scripts, it seemed beneficial to centralize them to the library to reduce redundancy and potential errors. This change can help make many codebases cleaner and more maintainable. 

Thank you for considering this addition!