### PR TITLE
Fix mkdocs gh-deploy by adding mkdocstrings-python dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
     "pytest-xdist>=3.6.1",
     "asyncstdlib>=3.14.0",
     "mkdocstrings>=0.18.0",
+    "mkdocstrings-python>=0.14.0",
     "mkdocs-material>=9.7.6",
     "ruff>=0.7.3",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -427,6 +427,15 @@ wheels = [
 ]
 
 [[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -828,6 +837,21 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocstrings-python"
+version = "2.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/b4/5fed370d8ebd96e4e399460a7146ae989263f16588b05a6facd6dbd51e60/mkdocstrings_python-2.0.4.tar.gz", hash = "sha256:58c73c5d358e64e9b1673447663f4a2f8a8941e392e225fc0a0c893758cc452f", size = 199219, upload-time = "2026-06-05T08:13:01.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/e3/00ec594aef5f55522e6d373bc2ac53e53a8f5e9ae32f2d6854b0de4270f3/mkdocstrings_python-2.0.4-py3-none-any.whl", hash = "sha256:fd87c173e1e719a85997b6d4f852cdc55f36710e0ed08da3a7bd9abe79c9db00", size = 104790, upload-time = "2026-06-05T08:13:00.393Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1195,6 +1219,7 @@ dev = [
     { name = "bump2version" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings" },
+    { name = "mkdocstrings-python" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1221,6 +1246,7 @@ dev = [
     { name = "bump2version", specifier = ">=1.0.1" },
     { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mkdocstrings", specifier = ">=0.18.0" },
+    { name = "mkdocstrings-python", specifier = ">=0.14.0" },
     { name = "mypy", specifier = ">=1.19" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", specifier = ">=0.18.3" },


### PR DESCRIPTION
## Summary

The `mkdocs gh-deploy --force` command was failing with:

```
ModuleNotFoundError: No module named 'mkdocstrings_handlers'
```

This error occurred because the `mkdocstrings-python` package, which provides the Python handler for mkdocstrings, was missing from the dependencies.

## Fix

Added `mkdocstrings-python>=0.14.0` to the dev dependencies in `pyproject.toml`.

## Changes

- `pyproject.toml`: Added `mkdocstrings-python>=0.14.0` dependency
- `uv.lock`: Updated lock file to include the new dependency

## Verification

The fix was tested by running `uv run mkdocs build` which now completes successfully.

@michaelhly can click here to [continue refining the PR](https://app.all-hands.dev/conversations/357f9974-a0ff-4d31-a48b-eab16d61463c)