### PR TITLE
Feat: add instructions for the transfer fees extension

### DIFF
--- a/src/spl/token/_layouts.py
+++ b/src/spl/token/_layouts.py
@@ -2,7 +2,7 @@
 
 from enum import IntEnum
 
-from construct import Bytes, GreedyBytes, Int8ul, Int32ul, Int64ul, Pass, Switch
+from construct import Bytes, GreedyBytes, If, Int8ul, Int16ul, Int32ul, Int64ul, Pass, Switch
 from construct import Struct as cStruct
 
 PUBLIC_KEY_LAYOUT = Bytes(32)
@@ -36,6 +36,16 @@ class InstructionType(IntEnum):
     INITIALIZE_IMMUTABLE_OWNER = 22
     AMOUNT_TO_UI_AMOUNT = 23
     UI_AMOUNT_TO_AMOUNT = 24
+    TRANSFER_FEE_EXTENSION = 26
+
+
+class TransferFeeInstructionType(IntEnum):
+    """Transfer fee extension instruction types."""
+
+    INITIALIZE_TRANSFER_FEE_CONFIG = 0
+    WITHDRAW_WITHHELD_TOKENS_FROM_MINT = 2
+    WITHDRAW_WITHHELD_TOKENS_FROM_ACCOUNTS = 3
+    HARVEST_WITHHELD_TOKENS_TO_MINT = 4
 
 
 _INITIALIZE_MINT_LAYOUT = cStruct(
@@ -60,6 +70,34 @@ _SET_AUTHORITY_LAYOUT = cStruct(
 _AMOUNT2_LAYOUT = cStruct("amount" / Int64ul, "decimals" / Int8ul)
 
 _UI_AMOUNT_LAYOUT = cStruct("ui_amount" / GreedyBytes)
+
+_PUBKEY_OPTION_LAYOUT = cStruct(
+    "option" / Int8ul,
+    "pubkey" / If(lambda this: this.option, PUBLIC_KEY_LAYOUT),
+)
+
+_INITIALIZE_TRANSFER_FEE_CONFIG_LAYOUT = cStruct(
+    "transfer_fee_config_authority" / _PUBKEY_OPTION_LAYOUT,
+    "withdraw_withheld_authority" / _PUBKEY_OPTION_LAYOUT,
+    "transfer_fee_basis_points" / Int16ul,
+    "maximum_fee" / Int64ul,
+)
+
+_WITHDRAW_WITHHELD_TOKENS_FROM_ACCOUNTS_LAYOUT = cStruct("num_token_accounts" / Int8ul)
+
+_TRANSFER_FEE_EXTENSION_LAYOUT = cStruct(
+    "transfer_fee_instruction_type" / Int8ul,
+    "args"
+    / Switch(
+        lambda this: this.transfer_fee_instruction_type,
+        {
+            TransferFeeInstructionType.INITIALIZE_TRANSFER_FEE_CONFIG: _INITIALIZE_TRANSFER_FEE_CONFIG_LAYOUT,
+            TransferFeeInstructionType.WITHDRAW_WITHHELD_TOKENS_FROM_ACCOUNTS: (
+                _WITHDRAW_WITHHELD_TOKENS_FROM_ACCOUNTS_LAYOUT
+            ),
+        },
+    ),
+)
 
 INSTRUCTIONS_LAYOUT = cStruct(
     "instruction_type" / Int8ul,
@@ -92,6 +130,7 @@ INSTRUCTIONS_LAYOUT = cStruct(
             InstructionType.INITIALIZE_IMMUTABLE_OWNER: Pass,
             InstructionType.AMOUNT_TO_UI_AMOUNT: _AMOUNT_LAYOUT,
             InstructionType.UI_AMOUNT_TO_AMOUNT: _UI_AMOUNT_LAYOUT,
+            InstructionType.TRANSFER_FEE_EXTENSION: _TRANSFER_FEE_EXTENSION_LAYOUT,
         },
     ),
 )

--- a/src/spl/token/instructions.py
+++ b/src/spl/token/instructions.py
@@ -9,7 +9,7 @@ from solders.system_program import ID as SYS_PROGRAM_ID
 from solders.sysvar import RENT
 
 from solana.utils.validate import validate_instruction_keys, validate_instruction_type
-from spl.token._layouts import INSTRUCTIONS_LAYOUT, InstructionType
+from spl.token._layouts import INSTRUCTIONS_LAYOUT, InstructionType, TransferFeeInstructionType
 from spl.token.constants import ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID
 
 
@@ -370,6 +370,66 @@ class InitializeImmutableOwnerParams(NamedTuple):
     """SPL Token program account."""
     account: Pubkey
     """Token account to initialize immutable owner for."""
+
+
+class InitializeTransferFeeConfigParams(NamedTuple):
+    """InitializeTransferFeeConfig token transaction params."""
+
+    program_id: Pubkey
+    """SPL Token 2022 program account."""
+    mint: Pubkey
+    """Mint to initialize transfer fee config for."""
+    transfer_fee_config_authority: Optional[Pubkey]
+    """Authority that may update the transfer fee config."""
+    withdraw_withheld_authority: Optional[Pubkey]
+    """Authority that may withdraw withheld tokens."""
+    transfer_fee_basis_points: int
+    """Amount of transfer collected as fees, expressed in basis points."""
+    maximum_fee: int
+    """Maximum fee assessed on transfers."""
+
+
+class WithdrawWithheldTokensFromAccountsParams(NamedTuple):
+    """WithdrawWithheldTokensFromAccounts token transaction params."""
+
+    program_id: Pubkey
+    """SPL Token 2022 program account."""
+    mint: Pubkey
+    """Mint that includes the TransferFeeConfig extension."""
+    dest: Pubkey
+    """Fee receiver token account."""
+    authority: Pubkey
+    """Withdraw withheld authority."""
+    signers: List[Pubkey] = []
+    """Signing accounts if `authority` is a multiSig."""
+    sources: List[Pubkey] = []
+    """Token accounts to withdraw withheld tokens from."""
+
+
+class WithdrawWithheldTokensFromMintParams(NamedTuple):
+    """WithdrawWithheldTokensFromMint token transaction params."""
+
+    program_id: Pubkey
+    """SPL Token 2022 program account."""
+    mint: Pubkey
+    """Mint that includes the TransferFeeConfig extension."""
+    dest: Pubkey
+    """Fee receiver token account."""
+    authority: Pubkey
+    """Withdraw withheld authority."""
+    signers: List[Pubkey] = []
+    """Signing accounts if `authority` is a multiSig."""
+
+
+class HarvestWithheldTokensToMintParams(NamedTuple):
+    """HarvestWithheldTokensToMint token transaction params."""
+
+    program_id: Pubkey
+    """SPL Token 2022 program account."""
+    mint: Pubkey
+    """Mint to harvest withheld tokens to."""
+    sources: List[Pubkey] = []
+    """Token accounts to harvest withheld tokens from."""
 
 
 class AmountToUiAmountParams(NamedTuple):
@@ -805,6 +865,78 @@ def decode_initialize_immutable_owner(instruction: Instruction) -> InitializeImm
     return InitializeImmutableOwnerParams(
         program_id=instruction.program_id,
         account=instruction.accounts[0].pubkey,
+    )
+
+
+def decode_initialize_transfer_fee_config(instruction: Instruction) -> InitializeTransferFeeConfigParams:
+    """Decode an initialize_transfer_fee_config token transaction and retrieve the instruction params."""
+    parsed_data = __parse_and_validate_instruction(instruction, 1, InstructionType.TRANSFER_FEE_EXTENSION)
+    if parsed_data.args.transfer_fee_instruction_type != TransferFeeInstructionType.INITIALIZE_TRANSFER_FEE_CONFIG:
+        raise ValueError("invalid transfer fee instruction type")
+    args = parsed_data.args.args
+    transfer_fee_config_authority = args.transfer_fee_config_authority
+    withdraw_withheld_authority = args.withdraw_withheld_authority
+    return InitializeTransferFeeConfigParams(
+        program_id=instruction.program_id,
+        mint=instruction.accounts[0].pubkey,
+        transfer_fee_config_authority=Pubkey(transfer_fee_config_authority.pubkey)
+        if transfer_fee_config_authority.option
+        else None,
+        withdraw_withheld_authority=Pubkey(withdraw_withheld_authority.pubkey)
+        if withdraw_withheld_authority.option
+        else None,
+        transfer_fee_basis_points=args.transfer_fee_basis_points,
+        maximum_fee=args.maximum_fee,
+    )
+
+
+def decode_withdraw_withheld_tokens_from_accounts(
+    instruction: Instruction,
+) -> WithdrawWithheldTokensFromAccountsParams:
+    """Decode a withdraw_withheld_tokens_from_accounts token transaction and retrieve the instruction params."""
+    parsed_data = __parse_and_validate_instruction(instruction, 3, InstructionType.TRANSFER_FEE_EXTENSION)
+    if (
+        parsed_data.args.transfer_fee_instruction_type
+        != TransferFeeInstructionType.WITHDRAW_WITHHELD_TOKENS_FROM_ACCOUNTS
+    ):
+        raise ValueError("invalid transfer fee instruction type")
+    num_token_accounts = parsed_data.args.args.num_token_accounts
+    validate_instruction_keys(instruction, 3 + num_token_accounts)
+    signers = instruction.accounts[3:-num_token_accounts] if num_token_accounts else instruction.accounts[3:]
+    sources = instruction.accounts[-num_token_accounts:] if num_token_accounts else []
+    return WithdrawWithheldTokensFromAccountsParams(
+        program_id=instruction.program_id,
+        mint=instruction.accounts[0].pubkey,
+        dest=instruction.accounts[1].pubkey,
+        authority=instruction.accounts[2].pubkey,
+        signers=[signer.pubkey for signer in signers],
+        sources=[source.pubkey for source in sources],
+    )
+
+
+def decode_withdraw_withheld_tokens_from_mint(instruction: Instruction) -> WithdrawWithheldTokensFromMintParams:
+    """Decode a withdraw_withheld_tokens_from_mint token transaction and retrieve the instruction params."""
+    parsed_data = __parse_and_validate_instruction(instruction, 3, InstructionType.TRANSFER_FEE_EXTENSION)
+    if parsed_data.args.transfer_fee_instruction_type != TransferFeeInstructionType.WITHDRAW_WITHHELD_TOKENS_FROM_MINT:
+        raise ValueError("invalid transfer fee instruction type")
+    return WithdrawWithheldTokensFromMintParams(
+        program_id=instruction.program_id,
+        mint=instruction.accounts[0].pubkey,
+        dest=instruction.accounts[1].pubkey,
+        authority=instruction.accounts[2].pubkey,
+        signers=[signer.pubkey for signer in instruction.accounts[3:]],
+    )
+
+
+def decode_harvest_withheld_tokens_to_mint(instruction: Instruction) -> HarvestWithheldTokensToMintParams:
+    """Decode a harvest_withheld_tokens_to_mint token transaction and retrieve the instruction params."""
+    parsed_data = __parse_and_validate_instruction(instruction, 1, InstructionType.TRANSFER_FEE_EXTENSION)
+    if parsed_data.args.transfer_fee_instruction_type != TransferFeeInstructionType.HARVEST_WITHHELD_TOKENS_TO_MINT:
+        raise ValueError("invalid transfer fee instruction type")
+    return HarvestWithheldTokensToMintParams(
+        program_id=instruction.program_id,
+        mint=instruction.accounts[0].pubkey,
+        sources=[source.pubkey for source in instruction.accounts[1:]],
     )
 
 
@@ -1485,6 +1617,106 @@ def initialize_immutable_owner(params: InitializeImmutableOwnerParams) -> Instru
     data = INSTRUCTIONS_LAYOUT.build({"instruction_type": InstructionType.INITIALIZE_IMMUTABLE_OWNER, "args": None})
     return Instruction(
         accounts=[AccountMeta(pubkey=params.account, is_signer=False, is_writable=True)],
+        program_id=params.program_id,
+        data=data,
+    )
+
+
+def initialize_transfer_fee_config(params: InitializeTransferFeeConfigParams) -> Instruction:
+    """Initializes the TransferFeeConfig extension for a mint."""
+    transfer_fee_config_authority = (
+        {"option": 1, "pubkey": bytes(params.transfer_fee_config_authority)}
+        if params.transfer_fee_config_authority
+        else {"option": 0, "pubkey": None}
+    )
+    withdraw_withheld_authority = (
+        {"option": 1, "pubkey": bytes(params.withdraw_withheld_authority)}
+        if params.withdraw_withheld_authority
+        else {"option": 0, "pubkey": None}
+    )
+    data = INSTRUCTIONS_LAYOUT.build(
+        {
+            "instruction_type": InstructionType.TRANSFER_FEE_EXTENSION,
+            "args": {
+                "transfer_fee_instruction_type": TransferFeeInstructionType.INITIALIZE_TRANSFER_FEE_CONFIG,
+                "args": {
+                    "transfer_fee_config_authority": transfer_fee_config_authority,
+                    "withdraw_withheld_authority": withdraw_withheld_authority,
+                    "transfer_fee_basis_points": params.transfer_fee_basis_points,
+                    "maximum_fee": params.maximum_fee,
+                },
+            },
+        }
+    )
+    return Instruction(
+        accounts=[AccountMeta(pubkey=params.mint, is_signer=False, is_writable=True)],
+        program_id=params.program_id,
+        data=data,
+    )
+
+
+def withdraw_withheld_tokens_from_accounts(params: WithdrawWithheldTokensFromAccountsParams) -> Instruction:
+    """Withdraws withheld tokens from token accounts to a fee receiver account."""
+    data = INSTRUCTIONS_LAYOUT.build(
+        {
+            "instruction_type": InstructionType.TRANSFER_FEE_EXTENSION,
+            "args": {
+                "transfer_fee_instruction_type": TransferFeeInstructionType.WITHDRAW_WITHHELD_TOKENS_FROM_ACCOUNTS,
+                "args": {"num_token_accounts": len(params.sources)},
+            },
+        }
+    )
+    keys = [
+        AccountMeta(pubkey=params.mint, is_signer=False, is_writable=False),
+        AccountMeta(pubkey=params.dest, is_signer=False, is_writable=True),
+    ]
+    __add_signers(keys, params.authority, params.signers)
+    keys.extend(AccountMeta(pubkey=source, is_signer=False, is_writable=True) for source in params.sources)
+    return Instruction(
+        accounts=keys,
+        program_id=params.program_id,
+        data=data,
+    )
+
+
+def withdraw_withheld_tokens_from_mint(params: WithdrawWithheldTokensFromMintParams) -> Instruction:
+    """Withdraws withheld tokens from a mint to a fee receiver account."""
+    data = INSTRUCTIONS_LAYOUT.build(
+        {
+            "instruction_type": InstructionType.TRANSFER_FEE_EXTENSION,
+            "args": {
+                "transfer_fee_instruction_type": TransferFeeInstructionType.WITHDRAW_WITHHELD_TOKENS_FROM_MINT,
+                "args": None,
+            },
+        }
+    )
+    keys = [
+        AccountMeta(pubkey=params.mint, is_signer=False, is_writable=True),
+        AccountMeta(pubkey=params.dest, is_signer=False, is_writable=True),
+    ]
+    __add_signers(keys, params.authority, params.signers)
+    return Instruction(
+        accounts=keys,
+        program_id=params.program_id,
+        data=data,
+    )
+
+
+def harvest_withheld_tokens_to_mint(params: HarvestWithheldTokensToMintParams) -> Instruction:
+    """Harvests withheld tokens from token accounts to the mint."""
+    data = INSTRUCTIONS_LAYOUT.build(
+        {
+            "instruction_type": InstructionType.TRANSFER_FEE_EXTENSION,
+            "args": {
+                "transfer_fee_instruction_type": TransferFeeInstructionType.HARVEST_WITHHELD_TOKENS_TO_MINT,
+                "args": None,
+            },
+        }
+    )
+    keys = [AccountMeta(pubkey=params.mint, is_signer=False, is_writable=True)]
+    keys.extend(AccountMeta(pubkey=source, is_signer=False, is_writable=True) for source in params.sources)
+    return Instruction(
+        accounts=keys,
         program_id=params.program_id,
         data=data,
     )

--- a/tests/unit/test_spl_token_instructions.py
+++ b/tests/unit/test_spl_token_instructions.py
@@ -3,7 +3,7 @@
 import spl.token.instructions as spl_token
 from solders.pubkey import Pubkey
 from solders.system_program import ID as SYSTEM_PROGRAM_ID
-from spl.token.constants import TOKEN_PROGRAM_ID, WRAPPED_SOL_MINT, ASSOCIATED_TOKEN_PROGRAM_ID
+from spl.token.constants import TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID, WRAPPED_SOL_MINT, ASSOCIATED_TOKEN_PROGRAM_ID
 from spl.token.instructions import get_associated_token_address
 
 
@@ -475,6 +475,180 @@ def test_initialize_immutable_owner():
     params = spl_token.InitializeImmutableOwnerParams(program_id=TOKEN_PROGRAM_ID, account=account)
     instruction = spl_token.initialize_immutable_owner(params)
     assert spl_token.decode_initialize_immutable_owner(instruction) == params
+
+
+def test_initialize_transfer_fee_config():
+    """Test initialize_transfer_fee_config."""
+    mint = Pubkey([0] * 31 + [0])
+    transfer_fee_config_authority = Pubkey([11] * 32)
+    params = spl_token.InitializeTransferFeeConfigParams(
+        program_id=TOKEN_2022_PROGRAM_ID,
+        mint=mint,
+        transfer_fee_config_authority=transfer_fee_config_authority,
+        withdraw_withheld_authority=None,
+        transfer_fee_basis_points=111,
+        maximum_fee=2**64 - 1,
+    )
+    instruction = spl_token.initialize_transfer_fee_config(params)
+
+    expected_data = bytes([26, 0, 1])
+    expected_data += bytes(transfer_fee_config_authority)
+    expected_data += bytes([0, 111, 0])
+    expected_data += (2**64 - 1).to_bytes(8, "little")
+
+    assert instruction.program_id == TOKEN_2022_PROGRAM_ID
+    assert instruction.data == expected_data
+    assert len(instruction.accounts) == 1
+    assert instruction.accounts[0].pubkey == mint
+    assert not instruction.accounts[0].is_signer
+    assert instruction.accounts[0].is_writable
+    assert spl_token.decode_initialize_transfer_fee_config(instruction) == params
+
+    params_no_authorities = spl_token.InitializeTransferFeeConfigParams(
+        program_id=TOKEN_2022_PROGRAM_ID,
+        mint=mint,
+        transfer_fee_config_authority=None,
+        withdraw_withheld_authority=None,
+        transfer_fee_basis_points=25,
+        maximum_fee=10_000,
+    )
+    instruction = spl_token.initialize_transfer_fee_config(params_no_authorities)
+
+    assert instruction.data == bytes([26, 0, 0, 0, 25, 0]) + (10_000).to_bytes(8, "little")
+    assert spl_token.decode_initialize_transfer_fee_config(instruction) == params_no_authorities
+
+
+def test_withdraw_withheld_tokens_from_accounts():
+    """Test withdraw_withheld_tokens_from_accounts."""
+    mint = Pubkey([0] * 31 + [0])
+    dest = Pubkey([0] * 31 + [1])
+    authority = Pubkey([0] * 31 + [2])
+    sources = [Pubkey([0] * 31 + [i]) for i in range(3, 6)]
+    params = spl_token.WithdrawWithheldTokensFromAccountsParams(
+        program_id=TOKEN_2022_PROGRAM_ID,
+        mint=mint,
+        dest=dest,
+        authority=authority,
+        sources=sources,
+    )
+    instruction = spl_token.withdraw_withheld_tokens_from_accounts(params)
+
+    assert instruction.program_id == TOKEN_2022_PROGRAM_ID
+    assert instruction.data == bytes([26, 3, len(sources)])
+    assert spl_token.decode_withdraw_withheld_tokens_from_accounts(instruction) == params
+    assert len(instruction.accounts) == 3 + len(sources)
+    assert instruction.accounts[0].pubkey == mint
+    assert not instruction.accounts[0].is_signer
+    assert not instruction.accounts[0].is_writable
+    assert instruction.accounts[1].pubkey == dest
+    assert not instruction.accounts[1].is_signer
+    assert instruction.accounts[1].is_writable
+    assert instruction.accounts[2].pubkey == authority
+    assert instruction.accounts[2].is_signer
+    assert not instruction.accounts[2].is_writable
+    for account, source in zip(instruction.accounts[3:], sources):
+        assert account.pubkey == source
+        assert not account.is_signer
+        assert account.is_writable
+
+    signers = [Pubkey([0] * 31 + [i]) for i in range(6, 9)]
+    multisig_params = spl_token.WithdrawWithheldTokensFromAccountsParams(
+        program_id=TOKEN_2022_PROGRAM_ID,
+        mint=mint,
+        dest=dest,
+        authority=authority,
+        signers=signers,
+        sources=sources,
+    )
+    instruction = spl_token.withdraw_withheld_tokens_from_accounts(multisig_params)
+
+    assert instruction.data == bytes([26, 3, len(sources)])
+    assert spl_token.decode_withdraw_withheld_tokens_from_accounts(instruction) == multisig_params
+    assert len(instruction.accounts) == 3 + len(signers) + len(sources)
+    assert instruction.accounts[2].pubkey == authority
+    assert not instruction.accounts[2].is_signer
+    assert not instruction.accounts[2].is_writable
+    for account, signer in zip(instruction.accounts[3 : 3 + len(signers)], signers):
+        assert account.pubkey == signer
+        assert account.is_signer
+        assert not account.is_writable
+    for account, source in zip(instruction.accounts[3 + len(signers) :], sources):
+        assert account.pubkey == source
+        assert not account.is_signer
+        assert account.is_writable
+
+
+def test_withdraw_withheld_tokens_from_mint():
+    """Test withdraw_withheld_tokens_from_mint."""
+    mint = Pubkey([0] * 31 + [0])
+    dest = Pubkey([0] * 31 + [1])
+    authority = Pubkey([0] * 31 + [2])
+    params = spl_token.WithdrawWithheldTokensFromMintParams(
+        program_id=TOKEN_2022_PROGRAM_ID,
+        mint=mint,
+        dest=dest,
+        authority=authority,
+    )
+    instruction = spl_token.withdraw_withheld_tokens_from_mint(params)
+
+    assert instruction.program_id == TOKEN_2022_PROGRAM_ID
+    assert instruction.data == bytes([26, 2])
+    assert spl_token.decode_withdraw_withheld_tokens_from_mint(instruction) == params
+    assert len(instruction.accounts) == 3
+    assert instruction.accounts[0].pubkey == mint
+    assert not instruction.accounts[0].is_signer
+    assert instruction.accounts[0].is_writable
+    assert instruction.accounts[1].pubkey == dest
+    assert not instruction.accounts[1].is_signer
+    assert instruction.accounts[1].is_writable
+    assert instruction.accounts[2].pubkey == authority
+    assert instruction.accounts[2].is_signer
+    assert not instruction.accounts[2].is_writable
+
+    signers = [Pubkey([0] * 31 + [i]) for i in range(3, 6)]
+    multisig_params = spl_token.WithdrawWithheldTokensFromMintParams(
+        program_id=TOKEN_2022_PROGRAM_ID,
+        mint=mint,
+        dest=dest,
+        authority=authority,
+        signers=signers,
+    )
+    instruction = spl_token.withdraw_withheld_tokens_from_mint(multisig_params)
+
+    assert instruction.data == bytes([26, 2])
+    assert spl_token.decode_withdraw_withheld_tokens_from_mint(instruction) == multisig_params
+    assert len(instruction.accounts) == 3 + len(signers)
+    assert instruction.accounts[2].pubkey == authority
+    assert not instruction.accounts[2].is_signer
+    assert not instruction.accounts[2].is_writable
+    for account, signer in zip(instruction.accounts[3:], signers):
+        assert account.pubkey == signer
+        assert account.is_signer
+        assert not account.is_writable
+
+
+def test_harvest_withheld_tokens_to_mint():
+    """Test harvest_withheld_tokens_to_mint."""
+    mint = Pubkey([0] * 31 + [0])
+    sources = [Pubkey([0] * 31 + [i]) for i in range(1, 4)]
+    params = spl_token.HarvestWithheldTokensToMintParams(
+        program_id=TOKEN_2022_PROGRAM_ID,
+        mint=mint,
+        sources=sources,
+    )
+    instruction = spl_token.harvest_withheld_tokens_to_mint(params)
+
+    assert instruction.program_id == TOKEN_2022_PROGRAM_ID
+    assert instruction.data == bytes([26, 4])
+    assert spl_token.decode_harvest_withheld_tokens_to_mint(instruction) == params
+    assert len(instruction.accounts) == 1 + len(sources)
+    assert instruction.accounts[0].pubkey == mint
+    assert not instruction.accounts[0].is_signer
+    assert instruction.accounts[0].is_writable
+    for account, source in zip(instruction.accounts[1:], sources):
+        assert account.pubkey == source
+        assert not account.is_signer
+        assert account.is_writable
 
 
 def test_amount_to_ui_amount():


### PR DESCRIPTION
Added several new instructions from the [Transfer Fees extension](https://solana.com/docs/tokens/extensions/transfer-fees)

initialize_transfer_fee_config
withdraw_withheld_tokens_from_accounts
withdraw_withheld_tokens_from_mint
harvest_withheld_tokens_to_mint