### PR TITLE
websocket: Return request Id on subscribe

### DIFF
--- a/src/solana/rpc/websocket_api.py
+++ b/src/solana/rpc/websocket_api.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import itertools
+from contextlib import asynccontextmanager
 from collections.abc import Sequence
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, AsyncIterator, Dict, List, Optional, Union, cast
 
 from solders.account_decoder import UiDataSliceConfig
 from solders.pubkey import Pubkey
@@ -123,7 +124,7 @@ class SolanaWsClientProtocol(ClientConnection):
         pubkey: Pubkey,
         commitment: Optional[Commitment] = None,
         encoding: Optional[str] = None,
-    ) -> None:
+    ) -> int:
         """Subscribe to an account to receive notifications when the lamports or data change.
 
         Args:
@@ -141,6 +142,7 @@ class SolanaWsClientProtocol(ClientConnection):
         )
         req = AccountSubscribe(pubkey, config, req_id)
         await self.send_request(req)
+        return req_id
 
     async def account_unsubscribe(
         self,
@@ -160,7 +162,7 @@ class SolanaWsClientProtocol(ClientConnection):
         self,
         filter_: Union[RpcTransactionLogsFilter, RpcTransactionLogsFilterMentions] = RpcTransactionLogsFilter.All,
         commitment: Optional[Commitment] = None,
-    ) -> None:
+    ) -> int:
         """Subscribe to transaction logging.
 
         Args:
@@ -172,6 +174,7 @@ class SolanaWsClientProtocol(ClientConnection):
         config = RpcTransactionLogsConfig(commitment_to_use)
         req = LogsSubscribe(filter_, config, req_id)
         await self.send_request(req)
+        return req_id
 
     async def logs_unsubscribe(
         self,
@@ -195,7 +198,7 @@ class SolanaWsClientProtocol(ClientConnection):
         transaction_details: Union[TransactionDetails, None] = None,
         show_rewards: Optional[bool] = None,
         max_supported_transaction_version: Optional[int] = None,
-    ) -> None:
+    ) -> int:
         """Subscribe to blocks.
 
         Args:
@@ -218,6 +221,7 @@ class SolanaWsClientProtocol(ClientConnection):
         )
         req = BlockSubscribe(filter_, config, req_id)
         await self.send_request(req)
+        return req_id
 
     async def block_unsubscribe(
         self,
@@ -240,7 +244,7 @@ class SolanaWsClientProtocol(ClientConnection):
         encoding: Optional[str] = None,
         data_slice: Optional[types.DataSliceOpts] = None,
         filters: Optional[Sequence[Union[int, types.MemcmpOpts]]] = None,
-    ) -> None:
+    ) -> int:
         """Receive notifications when the lamports or data for a given account owned by the program changes.
 
         Args:
@@ -272,6 +276,7 @@ class SolanaWsClientProtocol(ClientConnection):
             config = RpcProgramAccountsConfig(account_config, filters_to_use)
         req = ProgramSubscribe(program_id, config, req_id)
         await self.send_request(req)
+        return req_id
 
     async def program_unsubscribe(
         self,
@@ -291,7 +296,7 @@ class SolanaWsClientProtocol(ClientConnection):
         self,
         signature: Signature,
         commitment: Optional[Commitment] = None,
-    ) -> None:
+    ) -> int:
         """Subscribe to a transaction signature to receive notification when the transaction is confirmed.
 
         Args:
@@ -303,6 +308,7 @@ class SolanaWsClientProtocol(ClientConnection):
         config = None if commitment_to_use is None else RpcSignatureSubscribeConfig(commitment=commitment_to_use)
         req = SignatureSubscribe(signature, config, req_id)
         await self.send_request(req)
+        return req_id
 
     async def signature_unsubscribe(
         self,
@@ -318,11 +324,12 @@ class SolanaWsClientProtocol(ClientConnection):
         await self.send_request(req)
         del self.subscriptions[subscription]
 
-    async def slot_subscribe(self) -> None:
+    async def slot_subscribe(self) -> int:
         """Subscribe to receive notification anytime a slot is processed by the validator."""
         req_id = self.increment_counter_and_get_id()
         req = SlotSubscribe(req_id)
         await self.send_request(req)
+        return req_id
 
     async def slot_unsubscribe(
         self,
@@ -338,11 +345,12 @@ class SolanaWsClientProtocol(ClientConnection):
         await self.send_request(req)
         del self.subscriptions[subscription]
 
-    async def slots_updates_subscribe(self) -> None:
+    async def slots_updates_subscribe(self) -> int:
         """Subscribe to receive a notification from the validator on a variety of updates on every slot."""
         req_id = self.increment_counter_and_get_id()
         req = SlotsUpdatesSubscribe(req_id)
         await self.send_request(req)
+        return req_id
 
     async def slots_updates_unsubscribe(
         self,
@@ -358,11 +366,12 @@ class SolanaWsClientProtocol(ClientConnection):
         await self.send_request(req)
         del self.subscriptions[subscription]
 
-    async def root_subscribe(self) -> None:
+    async def root_subscribe(self) -> int:
         """Subscribe to receive notification anytime a new root is set by the validator."""
         req_id = self.increment_counter_and_get_id()
         req = RootSubscribe(req_id)
         await self.send_request(req)
+        return req_id
 
     async def root_unsubscribe(
         self,
@@ -378,11 +387,12 @@ class SolanaWsClientProtocol(ClientConnection):
         await self.send_request(req)
         del self.subscriptions[subscription]
 
-    async def vote_subscribe(self) -> None:
+    async def vote_subscribe(self) -> int:
         """Subscribe to receive notification anytime a new vote is observed in gossip."""
         req_id = self.increment_counter_and_get_id()
         req = VoteSubscribe(req_id)
         await self.send_request(req)
+        return req_id
 
     async def vote_unsubscribe(
         self,
@@ -410,24 +420,14 @@ class SolanaWsClientProtocol(ClientConnection):
         return cast(List[Union[Notification, SubscriptionResult]], parsed)
 
 
-class connect:  # pylint: disable=invalid-name,too-few-public-methods
-    """Solana RPC websocket connector."""
+@asynccontextmanager
+async def connect(uri: str = "ws://localhost:8900", **kwargs: Any) -> AsyncIterator[SolanaWsClientProtocol]:
+    """Solana RPC websocket connector.
 
