### PR TITLE
Add deprecated mark on make_batch_request

### DIFF
--- a/src/solana/rpc/providers/async_http.py
+++ b/src/solana/rpc/providers/async_http.py
@@ -59,9 +59,7 @@ class AsyncHTTPProvider(AsyncBaseProvider, _HTTPProviderCore):
                 limits=DEFAULT_LIMITS,
             )
         else:
-            self.session = httpx2.AsyncClient(
-                timeout=timeout, proxy=proxy, limits=DEFAULT_LIMITS
-            )
+            self.session = httpx2.AsyncClient(timeout=timeout, proxy=proxy, limits=DEFAULT_LIMITS)
 
     def __str__(self) -> str:
         """String definition for HTTPProvider."""
@@ -98,33 +96,21 @@ class AsyncHTTPProvider(AsyncBaseProvider, _HTTPProviderCore):
     async def make_batch_request(self, reqs: _BodiesTup, parsers: _Tup) -> _RespTup: ...
 
     @overload
-    async def make_batch_request(
-        self, reqs: _BodiesTup1, parsers: _Tup1
-    ) -> _RespTup1: ...
+    async def make_batch_request(self, reqs: _BodiesTup1, parsers: _Tup1) -> _RespTup1: ...
 
     @overload
-    async def make_batch_request(
-        self, reqs: _BodiesTup2, parsers: _Tup2
-    ) -> _RespTup2: ...
+    async def make_batch_request(self, reqs: _BodiesTup2, parsers: _Tup2) -> _RespTup2: ...
 
     @overload
-    async def make_batch_request(
-        self, reqs: _BodiesTup3, parsers: _Tup3
-    ) -> _RespTup3: ...
+    async def make_batch_request(self, reqs: _BodiesTup3, parsers: _Tup3) -> _RespTup3: ...
 
     @overload
-    async def make_batch_request(
-        self, reqs: _BodiesTup4, parsers: _Tup4
-    ) -> _RespTup4: ...
+    async def make_batch_request(self, reqs: _BodiesTup4, parsers: _Tup4) -> _RespTup4: ...
 
     @overload
-    async def make_batch_request(
-        self, reqs: _BodiesTup5, parsers: _Tup5
-    ) -> _RespTup5: ...
+    async def make_batch_request(self, reqs: _BodiesTup5, parsers: _Tup5) -> _RespTup5: ...
 
-    async def make_batch_request(
-        self, reqs: Tuple[Body, ...], parsers: _Tuples
-    ) -> Tuple[RPCResult, ...]:
+    async def make_batch_request(self, reqs: Tuple[Body, ...], parsers: _Tuples) -> Tuple[RPCResult, ...]:
         """Make an async HTTP batch request to an http rpc endpoint.
 
         .. deprecated::

--- a/src/solana/rpc/providers/async_http.py
+++ b/src/solana/rpc/providers/async_http.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Dict, Optional, Tuple, Type, overload
 
 import httpx2
@@ -58,7 +59,9 @@ class AsyncHTTPProvider(AsyncBaseProvider, _HTTPProviderCore):
                 limits=DEFAULT_LIMITS,
             )
         else:
-            self.session = httpx2.AsyncClient(timeout=timeout, proxy=proxy, limits=DEFAULT_LIMITS)
+            self.session = httpx2.AsyncClient(
+                timeout=timeout, proxy=proxy, limits=DEFAULT_LIMITS
+            )
 
     def __str__(self) -> str:
         """String definition for HTTPProvider."""
@@ -95,22 +98,39 @@ class AsyncHTTPProvider(AsyncBaseProvider, _HTTPProviderCore):
     async def make_batch_request(self, reqs: _BodiesTup, parsers: _Tup) -> _RespTup: ...
 
     @overload
-    async def make_batch_request(self, reqs: _BodiesTup1, parsers: _Tup1) -> _RespTup1: ...
+    async def make_batch_request(
+        self, reqs: _BodiesTup1, parsers: _Tup1
+    ) -> _RespTup1: ...
 
     @overload
-    async def make_batch_request(self, reqs: _BodiesTup2, parsers: _Tup2) -> _RespTup2: ...
+    async def make_batch_request(
+        self, reqs: _BodiesTup2, parsers: _Tup2
+    ) -> _RespTup2: ...
 
     @overload
-    async def make_batch_request(self, reqs: _BodiesTup3, parsers: _Tup3) -> _RespTup3: ...
+    async def make_batch_request(
+        self, reqs: _BodiesTup3, parsers: _Tup3
+    ) -> _RespTup3: ...
 
     @overload
-    async def make_batch_request(self, reqs: _BodiesTup4, parsers: _Tup4) -> _RespTup4: ...
+    async def make_batch_request(
+        self, reqs: _BodiesTup4, parsers: _Tup4
+    ) -> _RespTup4: ...
 
     @overload
-    async def make_batch_request(self, reqs: _BodiesTup5, parsers: _Tup5) -> _RespTup5: ...
+    async def make_batch_request(
+        self, reqs: _BodiesTup5, parsers: _Tup5
+    ) -> _RespTup5: ...
 
-    async def make_batch_request(self, reqs: Tuple[Body, ...], parsers: _Tuples) -> Tuple[RPCResult, ...]:
+    async def make_batch_request(
+        self, reqs: Tuple[Body, ...], parsers: _Tuples
+    ) -> Tuple[RPCResult, ...]:
         """Make an async HTTP batch request to an http rpc endpoint.
+
+        .. deprecated::
+            ``make_batch_request`` is deprecated and will be removed in a future release.
+            Use individual requests with ``asyncio.gather`` instead.
+            See https://github.com/michaelhly/solana-py/issues/645 for details.
 
         Args:
             reqs: A tuple of request objects from ``solders.rpc.requests``.
