### PR TITLE
fix this error: __init__() got an unexpected keyword argument 'proxy'

### DIFF
--- a/src/solana/rpc/providers/http.py
+++ b/src/solana/rpc/providers/http.py
@@ -49,7 +49,7 @@ class HTTPProvider(BaseProvider, _HTTPProviderCore):
     ):
         """Init HTTPProvider."""
         super().__init__(endpoint, extra_headers)
-        self.session = httpx.Client(timeout=timeout, proxy=proxy)
+        self.session = httpx.Client(timeout=timeout, proxies=proxy)
 
     def __str__(self) -> str:
         """String definition for HTTPProvider."""


### PR DESCRIPTION
fix this error:
File "c:\Users\admin\anaconda3\envs\py39\lib\site-packages\solana\rpc\providers\http.py", line 52, in __init__
    self.session = httpx.Client(timeout=timeout, proxy=proxy)
TypeError: __init__() got an unexpected keyword argument 'proxy'