-    def __init__(self, uri: str = "ws://localhost:8900", **kwargs: Any) -> None:
-        """Init. Kwargs are passed to `websockets.connect`.
-
-        Args:
-            uri: The websocket endpoint.
-            **kwargs: Keyword arguments for ``websockets.asyncio.client.connect``
-        """
-        kwargs.setdefault("create_connection", SolanaWsClientProtocol)
-        self._cm = ws_connect(uri, **kwargs)
-
-    async def __aenter__(self) -> SolanaWsClientProtocol:
-        """Enter the async context manager."""
-        connection = await self._cm.__aenter__()
-        return cast(SolanaWsClientProtocol, connection)
-
-    async def __aexit__(self, *args: Any) -> None:
-        """Exit the async context manager."""
-        await self._cm.__aexit__(*args)
+    Args:
+        uri: The websocket endpoint.
+        **kwargs: Keyword arguments for ``websockets.asyncio.client.connect``.
+    """
+    kwargs.setdefault("create_connection", SolanaWsClientProtocol)
+    async with ws_connect(uri, **kwargs) as connection:
+        yield cast(SolanaWsClientProtocol, connection)

--- a/tests/unit/test_websocket_api.py
+++ b/tests/unit/test_websocket_api.py
@@ -1,0 +1,69 @@
+"""Test websocket API helpers."""
+
+from __future__ import annotations
+
+import itertools
+
+from solders.pubkey import Pubkey
+
+from solana.rpc.websocket_api import SolanaWsClientProtocol, connect
+
+
+async def test_account_subscribe_returns_request_id(monkeypatch):
+    """Subscription helpers should return the request id used for the request."""
+    protocol = SolanaWsClientProtocol.__new__(SolanaWsClientProtocol)
+    protocol.request_counter = itertools.count()
+    sent_messages = []
+
+    async def fake_send_request(self, message):
+        sent_messages.append(message)
+
+    monkeypatch.setattr(SolanaWsClientProtocol, "send_request", fake_send_request)
+
+    request_id = await protocol.account_subscribe(Pubkey.default())
+
+    assert request_id == 1
+    assert sent_messages[0].id == request_id
+
+
+async def test_slot_subscribe_returns_request_id(monkeypatch):
+    """Single-argument subscribe helpers should also return their request id."""
+    protocol = SolanaWsClientProtocol.__new__(SolanaWsClientProtocol)
+    protocol.request_counter = itertools.count()
+    sent_messages = []
+
+    async def fake_send_request(self, message):
+        sent_messages.append(message)
+
+    monkeypatch.setattr(SolanaWsClientProtocol, "send_request", fake_send_request)
+
+    request_id = await protocol.slot_subscribe()
+
+    assert request_id == 1
+    assert sent_messages[0].id == request_id
+
+
+async def test_connect_preserves_async_with_and_custom_connection(monkeypatch):
+    """The connect helper should stay usable as an async context manager."""
+    captured = {}
+    sentinel_connection = object()
+
+    class FakeConnectionManager:
+        async def __aenter__(self):
+            return sentinel_connection
+
+        async def __aexit__(self, *args):
+            return None
+
+    def fake_ws_connect(uri, **kwargs):
+        captured["uri"] = uri
+        captured["kwargs"] = kwargs
+        return FakeConnectionManager()
+
+    monkeypatch.setattr("solana.rpc.websocket_api.ws_connect", fake_ws_connect)
+
+    async with connect(uri="ws://example") as connection:
+        assert connection is sentinel_connection
+
+    assert captured["uri"] == "ws://example"
+    assert captured["kwargs"]["create_connection"] is SolanaWsClientProtocol


### PR DESCRIPTION
This pull request updates the Solana WebSocket API to improve usability and test coverage. The main changes are that all subscription helper methods now return the request ID used for the subscription, and the `connect` helper is refactored to be a proper async context manager. Comprehensive unit tests have been added to verify these behaviors.

**API improvements:**

* All subscription methods (e.g., `account_subscribe`, `logs_subscribe`, `block_subscribe`, etc.) now return the request ID (`int`) used for the subscription, instead of `None`, making it easier for users to manage and track subscriptions. 

* The `connect` helper is now implemented as an `@asynccontextmanager` function, replacing the previous class-based context manager. This simplifies usage and ensures compatibility with async context management. 

**Testing improvements:**

* Added a new unit test module (`tests/unit/test_websocket_api.py`) to verify that subscription helpers return the correct request ID and that the `connect` helper works as an async context manager and passes through custom arguments.