### PR TITLE
Fix flaky test_multiple_subscriptions by confirming airdrop

### DIFF
--- a/tests/integration/test_websockets.py
+++ b/tests/integration/test_websockets.py
@@ -238,7 +238,7 @@ async def test_multiple_subscriptions(
     websocket: SolanaWsClientProtocol,
 ):
     """Test subscribing to multiple feeds."""
-    await test_http_client_async.request_airdrop(stubbed_sender_for_websockets.pubkey(), AIRDROP_AMOUNT)
+    airdrop_resp = await test_http_client_async.request_airdrop(stubbed_sender_for_websockets.pubkey(), AIRDROP_AMOUNT)
     async for idx, message in asyncstdlib.enumerate(websocket):
         for item in message:
             if isinstance(item, (AccountNotification, LogsNotification)):
@@ -247,6 +247,7 @@ async def test_multiple_subscriptions(
                 raise ValueError(f"Unexpected message for this test: {item}")
         if idx == len(multiple_subscriptions) - 1:
             break
+    await test_http_client_async.confirm_transaction(airdrop_resp.value, Finalized)
     balance = await test_http_client_async.get_balance(stubbed_sender_for_websockets.pubkey(), Finalized)
     assert balance.value == AIRDROP_AMOUNT
 


### PR DESCRIPTION
## Summary

Fixes the intermittent failure in `test_multiple_subscriptions`:

```
assert balance.value == AIRDROP_AMOUNT
E  assert 0 == 10000000000
```

The test requested an airdrop and then waited only for the websocket subscription notifications to arrive before asserting the balance with `Finalized` commitment. Those notifications can fire before the airdrop transaction reaches the finalized bank state, so the finalized balance read could still return `0`.

The fix captures the airdrop response and explicitly waits for finalization before reading the balance, mirroring the existing `request_airdrop` → `confirm_transaction` pattern already used in the `account_subscribed` fixture.

## Test plan

- [ ] CI integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)