### PR TITLE
Enhance Type Hinting for WebSocket Connection

### DIFF
--- a/src/solana/rpc/websocket_api.py
+++ b/src/solana/rpc/websocket_api.py
@@ -406,7 +406,7 @@ class SolanaWsClientProtocol(WebSocketClientProtocol):
         return cast(List[Union[Notification, SubscriptionResult]], parsed)
 
 
-class connect(ws_connect):  # pylint: disable=invalid-name
+class connect(ws_connect):  # pylint: disable=invalid-name,too-few-public-methods
     """Solana RPC websocket connector."""
 
     def __init__(self, uri: str = "ws://localhost:8900", **kwargs: Any) -> None:

--- a/src/solana/rpc/websocket_api.py
+++ b/src/solana/rpc/websocket_api.py
@@ -406,7 +406,7 @@ class SolanaWsClientProtocol(WebSocketClientProtocol):
         return cast(List[Union[Notification, SubscriptionResult]], parsed)
 
 
-class connect(ws_connect):  # pylint: disable=invalid-name,too-few-public-methods
+class connect(ws_connect):  # pylint: disable=invalid-name
     """Solana RPC websocket connector."""
 
     def __init__(self, uri: str = "ws://localhost:8900", **kwargs: Any) -> None:
@@ -416,4 +416,11 @@ class connect(ws_connect):  # pylint: disable=invalid-name,too-few-public-method
             uri: The websocket endpoint.
             **kwargs: Keyword arguments for ``websockets.legacy.client.connect``
         """
-        super().__init__(uri, **kwargs, create_protocol=SolanaWsClientProtocol)
+        # Ensure that create_protocol explicitly creates a SolanaWsClientProtocol
+        kwargs.setdefault("create_protocol", SolanaWsClientProtocol)
+        super().__init__(uri, **kwargs)
+
+    async def __aenter__(self) -> SolanaWsClientProtocol:
+        """Overrides to specify the type of protocol explicitly."""
+        protocol = await super().__aenter__()
+        return cast(SolanaWsClientProtocol, protocol)


### PR DESCRIPTION
This PR enhances the type hinting of the `connect` method in `websocket_api.py` to return `SolanaWsClientProtocol` instead of the general `WebSocketClientProtocol`. This change helps improve IDE support and developer experience by enabling better autocompletion and type checking for specific methods like `logs_subscribe` that are available on `SolanaWsClientProtocol`.

This addresses the issue #434 where there was a lack of autocompletion support in IDEs due to incorrect type hinting.