### PR TITLE
Add recent prioritization fees RPC helper

### DIFF
--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional, Sequence, Union
 
 from solders.message import VersionedMessage
 from solders.pubkey import Pubkey
+from solders.rpc.requests import GetRecentPrioritizationFees
 from solders.rpc.responses import (
     GetAccountInfoMaybeJsonParsedResp,
     GetAccountInfoResp,
@@ -36,6 +37,7 @@ from solders.rpc.responses import (
     GetProgramAccountsMaybeJsonParsedResp,
     GetProgramAccountsResp,
     GetRecentPerformanceSamplesResp,
+    GetRecentPrioritizationFeesResp,
     GetSignaturesForAddressResp,
     GetSignatureStatusesResp,
     GetSlotLeaderResp,
@@ -281,6 +283,28 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         """  # noqa: E501 # pylint: disable=line-too-long
         body = self._get_recent_performance_samples_body(limit)
         return self._provider.make_request(body, GetRecentPerformanceSamplesResp)
+
+    def get_recent_prioritization_fees(
+        self, addresses: Optional[Sequence[Pubkey]] = None
+    ) -> GetRecentPrioritizationFeesResp:
+        """Returns a list of recent prioritization fees, in reverse slot order.
+
+        Args:
+            addresses: Account addresses to query. If omitted, the response includes recent prioritization fees
+                from the node's recent blocks.
+
+        Example:
+            >>> solana_client = Client("http://localhost:8899")
+            >>> solana_client.get_recent_prioritization_fees().value[0] # doctest: +SKIP
+            RpcPrioritizationFee(
+                RpcPrioritizationFee {
+                    slot: 348125,
+                    prioritization_fee: 1000,
+                },
+            )
+        """
+        body = GetRecentPrioritizationFees(addresses)
+        return self._provider.make_request(body, GetRecentPrioritizationFeesResp)
 
     def get_block_height(self, commitment: Optional[Commitment] = None) -> GetBlockHeightResp:
         """Returns the current block height of the node.

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Sequence, Union
 
 from solders.message import VersionedMessage
 from solders.pubkey import Pubkey
+from solders.rpc.requests import GetRecentPrioritizationFees
 from solders.rpc.responses import (
     GetAccountInfoMaybeJsonParsedResp,
     GetAccountInfoResp,
@@ -35,6 +36,7 @@ from solders.rpc.responses import (
     GetProgramAccountsMaybeJsonParsedResp,
     GetProgramAccountsResp,
     GetRecentPerformanceSamplesResp,
+    GetRecentPrioritizationFeesResp,
     GetSignaturesForAddressResp,
     GetSignatureStatusesResp,
     GetSlotLeaderResp,
@@ -296,6 +298,28 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         """  # noqa: E501 # pylint: disable=line-too-long
         body = self._get_recent_performance_samples_body(limit)
         return await self._provider.make_request(body, GetRecentPerformanceSamplesResp)
+
+    async def get_recent_prioritization_fees(
+        self, addresses: Optional[Sequence[Pubkey]] = None
+    ) -> GetRecentPrioritizationFeesResp:
+        """Returns a list of recent prioritization fees, in reverse slot order.
+
+        Args:
+            addresses: Account addresses to query. If omitted, the response includes recent prioritization fees
+                from the node's recent blocks.
+
+        Example:
+            >>> solana_client = AsyncClient("http://localhost:8899")
+            >>> (await solana_client.get_recent_prioritization_fees()).value[0] # doctest: +SKIP
+            RpcPrioritizationFee(
+                RpcPrioritizationFee {
+                    slot: 348125,
+                    prioritization_fee: 1000,
+                },
+            )
+        """
+        body = GetRecentPrioritizationFees(addresses)
+        return await self._provider.make_request(body, GetRecentPrioritizationFeesResp)
 
     async def get_block_height(self, commitment: Optional[Commitment] = None) -> GetBlockHeightResp:
         """Returns the current block height of the node.


### PR DESCRIPTION
Adds sync and async client helpers for the getRecentPrioritizationFees RPC method, with optional account address filtering and the matching solders response parser. This keeps the method available through the public client API instead of requiring callers to drop down to the provider layer.

Checks run:
- ruff check src/solana/rpc/api.py src/solana/rpc/async_api.py
- PYTHONPATH=src python3 snippet verifying the generated getRecentPrioritizationFees request body and response parser

Closes #548