### PR TITLE
Quality: Typo in docstring: 'ot' instead of 'to'

### DIFF
--- a/src/solana/rpc/providers/async_base.py
+++ b/src/solana/rpc/providers/async_base.py
@@ -12,5 +12,5 @@ class AsyncBaseProvider:
     """Base class for async RPC providers to implement."""
 
     def make_request(self, body: Body, parser: type[T]) -> Coroutine[Any, Any, T]:
-        """Make a request ot the rpc endpoint."""
+        """Make a request to the rpc endpoint."""
         raise NotImplementedError("Providers must implement this method")


### PR DESCRIPTION
## Summary

Quality: Typo in docstring: 'ot' instead of 'to'

## Problem

**Severity**: `Low` | **File**: `src/solana/rpc/providers/async_base.py:L16`

In the docstring for `AsyncBaseProvider.make_request`, the word 'to' is misspelled as 'ot' in 'Make a request ot the rpc endpoint.'

## Solution

Fix the typo: change 'ot' to 'to' in the docstring.

## Changes

- `src/solana/rpc/providers/async_base.py` (modified)