### PR TITLE
Fix incorrect program ID in create_associated_token_account for TOKEN_2022_PROGRAM_ID

### DIFF
--- a/src/spl/token/async_client.py
+++ b/src/spl/token/async_client.py
@@ -283,7 +283,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
             (await self._conn.get_latest_blockhash()).value.blockhash if recent_blockhash is None else recent_blockhash
         )
         public_key, txn, payer, opts = self._create_associated_token_account_args(
-            owner, skip_confirmation, self._conn.commitment, recent_blockhash_to_use
+            owner, skip_confirmation, self._conn.commitment, recent_blockhash_to_use, token_program_id = self.program_id
         )
         await self._conn.send_transaction(txn, opts=opts)
         return public_key

--- a/src/spl/token/async_client.py
+++ b/src/spl/token/async_client.py
@@ -283,7 +283,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
             (await self._conn.get_latest_blockhash()).value.blockhash if recent_blockhash is None else recent_blockhash
         )
         public_key, txn, payer, opts = self._create_associated_token_account_args(
-            owner, skip_confirmation, self._conn.commitment, recent_blockhash_to_use, token_program_id = self.program_id
+            owner, skip_confirmation, self._conn.commitment, recent_blockhash_to_use, token_program_id=self.program_id
         )
         await self._conn.send_transaction(txn, opts=opts)
         return public_key

--- a/src/spl/token/client.py
+++ b/src/spl/token/client.py
@@ -282,7 +282,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
             self._conn.get_latest_blockhash().value.blockhash if recent_blockhash is None else recent_blockhash
         )
         public_key, txn, payer, opts = self._create_associated_token_account_args(
-            owner, skip_confirmation, self._conn.commitment, recent_blockhash_to_use
+            owner, skip_confirmation, self._conn.commitment, recent_blockhash_to_use, token_program_id=self.program_id
         )
         self._conn.send_transaction(txn, opts=opts)
         return public_key

--- a/src/spl/token/core.py
+++ b/src/spl/token/core.py
@@ -19,7 +19,7 @@ from solders.hash import Hash as Blockhash
 from solders.message import Message
 from solders.transaction import Transaction
 from spl.token._layouts import ACCOUNT_LAYOUT, MINT_LAYOUT, MULTISIG_LAYOUT  # type: ignore
-from spl.token.constants import WRAPPED_SOL_MINT
+from spl.token.constants import WRAPPED_SOL_MINT, TOKEN_PROGRAM_ID
 
 if TYPE_CHECKING:
     from spl.token.async_client import AsyncToken
@@ -188,10 +188,10 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
         )
 
     def _create_associated_token_account_args(
-        self, owner: Pubkey, skip_confirmation: bool, commitment: Commitment, recent_blockhash: Blockhash
+        self, owner: Pubkey, skip_confirmation: bool, commitment: Commitment, recent_blockhash: Blockhash, token_program_id: Pubkey = TOKEN_PROGRAM_ID
     ) -> Tuple[Pubkey, Transaction, Keypair, TxOpts]:
         # Construct transaction
-        ix = spl_token.create_associated_token_account(payer=self.payer.pubkey(), owner=owner, mint=self.pubkey)
+        ix = spl_token.create_associated_token_account(payer=self.payer.pubkey(), owner=owner, mint=self.pubkey, token_program_id=token_program_id)
         msg = Message.new_with_blockhash([ix], self.payer.pubkey(), recent_blockhash)
         txn = Transaction([self.payer], msg, recent_blockhash)
         return (

--- a/src/spl/token/core.py
+++ b/src/spl/token/core.py
@@ -188,10 +188,17 @@ class _TokenCore:  # pylint: disable=too-few-public-methods
         )
 
     def _create_associated_token_account_args(
-        self, owner: Pubkey, skip_confirmation: bool, commitment: Commitment, recent_blockhash: Blockhash, token_program_id: Pubkey = TOKEN_PROGRAM_ID
+        self,
+        owner: Pubkey,
+        skip_confirmation: bool,
+        commitment: Commitment,
+        recent_blockhash: Blockhash,
+        token_program_id: Pubkey = TOKEN_PROGRAM_ID,
     ) -> Tuple[Pubkey, Transaction, Keypair, TxOpts]:
         # Construct transaction
-        ix = spl_token.create_associated_token_account(payer=self.payer.pubkey(), owner=owner, mint=self.pubkey, token_program_id=token_program_id)
+        ix = spl_token.create_associated_token_account(
+            payer=self.payer.pubkey(), owner=owner, mint=self.pubkey, token_program_id=token_program_id
+        )
         msg = Message.new_with_blockhash([ix], self.payer.pubkey(), recent_blockhash)
         txn = Transaction([self.payer], msg, recent_blockhash)
         return (


### PR DESCRIPTION
Tokens using TOKEN_2022_PROGRAM_ID were throwing an error due to an incorrect program ID, as create_associated_token_account internally defaulted to TOKEN_PROGRAM_ID. This update ensures that the program ID used when creating the token client via AsyncToken is passed to create_associated_token_account.