### PR TITLE
Add Python version classifiers to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,13 @@
 name = "solana"
 version = "0.37.0"
 requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
 dependencies = [
     "construct-typing>=0.6.2,<0.8.0",
     "typing-extensions>=4.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "construct-typing>=0.6.2,<0.8.0",


### PR DESCRIPTION
Restore the trove classifiers that control the supported Python versions shown on PyPI. These were dropped during the hatchling migration, so the PyPI page only reflected metadata from an older release.