@@ -131,6 +151,13 @@ class AsyncHTTPProvider(AsyncBaseProvider, _HTTPProviderCore):
                 86753592,
             ))
         """
+        warnings.warn(
+            "make_batch_request is deprecated and will be removed in a future release. "
+            "Use individual requests with asyncio.gather instead. "
+            "See https://github.com/michaelhly/solana-py/issues/645 for details.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         raw = await self.make_batch_request_unparsed(reqs)
         return _parse_raw_batch(raw, parsers)
 

--- a/src/solana/rpc/providers/http.py
+++ b/src/solana/rpc/providers/http.py
@@ -59,9 +59,7 @@ class HTTPProvider(BaseProvider, _HTTPProviderCore):
                 limits=DEFAULT_LIMITS,
             )
         else:
-            self.session = httpx2.Client(
-                timeout=timeout, proxy=proxy, limits=DEFAULT_LIMITS
-            )
+            self.session = httpx2.Client(timeout=timeout, proxy=proxy, limits=DEFAULT_LIMITS)
 
     def __str__(self) -> str:
         """String definition for HTTPProvider."""
@@ -112,9 +110,7 @@ class HTTPProvider(BaseProvider, _HTTPProviderCore):
     @overload
     def make_batch_request(self, reqs: _BodiesTup5, parsers: _Tup5) -> _RespTup5: ...
 
-    def make_batch_request(
-        self, reqs: Tuple[Body, ...], parsers: _Tuples
-    ) -> Tuple[RPCResult, ...]:
+    def make_batch_request(self, reqs: Tuple[Body, ...], parsers: _Tuples) -> Tuple[RPCResult, ...]:
         """Make a HTTP batch request to an http rpc endpoint.
 
         .. deprecated::

--- a/src/solana/rpc/providers/http.py
+++ b/src/solana/rpc/providers/http.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Dict, Optional, Tuple, Type, overload
 
 import httpx2
@@ -58,7 +59,9 @@ class HTTPProvider(BaseProvider, _HTTPProviderCore):
                 limits=DEFAULT_LIMITS,
             )
         else:
-            self.session = httpx2.Client(timeout=timeout, proxy=proxy, limits=DEFAULT_LIMITS)
+            self.session = httpx2.Client(
+                timeout=timeout, proxy=proxy, limits=DEFAULT_LIMITS
+            )
 
     def __str__(self) -> str:
         """String definition for HTTPProvider."""
@@ -109,8 +112,15 @@ class HTTPProvider(BaseProvider, _HTTPProviderCore):
     @overload
     def make_batch_request(self, reqs: _BodiesTup5, parsers: _Tup5) -> _RespTup5: ...
 
-    def make_batch_request(self, reqs: Tuple[Body, ...], parsers: _Tuples) -> Tuple[RPCResult, ...]:
+    def make_batch_request(
+        self, reqs: Tuple[Body, ...], parsers: _Tuples
+    ) -> Tuple[RPCResult, ...]:
         """Make a HTTP batch request to an http rpc endpoint.
+
+        .. deprecated::
+            ``make_batch_request`` is deprecated and will be removed in a future release.
+            Use individual requests with ``asyncio.gather`` (async) or sequential calls (sync) instead.
+            See https://github.com/michaelhly/solana-py/issues/645 for details.
 
         Args:
             reqs: A tuple of request objects from ``solders.rpc.requests``.
@@ -131,5 +141,12 @@ class HTTPProvider(BaseProvider, _HTTPProviderCore):
                 86753592,
             ))
         """
