### PR TITLE
Add deprecated warning to get_stake_activation method

### DIFF
--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -780,6 +780,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
             >>> solana_client.get_stake_activation().value.active # doctest: +SKIP
             124429280
         """
+        warn("get_stake_activation is deprecated. Use get_account_info instead.", DeprecationWarning)
         body = self._get_stake_activation_body(pubkey, epoch, commitment)
         return self._provider.make_request(body, GetStakeActivationResp)
 

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -791,6 +791,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
             >>> (await solana_client.get_stake_activation()).value.active # doctest: +SKIP
             124429280
         """
+        warn("get_stake_activation is deprecated. Use get_account_info instead.", DeprecationWarning)
         body = self._get_stake_activation_body(pubkey, epoch, commitment)
         return await self._provider.make_request(body, GetStakeActivationResp)
 


### PR DESCRIPTION
Adding deprecated warning to get_stake_activation method for both sync and async client. Fixes #451 