### PR TITLE
fix: bump httpx version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1391,4 +1391,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "5434655b6ff5da952a7cabaa2aea92726d41f6dbc1f792e4a4cb7af27598de5a"
+content-hash = "0a0d36d113e3b4aef31bd5278551fdccb6b7ed2ad0a112fed2fcb85df33fb67e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.9"
 construct-typing = "^0.6.2"
-httpx = ">=0.23.0"
+httpx = ">=0.28.0"
 typing-extensions = ">=4.2.0"
 websockets = ">=9.0,<=15.0.1"
 solders = ">=0.23,<0.27"


### PR DESCRIPTION
the version is different:

This is the code in version 0.23 with name `proxies`:
https://github.com/encode/httpx/blob/89cdd903b2f339c6ae319773c31b8c9352bd9cd8/httpx/_client.py#L1353

This is the code in version 0.28 with name `proxy`:
https://github.com/encode/httpx/blob/4fb9528c2f5ac000441c3634d297e77da23067cd/httpx/_client.py#L1364

link to #566