### PR TITLE
Use all signers when constructing a SPL transfer transaction

### DIFF
--- a/src/spl/token/core.py
+++ b/src/spl/token/core.py
@@ -281,7 +281,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
             )
         ]
         msg = Message.new_with_blockhash(ixs, self.payer.pubkey(), recent_blockhash)
-        txn = Transaction([self.payer], msg, recent_blockhash)
+        txn = Transaction([self.payer, *signers], msg, recent_blockhash)
         return txn, opts
 
     def _set_authority_args(
@@ -666,7 +666,7 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
             )
         ]
         msg = Message.new_with_blockhash(ixs, self.payer.pubkey(), recent_blockhash)
-        txn = Transaction([self.payer], msg, recent_blockhash)
+        txn = Transaction([self.payer, *signers], msg, recent_blockhash)
         return txn, opts
 
     def _mint_to_checked_args(


### PR DESCRIPTION
When the payer is not the owner, it will raise an exception.

```
thread '<unnamed>' panicked at /root/.cargo/registry/src/index.crates.io-6f17d2aaaaa001f/solana-sdk-1.18.1/src/transaction/mod.rs:710:13:
Transaction::sign failed with error NotEnoughSigners
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Traceback (most recent call last):
  File "test-transfer.py", line 30, in <module>
    sig=token_client.transfer_checked(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python-3.12.7/lib/python3.12/site-packages/spl/token/client.py", line 653, in transfer_checked
    txn, opts = self._transfer_checked_args(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python-3.12.7/lib/python3.12/site-packages/spl/token/core.py", line 670, in _transfer_checked_args
    txn = Transaction([self.payer], msg, recent_blockhash)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pyo3_runtime.PanicException: Transaction::sign failed with error NotEnoughSigners
```