+        warnings.warn(
+            "make_batch_request is deprecated and will be removed in a future release. "
+            "Use individual requests instead. "
+            "See https://github.com/michaelhly/solana-py/issues/645 for details.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         raw = self.make_batch_request_unparsed(reqs)
         return _parse_raw_batch(raw, parsers)

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -1,15 +1,11 @@
 """Tests for the HTTP API Client."""
 
-from typing import Tuple
-
 import pytest
 import solders.system_program as sp
 from solders.keypair import Keypair
 from solders.message import MessageV0, Message
 from solders.pubkey import Pubkey
 from solders.rpc.errors import SendTransactionPreflightFailureMessage
-from solders.rpc.requests import GetBlockHeight, GetFirstAvailableBlock
-from solders.rpc.responses import GetBlockHeightResp, GetFirstAvailableBlockResp, Resp
 from solders.transaction import VersionedTransaction
 from spl.token.constants import WRAPPED_SOL_MINT
 
@@ -23,7 +19,9 @@ from solders.transaction import Transaction
 from ..utils import AIRDROP_AMOUNT, assert_valid_response
 
 
-async def _ensure_minimum_balance(client: AsyncClient, pubkey: Pubkey, minimum_balance: int) -> int:
+async def _ensure_minimum_balance(
+    client: AsyncClient, pubkey: Pubkey, minimum_balance: int
+) -> int:
     """Top up an account when needed and return its current balance."""
     balance_resp = await client.get_balance(pubkey)
     assert_valid_response(balance_resp)
@@ -102,8 +100,12 @@ async def test_send_transaction_and_get_balance(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
-    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
+    sender_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, sender.pubkey(), amount + 50_000
+    )
+    receiver_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, receiver, 1
+    )
     ixs = [
         sp.transfer(
             sp.TransferParams(
@@ -142,7 +144,9 @@ async def test_send_versioned_transaction_and_get_balance(
     sender_balance_before = await _ensure_minimum_balance(
         test_http_client_async, random_funded_keypair.pubkey(), amount + 50_000
     )
-    receiver_balance_before = await test_http_client_async.get_balance(receiver.pubkey())
+    receiver_balance_before = await test_http_client_async.get_balance(
+        receiver.pubkey()
+    )
     assert_valid_response(receiver_balance_before)
     transfer_ix = sp.transfer(
         sp.TransferParams(
@@ -151,7 +155,9 @@ async def test_send_versioned_transaction_and_get_balance(
             lamports=amount,
         )
     )
-    recent_blockhash = (await test_http_client_async.get_latest_blockhash()).value.blockhash
+    recent_blockhash = (
+        await test_http_client_async.get_latest_blockhash()
+    ).value.blockhash
     msg = MessageV0.try_compile(
         payer=random_funded_keypair.pubkey(),
         instructions=[transfer_ix],
@@ -169,7 +175,9 @@ async def test_send_versioned_transaction_and_get_balance(
     # Confirm transaction
     await test_http_client_async.confirm_transaction(resp.value)
     # Check balances
-    sender_balance_resp = await test_http_client_async.get_balance(random_funded_keypair.pubkey())
+    sender_balance_resp = await test_http_client_async.get_balance(
+        random_funded_keypair.pubkey()
+    )
     assert_valid_response(sender_balance_resp)
     assert sender_balance_resp.value == sender_balance_before - amount - fee_resp.value
     receiver_balance_resp = await test_http_client_async.get_balance(receiver.pubkey())
@@ -178,11 +186,15 @@ async def test_send_versioned_transaction_and_get_balance(
 
 
 @pytest.mark.integration
-async def test_send_bad_transaction(stubbed_receiver: Pubkey, test_http_client_async: AsyncClient):
+async def test_send_bad_transaction(
+    stubbed_receiver: Pubkey, test_http_client_async: AsyncClient
+):
     """Test sending a transaction that errors."""
     poor_account = Keypair()
     airdrop_amount = 1000000
-    airdrop_resp = await test_http_client_async.request_airdrop(poor_account.pubkey(), airdrop_amount)
+    airdrop_resp = await test_http_client_async.request_airdrop(
+        poor_account.pubkey(), airdrop_amount
+    )
     assert_valid_response(airdrop_resp)
     await test_http_client_async.confirm_transaction(airdrop_resp.value)
     balance = await test_http_client_async.get_balance(poor_account.pubkey())
@@ -216,8 +228,12 @@ async def test_send_transaction_prefetched_blockhash(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
-    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
+    sender_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, sender.pubkey(), amount + 50_000
+    )
+    receiver_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, receiver, 1
+    )
     blockhash = (await test_http_client_async.get_latest_blockhash()).value.blockhash
     ixs = [
         sp.transfer(
@@ -253,8 +269,12 @@ async def test_send_raw_transaction_and_get_balance(test_http_client_async):
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
-    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
+    sender_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, sender.pubkey(), amount + 50_000
+    )
+    receiver_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, receiver, 1
+    )
     resp = await test_http_client_async.get_latest_blockhash(Finalized)
     assert_valid_response(resp)
     recent_blockhash = resp.value.blockhash
@@ -298,8 +318,12 @@ async def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
-    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
+    sender_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, sender.pubkey(), amount + 50_000
+    )
+    receiver_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, receiver, 1
+    )
     resp = await test_http_client_async.get_latest_blockhash(Finalized)
     assert_valid_response(resp)
     recent_blockhash = resp.value.blockhash
@@ -331,7 +355,9 @@ async def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
     )
     assert_valid_response(resp)
     # Confirm transaction
-    resp = await test_http_client_async.confirm_transaction(resp.value, last_valid_block_height=last_valid_block_height)
+    resp = await test_http_client_async.confirm_transaction(
+        resp.value, last_valid_block_height=last_valid_block_height
+    )
     # Check balances
     resp = await test_http_client_async.get_balance(sender.pubkey())
     assert_valid_response(resp)
@@ -342,7 +368,9 @@ async def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
 
 
 @pytest.mark.integration
-async def test_confirm_expired_transaction(stubbed_sender, stubbed_receiver, test_http_client_async):
+async def test_confirm_expired_transaction(
+    stubbed_sender, stubbed_receiver, test_http_client_async
+):
     """Test that RPCException is raised when trying to confirm a transaction that exceeded last valid block height."""
     # Get a recent blockhash
     resp = await test_http_client_async.get_latest_blockhash()
@@ -377,7 +405,9 @@ async def test_confirm_expired_transaction(stubbed_sender, stubbed_receiver, tes
 
 
 @pytest.mark.integration
-async def test_get_fee_for_transaction_message(stubbed_sender, stubbed_receiver, test_http_client_async: AsyncClient):
+async def test_get_fee_for_transaction_message(
+    stubbed_sender, stubbed_receiver, test_http_client_async: AsyncClient
+):
     """Test that gets a fee for a transaction using get fee for message."""
     # Get latest blockhash
     resp = await test_http_client_async.get_latest_blockhash()
@@ -476,7 +506,9 @@ async def test_get_blocks(test_http_client_async):
 @pytest.mark.integration
 async def test_get_signatures_for_address(test_http_client_async: AsyncClient):
     """Test get signatures for addresses."""
-    resp = await test_http_client_async.get_signatures_for_address(VOTE_PROGRAM_ID, limit=1, commitment=Confirmed)
+    resp = await test_http_client_async.get_signatures_for_address(
+        VOTE_PROGRAM_ID, limit=1, commitment=Confirmed
+    )
     assert_valid_response(resp)
 
 
@@ -550,7 +582,9 @@ async def test_get_inflation_rate(test_http_client_async):
 @pytest.mark.integration
 async def test_get_inflation_reward(stubbed_sender, test_http_client_async):
     """Test get inflation reward."""
-    resp = await test_http_client_async.get_inflation_reward([stubbed_sender.pubkey()], commitment=Confirmed)
+    resp = await test_http_client_async.get_inflation_reward(
+        [stubbed_sender.pubkey()], commitment=Confirmed
+    )
     assert_valid_response(resp)
 
 
@@ -622,9 +656,13 @@ async def test_get_account_info(async_stubbed_sender, test_http_client_async):
     """Test get_account_info."""
     resp = await test_http_client_async.get_account_info(async_stubbed_sender.pubkey())
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_account_info(async_stubbed_sender.pubkey(), encoding="jsonParsed")
+    resp = await test_http_client_async.get_account_info(
+        async_stubbed_sender.pubkey(), encoding="jsonParsed"
+    )
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_account_info(async_stubbed_sender.pubkey(), data_slice=DataSliceOpts(1, 1))
+    resp = await test_http_client_async.get_account_info(
+        async_stubbed_sender.pubkey(), data_slice=DataSliceOpts(1, 1)
+    )
     assert_valid_response(resp)
 
 
@@ -634,9 +672,13 @@ async def test_get_multiple_accounts(async_stubbed_sender, test_http_client_asyn
     pubkeys = [async_stubbed_sender.pubkey()] * 2
     resp = await test_http_client_async.get_multiple_accounts(pubkeys)
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_multiple_accounts(pubkeys, encoding="jsonParsed")
+    resp = await test_http_client_async.get_multiple_accounts(
+        pubkeys, encoding="jsonParsed"
+    )
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_multiple_accounts(pubkeys, data_slice=DataSliceOpts(1, 1))
+    resp = await test_http_client_async.get_multiple_accounts(
+        pubkeys, data_slice=DataSliceOpts(1, 1)
+    )
     assert_valid_response(resp)
 
 
@@ -645,17 +687,3 @@ async def test_get_vote_accounts(test_http_client_async):
     """Test get vote accounts."""
     resp = await test_http_client_async.get_vote_accounts()
     assert_valid_response(resp)
-
-
-@pytest.mark.integration
-async def test_batch_request(test_http_client_async: AsyncClient):
-    """Test get vote accounts."""
-    reqs = (GetBlockHeight(), GetFirstAvailableBlock())
-    parsers = (GetBlockHeightResp, GetFirstAvailableBlockResp)
-    resp: Tuple[
-        Resp[GetBlockHeightResp], Resp[GetFirstAvailableBlockResp]
-    ] = await test_http_client_async._provider.make_batch_request(  # pylint: disable=protected-access
-        reqs, parsers
-    )
-    assert_valid_response(resp[0])
-    assert_valid_response(resp[1])

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -19,9 +19,7 @@ from solders.transaction import Transaction
 from ..utils import AIRDROP_AMOUNT, assert_valid_response
 
 
-async def _ensure_minimum_balance(
-    client: AsyncClient, pubkey: Pubkey, minimum_balance: int
-) -> int:
+async def _ensure_minimum_balance(client: AsyncClient, pubkey: Pubkey, minimum_balance: int) -> int:
     """Top up an account when needed and return its current balance."""
     balance_resp = await client.get_balance(pubkey)
     assert_valid_response(balance_resp)
@@ -100,12 +98,8 @@ async def test_send_transaction_and_get_balance(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, sender.pubkey(), amount + 50_000
-    )
-    receiver_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, receiver, 1
-    )
+    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
+    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
     ixs = [
         sp.transfer(
             sp.TransferParams(
@@ -144,9 +138,7 @@ async def test_send_versioned_transaction_and_get_balance(
     sender_balance_before = await _ensure_minimum_balance(
         test_http_client_async, random_funded_keypair.pubkey(), amount + 50_000
     )
-    receiver_balance_before = await test_http_client_async.get_balance(
-        receiver.pubkey()
-    )
+    receiver_balance_before = await test_http_client_async.get_balance(receiver.pubkey())
     assert_valid_response(receiver_balance_before)
     transfer_ix = sp.transfer(
         sp.TransferParams(
@@ -155,9 +147,7 @@ async def test_send_versioned_transaction_and_get_balance(
             lamports=amount,
         )
     )
-    recent_blockhash = (
-        await test_http_client_async.get_latest_blockhash()
-    ).value.blockhash
+    recent_blockhash = (await test_http_client_async.get_latest_blockhash()).value.blockhash
     msg = MessageV0.try_compile(
         payer=random_funded_keypair.pubkey(),
         instructions=[transfer_ix],
@@ -175,9 +165,7 @@ async def test_send_versioned_transaction_and_get_balance(
     # Confirm transaction
     await test_http_client_async.confirm_transaction(resp.value)
     # Check balances
-    sender_balance_resp = await test_http_client_async.get_balance(
-        random_funded_keypair.pubkey()
-    )
+    sender_balance_resp = await test_http_client_async.get_balance(random_funded_keypair.pubkey())
     assert_valid_response(sender_balance_resp)
     assert sender_balance_resp.value == sender_balance_before - amount - fee_resp.value
     receiver_balance_resp = await test_http_client_async.get_balance(receiver.pubkey())
@@ -186,15 +174,11 @@ async def test_send_versioned_transaction_and_get_balance(
 
 
 @pytest.mark.integration
-async def test_send_bad_transaction(
-    stubbed_receiver: Pubkey, test_http_client_async: AsyncClient
-):
+async def test_send_bad_transaction(stubbed_receiver: Pubkey, test_http_client_async: AsyncClient):
     """Test sending a transaction that errors."""
     poor_account = Keypair()
     airdrop_amount = 1000000
-    airdrop_resp = await test_http_client_async.request_airdrop(
-        poor_account.pubkey(), airdrop_amount
-    )
+    airdrop_resp = await test_http_client_async.request_airdrop(poor_account.pubkey(), airdrop_amount)
     assert_valid_response(airdrop_resp)
     await test_http_client_async.confirm_transaction(airdrop_resp.value)
     balance = await test_http_client_async.get_balance(poor_account.pubkey())
@@ -228,12 +212,8 @@ async def test_send_transaction_prefetched_blockhash(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, sender.pubkey(), amount + 50_000
-    )
-    receiver_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, receiver, 1
-    )
+    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
+    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
     blockhash = (await test_http_client_async.get_latest_blockhash()).value.blockhash
     ixs = [
         sp.transfer(
@@ -269,12 +249,8 @@ async def test_send_raw_transaction_and_get_balance(test_http_client_async):
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, sender.pubkey(), amount + 50_000
-    )
-    receiver_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, receiver, 1
-    )
+    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
+    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
     resp = await test_http_client_async.get_latest_blockhash(Finalized)
     assert_valid_response(resp)
     recent_blockhash = resp.value.blockhash
@@ -318,12 +294,8 @@ async def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, sender.pubkey(), amount + 50_000
-    )
-    receiver_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, receiver, 1
-    )
+    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
+    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
     resp = await test_http_client_async.get_latest_blockhash(Finalized)
     assert_valid_response(resp)
     recent_blockhash = resp.value.blockhash
@@ -355,9 +327,7 @@ async def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
     )
     assert_valid_response(resp)
     # Confirm transaction
-    resp = await test_http_client_async.confirm_transaction(
-        resp.value, last_valid_block_height=last_valid_block_height
-    )
+    resp = await test_http_client_async.confirm_transaction(resp.value, last_valid_block_height=last_valid_block_height)
     # Check balances
     resp = await test_http_client_async.get_balance(sender.pubkey())
     assert_valid_response(resp)
@@ -368,9 +338,7 @@ async def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
 
 
 @pytest.mark.integration
-async def test_confirm_expired_transaction(
-    stubbed_sender, stubbed_receiver, test_http_client_async
-):
+async def test_confirm_expired_transaction(stubbed_sender, stubbed_receiver, test_http_client_async):
     """Test that RPCException is raised when trying to confirm a transaction that exceeded last valid block height."""
     # Get a recent blockhash
     resp = await test_http_client_async.get_latest_blockhash()
@@ -405,9 +373,7 @@ async def test_confirm_expired_transaction(
 
 
 @pytest.mark.integration
-async def test_get_fee_for_transaction_message(
-    stubbed_sender, stubbed_receiver, test_http_client_async: AsyncClient
-):
+async def test_get_fee_for_transaction_message(stubbed_sender, stubbed_receiver, test_http_client_async: AsyncClient):
     """Test that gets a fee for a transaction using get fee for message."""
     # Get latest blockhash
     resp = await test_http_client_async.get_latest_blockhash()
@@ -506,9 +472,7 @@ async def test_get_blocks(test_http_client_async):
 @pytest.mark.integration
 async def test_get_signatures_for_address(test_http_client_async: AsyncClient):
     """Test get signatures for addresses."""
-    resp = await test_http_client_async.get_signatures_for_address(
-        VOTE_PROGRAM_ID, limit=1, commitment=Confirmed
-    )
+    resp = await test_http_client_async.get_signatures_for_address(VOTE_PROGRAM_ID, limit=1, commitment=Confirmed)
     assert_valid_response(resp)
 
 
@@ -582,9 +546,7 @@ async def test_get_inflation_rate(test_http_client_async):
 @pytest.mark.integration
 async def test_get_inflation_reward(stubbed_sender, test_http_client_async):
     """Test get inflation reward."""
-    resp = await test_http_client_async.get_inflation_reward(
-        [stubbed_sender.pubkey()], commitment=Confirmed
-    )
+    resp = await test_http_client_async.get_inflation_reward([stubbed_sender.pubkey()], commitment=Confirmed)
     assert_valid_response(resp)
 
 
@@ -656,13 +618,9 @@ async def test_get_account_info(async_stubbed_sender, test_http_client_async):
     """Test get_account_info."""
     resp = await test_http_client_async.get_account_info(async_stubbed_sender.pubkey())
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_account_info(
-        async_stubbed_sender.pubkey(), encoding="jsonParsed"
-    )
+    resp = await test_http_client_async.get_account_info(async_stubbed_sender.pubkey(), encoding="jsonParsed")
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_account_info(
-        async_stubbed_sender.pubkey(), data_slice=DataSliceOpts(1, 1)
-    )
+    resp = await test_http_client_async.get_account_info(async_stubbed_sender.pubkey(), data_slice=DataSliceOpts(1, 1))
     assert_valid_response(resp)
 
 
@@ -672,13 +630,9 @@ async def test_get_multiple_accounts(async_stubbed_sender, test_http_client_asyn
     pubkeys = [async_stubbed_sender.pubkey()] * 2
     resp = await test_http_client_async.get_multiple_accounts(pubkeys)
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_multiple_accounts(
-        pubkeys, encoding="jsonParsed"
-    )
+    resp = await test_http_client_async.get_multiple_accounts(pubkeys, encoding="jsonParsed")
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_multiple_accounts(
-        pubkeys, data_slice=DataSliceOpts(1, 1)
-    )
+    resp = await test_http_client_async.get_multiple_accounts(pubkeys, data_slice=DataSliceOpts(1, 1))
     assert_valid_response(resp)
 
 

--- a/tests/integration/test_http_client.py
+++ b/tests/integration/test_http_client.py
@@ -19,9 +19,7 @@ from spl.token.constants import WRAPPED_SOL_MINT
 from ..utils import AIRDROP_AMOUNT, assert_valid_response
 
 
-def _ensure_minimum_balance(
-    client: Client, pubkey: Pubkey, minimum_balance: int
-) -> int:
+def _ensure_minimum_balance(client: Client, pubkey: Pubkey, minimum_balance: int) -> int:
     """Top up an account when needed and return its current balance."""
     balance_resp = client.get_balance(pubkey)
     assert_valid_response(balance_resp)
@@ -96,9 +94,7 @@ def test_send_transaction_and_get_balance(test_http_client: Client):
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = _ensure_minimum_balance(
-        test_http_client, sender.pubkey(), amount + 50_000
-    )
+    sender_balance_before = _ensure_minimum_balance(test_http_client, sender.pubkey(), amount + 50_000)
     receiver_balance_before = _ensure_minimum_balance(test_http_client, receiver, 1)
     blockhash = test_http_client.get_latest_blockhash().value.blockhash
     ixs = [
@@ -131,15 +127,11 @@ def test_send_transaction_and_get_balance(test_http_client: Client):
 
 
 @pytest.mark.integration
-def test_send_versioned_transaction_and_get_balance(
-    random_funded_keypair: Keypair, test_http_client: Client
-):
+def test_send_versioned_transaction_and_get_balance(random_funded_keypair: Keypair, test_http_client: Client):
     """Test sending a transaction to localnet."""
     receiver = Keypair()
     amount = 1_000_000
-    sender_balance_before = _ensure_minimum_balance(
-        test_http_client, random_funded_keypair.pubkey(), amount + 50_000
-    )
+    sender_balance_before = _ensure_minimum_balance(test_http_client, random_funded_keypair.pubkey(), amount + 50_000)
     receiver_balance_before = test_http_client.get_balance(receiver.pubkey())
     assert_valid_response(receiver_balance_before)
     transfer_ix = sp.transfer(
@@ -178,9 +170,7 @@ def test_send_bad_transaction(stubbed_receiver: Pubkey, test_http_client: Client
     """Test sending a transaction that errors."""
     poor_account = Keypair()
     airdrop_amount = 1000000
-    airdrop_resp = test_http_client.request_airdrop(
-        poor_account.pubkey(), airdrop_amount
-    )
+    airdrop_resp = test_http_client.request_airdrop(poor_account.pubkey(), airdrop_amount)
     assert_valid_response(airdrop_resp)
     test_http_client.confirm_transaction(airdrop_resp.value)
     balance = test_http_client.get_balance(poor_account.pubkey())
@@ -214,13 +204,9 @@ def test_send_transaction_prefetched_blockhash(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = _ensure_minimum_balance(
-        test_http_client, sender.pubkey(), amount + 50_000
-    )
+    sender_balance_before = _ensure_minimum_balance(test_http_client, sender.pubkey(), amount + 50_000)
     receiver_balance_before = _ensure_minimum_balance(test_http_client, receiver, 1)
-    recent_blockhash = test_http_client.parse_recent_blockhash(
-        test_http_client.get_latest_blockhash()
-    )
+    recent_blockhash = test_http_client.parse_recent_blockhash(test_http_client.get_latest_blockhash())
     ixs = [
         sp.transfer(
             sp.TransferParams(
@@ -255,9 +241,7 @@ def test_send_raw_transaction_and_get_balance(test_http_client: Client):
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = _ensure_minimum_balance(
-        test_http_client, sender.pubkey(), amount + 50_000
-    )
+    sender_balance_before = _ensure_minimum_balance(test_http_client, sender.pubkey(), amount + 50_000)
     receiver_balance_before = _ensure_minimum_balance(test_http_client, receiver, 1)
     resp = test_http_client.get_latest_blockhash()
     assert_valid_response(resp)
@@ -302,9 +286,7 @@ def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = _ensure_minimum_balance(
-        test_http_client, sender.pubkey(), amount + 50_000
-    )
+    sender_balance_before = _ensure_minimum_balance(test_http_client, sender.pubkey(), amount + 50_000)
     receiver_balance_before = _ensure_minimum_balance(test_http_client, receiver, 1)
     resp = test_http_client.get_latest_blockhash(Finalized)
     assert_valid_response(resp)
@@ -337,9 +319,7 @@ def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
     )
     assert_valid_response(resp)
     # Confirm transaction
-    test_http_client.confirm_transaction(
-        resp.value, last_valid_block_height=last_valid_block_height
-    )
+    test_http_client.confirm_transaction(resp.value, last_valid_block_height=last_valid_block_height)
     # Check balances
     resp = test_http_client.get_balance(sender.pubkey())
     assert_valid_response(resp)
@@ -350,9 +330,7 @@ def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
 
 
 @pytest.mark.integration
-def test_confirm_expired_transaction(
-    stubbed_sender, stubbed_receiver, test_http_client: Client
-):
+def test_confirm_expired_transaction(stubbed_sender, stubbed_receiver, test_http_client: Client):
     """Test that RPCException is raised when trying to confirm a transaction that exceeded last valid block height."""
     # Get a recent blockhash
     resp = test_http_client.get_latest_blockhash()
@@ -378,17 +356,13 @@ def test_confirm_expired_transaction(
     assert_valid_response(tx_resp)
     # Confirm transaction
     with pytest.raises(TransactionExpiredBlockheightExceededError) as exc_info:
-        test_http_client.confirm_transaction(
-            tx_resp.value, Finalized, last_valid_block_height=last_valid_block_height
-        )
+        test_http_client.confirm_transaction(tx_resp.value, Finalized, last_valid_block_height=last_valid_block_height)
     err_object = exc_info.value.args[0]
     assert "block height exceeded" in err_object
 
 
 @pytest.mark.integration
-def test_get_fee_for_transaction(
-    stubbed_sender, stubbed_receiver, test_http_client: Client
-):
+def test_get_fee_for_transaction(stubbed_sender, stubbed_receiver, test_http_client: Client):
     """Test that gets a fee for a transaction using get_fee_for_message."""
     # Get a recent blockhash
     resp = test_http_client.get_latest_blockhash()
@@ -412,9 +386,7 @@ def test_get_fee_for_transaction(
 
 
 @pytest.mark.integration
-def test_get_fee_for_versioned_message(
-    stubbed_sender: Keypair, stubbed_receiver: Pubkey, test_http_client: Client
-):
+def test_get_fee_for_versioned_message(stubbed_sender: Keypair, stubbed_receiver: Pubkey, test_http_client: Client):
     """Test that gets a fee for a transaction using get_fee_for_message."""
     # Get a recent blockhash
     resp = test_http_client.get_latest_blockhash()
@@ -492,9 +464,7 @@ def test_get_blocks(test_http_client: Client):
 @pytest.mark.integration
 def test_get_signatures_for_address(test_http_client: Client):
     """Test get signatures for addresses."""
-    resp = test_http_client.get_signatures_for_address(
-        VOTE_PROGRAM_ID, limit=1, commitment=Confirmed
-    )
+    resp = test_http_client.get_signatures_for_address(VOTE_PROGRAM_ID, limit=1, commitment=Confirmed)
     assert_valid_response(resp)
 
 
@@ -568,9 +538,7 @@ def test_get_inflation_rate(test_http_client: Client):
 @pytest.mark.integration
 def test_get_inflation_reward(stubbed_sender, test_http_client: Client):
     """Test get inflation reward."""
-    resp = test_http_client.get_inflation_reward(
-        [stubbed_sender.pubkey()], commitment=Confirmed
-    )
+    resp = test_http_client.get_inflation_reward([stubbed_sender.pubkey()], commitment=Confirmed)
     assert_valid_response(resp)
 
 
@@ -628,13 +596,9 @@ def test_get_account_info(stubbed_sender, test_http_client: Client):
     """Test get_account_info."""
     resp = test_http_client.get_account_info(stubbed_sender.pubkey())
     assert_valid_response(resp)
-    resp = test_http_client.get_account_info(
-        stubbed_sender.pubkey(), encoding="jsonParsed"
-    )
+    resp = test_http_client.get_account_info(stubbed_sender.pubkey(), encoding="jsonParsed")
     assert_valid_response(resp)
-    resp = test_http_client.get_account_info(
-        stubbed_sender.pubkey(), data_slice=DataSliceOpts(1, 1)
-    )
+    resp = test_http_client.get_account_info(stubbed_sender.pubkey(), data_slice=DataSliceOpts(1, 1))
     assert_valid_response(resp)
 
 
@@ -646,9 +610,7 @@ def test_get_multiple_accounts(stubbed_sender, test_http_client: Client):
     assert_valid_response(resp)
     resp = test_http_client.get_multiple_accounts(pubkeys, encoding="jsonParsed")
     assert_valid_response(resp)
-    resp = test_http_client.get_multiple_accounts(
-        pubkeys, data_slice=DataSliceOpts(1, 1)
-    )
+    resp = test_http_client.get_multiple_accounts(pubkeys, data_slice=DataSliceOpts(1, 1))
     assert_valid_response(resp)
 
 

--- a/tests/integration/test_http_client.py
+++ b/tests/integration/test_http_client.py
@@ -1,15 +1,11 @@
 """Tests for the HTTP API Client."""
 
-from typing import Tuple
-
 import pytest
 import solders.system_program as sp
 from solders.keypair import Keypair
 from solders.message import MessageV0, Message
 from solders.pubkey import Pubkey
 from solders.rpc.errors import SendTransactionPreflightFailureMessage
-from solders.rpc.requests import GetBlockHeight, GetFirstAvailableBlock
-from solders.rpc.responses import GetBlockHeightResp, GetFirstAvailableBlockResp, Resp
 from solders.transaction import VersionedTransaction
 
 from solana.constants import VOTE_PROGRAM_ID
@@ -23,7 +19,9 @@ from spl.token.constants import WRAPPED_SOL_MINT
 from ..utils import AIRDROP_AMOUNT, assert_valid_response
 
 
-def _ensure_minimum_balance(client: Client, pubkey: Pubkey, minimum_balance: int) -> int:
+def _ensure_minimum_balance(
+    client: Client, pubkey: Pubkey, minimum_balance: int
+) -> int:
     """Top up an account when needed and return its current balance."""
     balance_resp = client.get_balance(pubkey)
     assert_valid_response(balance_resp)
@@ -98,7 +96,9 @@ def test_send_transaction_and_get_balance(test_http_client: Client):
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = _ensure_minimum_balance(test_http_client, sender.pubkey(), amount + 50_000)
+    sender_balance_before = _ensure_minimum_balance(
+        test_http_client, sender.pubkey(), amount + 50_000
+    )
     receiver_balance_before = _ensure_minimum_balance(test_http_client, receiver, 1)
     blockhash = test_http_client.get_latest_blockhash().value.blockhash
     ixs = [
@@ -131,11 +131,15 @@ def test_send_transaction_and_get_balance(test_http_client: Client):
 
 
 @pytest.mark.integration
-def test_send_versioned_transaction_and_get_balance(random_funded_keypair: Keypair, test_http_client: Client):
+def test_send_versioned_transaction_and_get_balance(
+    random_funded_keypair: Keypair, test_http_client: Client
+):
     """Test sending a transaction to localnet."""
     receiver = Keypair()
     amount = 1_000_000
-    sender_balance_before = _ensure_minimum_balance(test_http_client, random_funded_keypair.pubkey(), amount + 50_000)
+    sender_balance_before = _ensure_minimum_balance(
+        test_http_client, random_funded_keypair.pubkey(), amount + 50_000
+    )
     receiver_balance_before = test_http_client.get_balance(receiver.pubkey())
     assert_valid_response(receiver_balance_before)
     transfer_ix = sp.transfer(
@@ -174,7 +178,9 @@ def test_send_bad_transaction(stubbed_receiver: Pubkey, test_http_client: Client
     """Test sending a transaction that errors."""
     poor_account = Keypair()
     airdrop_amount = 1000000
-    airdrop_resp = test_http_client.request_airdrop(poor_account.pubkey(), airdrop_amount)
+    airdrop_resp = test_http_client.request_airdrop(
+        poor_account.pubkey(), airdrop_amount
+    )
     assert_valid_response(airdrop_resp)
     test_http_client.confirm_transaction(airdrop_resp.value)
     balance = test_http_client.get_balance(poor_account.pubkey())
@@ -208,9 +214,13 @@ def test_send_transaction_prefetched_blockhash(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = _ensure_minimum_balance(test_http_client, sender.pubkey(), amount + 50_000)
+    sender_balance_before = _ensure_minimum_balance(
+        test_http_client, sender.pubkey(), amount + 50_000
+    )
     receiver_balance_before = _ensure_minimum_balance(test_http_client, receiver, 1)
-    recent_blockhash = test_http_client.parse_recent_blockhash(test_http_client.get_latest_blockhash())
+    recent_blockhash = test_http_client.parse_recent_blockhash(
+        test_http_client.get_latest_blockhash()
+    )
     ixs = [
         sp.transfer(
             sp.TransferParams(
@@ -245,7 +255,9 @@ def test_send_raw_transaction_and_get_balance(test_http_client: Client):
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = _ensure_minimum_balance(test_http_client, sender.pubkey(), amount + 50_000)
+    sender_balance_before = _ensure_minimum_balance(
+        test_http_client, sender.pubkey(), amount + 50_000
+    )
     receiver_balance_before = _ensure_minimum_balance(test_http_client, receiver, 1)
     resp = test_http_client.get_latest_blockhash()
     assert_valid_response(resp)
@@ -290,7 +302,9 @@ def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = _ensure_minimum_balance(test_http_client, sender.pubkey(), amount + 50_000)
+    sender_balance_before = _ensure_minimum_balance(
+        test_http_client, sender.pubkey(), amount + 50_000
+    )
     receiver_balance_before = _ensure_minimum_balance(test_http_client, receiver, 1)
     resp = test_http_client.get_latest_blockhash(Finalized)
     assert_valid_response(resp)
@@ -323,7 +337,9 @@ def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
     )
     assert_valid_response(resp)
     # Confirm transaction
-    test_http_client.confirm_transaction(resp.value, last_valid_block_height=last_valid_block_height)
+    test_http_client.confirm_transaction(
+        resp.value, last_valid_block_height=last_valid_block_height
+    )
     # Check balances
     resp = test_http_client.get_balance(sender.pubkey())
     assert_valid_response(resp)
@@ -334,7 +350,9 @@ def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
 
 
 @pytest.mark.integration
-def test_confirm_expired_transaction(stubbed_sender, stubbed_receiver, test_http_client: Client):
+def test_confirm_expired_transaction(
+    stubbed_sender, stubbed_receiver, test_http_client: Client
+):
     """Test that RPCException is raised when trying to confirm a transaction that exceeded last valid block height."""
     # Get a recent blockhash
     resp = test_http_client.get_latest_blockhash()
@@ -360,13 +378,17 @@ def test_confirm_expired_transaction(stubbed_sender, stubbed_receiver, test_http
     assert_valid_response(tx_resp)
     # Confirm transaction
     with pytest.raises(TransactionExpiredBlockheightExceededError) as exc_info:
-        test_http_client.confirm_transaction(tx_resp.value, Finalized, last_valid_block_height=last_valid_block_height)
+        test_http_client.confirm_transaction(
+            tx_resp.value, Finalized, last_valid_block_height=last_valid_block_height
+        )
     err_object = exc_info.value.args[0]
     assert "block height exceeded" in err_object
 
 
 @pytest.mark.integration
-def test_get_fee_for_transaction(stubbed_sender, stubbed_receiver, test_http_client: Client):
+def test_get_fee_for_transaction(
+    stubbed_sender, stubbed_receiver, test_http_client: Client
+):
     """Test that gets a fee for a transaction using get_fee_for_message."""
     # Get a recent blockhash
     resp = test_http_client.get_latest_blockhash()
@@ -390,7 +412,9 @@ def test_get_fee_for_transaction(stubbed_sender, stubbed_receiver, test_http_cli
 
 
 @pytest.mark.integration
-def test_get_fee_for_versioned_message(stubbed_sender: Keypair, stubbed_receiver: Pubkey, test_http_client: Client):
+def test_get_fee_for_versioned_message(
+    stubbed_sender: Keypair, stubbed_receiver: Pubkey, test_http_client: Client
+):
     """Test that gets a fee for a transaction using get_fee_for_message."""
     # Get a recent blockhash
     resp = test_http_client.get_latest_blockhash()
@@ -468,7 +492,9 @@ def test_get_blocks(test_http_client: Client):
 @pytest.mark.integration
 def test_get_signatures_for_address(test_http_client: Client):
     """Test get signatures for addresses."""
-    resp = test_http_client.get_signatures_for_address(VOTE_PROGRAM_ID, limit=1, commitment=Confirmed)
+    resp = test_http_client.get_signatures_for_address(
+        VOTE_PROGRAM_ID, limit=1, commitment=Confirmed
+    )
     assert_valid_response(resp)
 
 
@@ -542,7 +568,9 @@ def test_get_inflation_rate(test_http_client: Client):
 @pytest.mark.integration
 def test_get_inflation_reward(stubbed_sender, test_http_client: Client):
     """Test get inflation reward."""
-    resp = test_http_client.get_inflation_reward([stubbed_sender.pubkey()], commitment=Confirmed)
+    resp = test_http_client.get_inflation_reward(
+        [stubbed_sender.pubkey()], commitment=Confirmed
+    )
     assert_valid_response(resp)
 
 
@@ -600,9 +628,13 @@ def test_get_account_info(stubbed_sender, test_http_client: Client):
     """Test get_account_info."""
     resp = test_http_client.get_account_info(stubbed_sender.pubkey())
     assert_valid_response(resp)
-    resp = test_http_client.get_account_info(stubbed_sender.pubkey(), encoding="jsonParsed")
+    resp = test_http_client.get_account_info(
+        stubbed_sender.pubkey(), encoding="jsonParsed"
+    )
     assert_valid_response(resp)
-    resp = test_http_client.get_account_info(stubbed_sender.pubkey(), data_slice=DataSliceOpts(1, 1))
+    resp = test_http_client.get_account_info(
+        stubbed_sender.pubkey(), data_slice=DataSliceOpts(1, 1)
+    )
     assert_valid_response(resp)
 
 
@@ -614,7 +646,9 @@ def test_get_multiple_accounts(stubbed_sender, test_http_client: Client):
     assert_valid_response(resp)
     resp = test_http_client.get_multiple_accounts(pubkeys, encoding="jsonParsed")
     assert_valid_response(resp)
-    resp = test_http_client.get_multiple_accounts(pubkeys, data_slice=DataSliceOpts(1, 1))
+    resp = test_http_client.get_multiple_accounts(
+        pubkeys, data_slice=DataSliceOpts(1, 1)
+    )
     assert_valid_response(resp)
 
 
@@ -637,17 +671,3 @@ def test_get_vote_accounts(test_http_client: Client):
     """Test get vote accounts."""
     resp = test_http_client.get_vote_accounts()
     assert_valid_response(resp)
-
-
-@pytest.mark.integration
-def test_batch_request(test_http_client: Client):
-    """Test get vote accounts."""
-    reqs = (GetBlockHeight(), GetFirstAvailableBlock())
-    parsers = (GetBlockHeightResp, GetFirstAvailableBlockResp)
-    resp: Tuple[Resp[GetBlockHeightResp], Resp[GetFirstAvailableBlockResp]] = (
-        test_http_client._provider.make_batch_request(  # pylint: disable=protected-access
-            reqs, parsers
-        )
-    )
-    assert_valid_response(resp[0])
-    assert_valid_response(resp[1])


### PR DESCRIPTION
This pull request focuses on deprecating the `make_batch_request` method in both the asynchronous and synchronous Solana HTTP providers, and cleans up related integration tests. The main changes include adding deprecation warnings and documentation, as well as removing the batch request integration test. Additionally, there are numerous code style improvements in the test files for better readability.

**Deprecation of batch request functionality:**

* Added deprecation warnings and documentation to the `make_batch_request` methods in both `src/solana/rpc/providers/async_http.py` and `src/solana/rpc/providers/http.py`, informing users that these methods will be removed in a future release and suggesting alternatives. 

**Test suite cleanup:**

* Removed the batch request integration test from `tests/integration/test_async_http_client.py`, reflecting the deprecation of the feature.

**Code style and readability improvements:**

* Reformatted function signatures and calls in integration tests to improve readability, especially for functions with many arguments. 
* Removed unused imports from test files. 
* Applied consistent formatting to helper functions in test files. 

#645 Phase 1