### PR TITLE
Add Rate limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,23 +16,24 @@ dependencies = [
     "websockets>=14.0",
     "solders>=0.23,<0.28",
     "httpx2[http2]>=2.4.0",
+    "aiolimiter>=1.1.0",
 ]
 
 [dependency-groups]
 dev = [
-    "pytest>=8.4.2",
-    "mypy>=1.19",
-    "pyyaml>=6.0.2",
+    "pytest>=9.1.1",
+    "mypy>=2.1",
+    "pyyaml>=6.0.3",
     "bump2version>=1.0.1",
-    "pytest-asyncio>=0.18.3",
+    "pytest-asyncio>=1.4.0",
     "pytest-cov>=7.1.0",
     "pytest-html>=4.2.0",
-    "pytest-xdist>=3.6.1",
+    "pytest-xdist>=3.8.0",
     "asyncstdlib>=3.14.0",
-    "mkdocstrings>=0.18.0",
-    "mkdocstrings-python>=0.14.0",
+    "mkdocstrings>=1.0.4",
+    "mkdocstrings-python>=2.0.5",
     "mkdocs-material>=9.7.6",
-    "ruff>=0.7.3",
+    "ruff>=0.15.18",
 ]
 
 [build-system]

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -86,6 +86,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         timeout: HTTP request timeout in seconds.
         extra_headers: Extra headers to pass for HTTP request.
         proxy: Proxy URL to pass to the HTTP client.
+        rate_limit: Maximum requests per second. ``0`` (default) disables rate limiting.
     """
 
     def __init__(
@@ -95,11 +96,16 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         timeout: float = 10,
         extra_headers: Optional[Dict[str, str]] = None,
         proxy: Optional[str] = None,
+        rate_limit: float = 0,
     ) -> None:
         """Init API client."""
         super().__init__(commitment)
         self._provider = async_http.AsyncHTTPProvider(
-            endpoint, timeout=timeout, extra_headers=extra_headers, proxy=proxy
+            endpoint,
+            timeout=timeout,
+            extra_headers=extra_headers,
+            proxy=proxy,
+            rate_limit=rate_limit,
         )
 
     async def __aenter__(self) -> "AsyncClient":

--- a/src/solana/rpc/providers/async_http.py
+++ b/src/solana/rpc/providers/async_http.py
@@ -6,6 +6,7 @@ import warnings
 from typing import Dict, Optional, Tuple, Type, overload
 
 import httpx2
+from aiolimiter import AsyncLimiter
 from solders.rpc.requests import Body
 from solders.rpc.responses import RPCResult
 
@@ -50,8 +51,17 @@ class AsyncHTTPProvider(AsyncBaseProvider, _HTTPProviderCore):
         extra_headers: Optional[Dict[str, str]] = None,
         timeout: float = DEFAULT_TIMEOUT,
         proxy: Optional[str] = None,
+        rate_limit: float = 0,
     ):
-        """Init AsyncHTTPProvider."""
+        """Init AsyncHTTPProvider.
+
+        Args:
+            endpoint: URL of the RPC endpoint.
+            extra_headers: Extra headers to pass for HTTP request.
+            timeout: HTTP request timeout in seconds.
+            proxy: Proxy URL to pass to the HTTP client.
+            rate_limit: Maximum requests per second. ``0`` (default) disables rate limiting.
+        """
         super().__init__(endpoint, extra_headers)
         if proxy is None:
             self.session = httpx2.AsyncClient(
@@ -60,6 +70,7 @@ class AsyncHTTPProvider(AsyncBaseProvider, _HTTPProviderCore):
             )
         else:
             self.session = httpx2.AsyncClient(timeout=timeout, proxy=proxy, limits=DEFAULT_LIMITS)
+        self._limiter: Optional[AsyncLimiter] = AsyncLimiter(rate_limit, time_period=1) if rate_limit > 0 else None
 
     def __str__(self) -> str:
         """String definition for HTTPProvider."""
@@ -73,6 +84,14 @@ class AsyncHTTPProvider(AsyncBaseProvider, _HTTPProviderCore):
 
     async def make_request_unparsed(self, body: Body) -> str:
         """Make an async HTTP request to an http rpc endpoint."""
+        if self._limiter is not None:
+            async with self._limiter:
+                request_kwargs = self._before_request(body=body)
+                try:
+                    raw_response = await self.session.post(**request_kwargs)
+                except (httpx2.RemoteProtocolError, httpx2.ReadError):
+                    raw_response = await self.session.post(**request_kwargs)
+                return _after_request_unparsed(raw_response)
         request_kwargs = self._before_request(body=body)
         try:
             raw_response = await self.session.post(**request_kwargs)
@@ -85,6 +104,14 @@ class AsyncHTTPProvider(AsyncBaseProvider, _HTTPProviderCore):
 
     async def make_batch_request_unparsed(self, reqs: Tuple[Body, ...]) -> str:
         """Make an async HTTP batch request to an http rpc endpoint."""
+        if self._limiter is not None:
+            async with self._limiter:
+                request_kwargs = self._before_batch_request(reqs)
+                try:
+                    raw_response = await self.session.post(**request_kwargs)
+                except (httpx2.RemoteProtocolError, httpx2.ReadError):
+                    raw_response = await self.session.post(**request_kwargs)
+                return _after_request_unparsed(raw_response)
         request_kwargs = self._before_batch_request(reqs)
         try:
             raw_response = await self.session.post(**request_kwargs)

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -22,9 +22,7 @@ from solders.transaction import Transaction
 from ..utils import AIRDROP_AMOUNT, assert_valid_response
 
 
-async def _ensure_minimum_balance(
-    client: AsyncClient, pubkey: Pubkey, minimum_balance: int
-) -> int:
+async def _ensure_minimum_balance(client: AsyncClient, pubkey: Pubkey, minimum_balance: int) -> int:
     """Top up an account when needed and return its current balance."""
     balance_resp = await client.get_balance(pubkey)
     assert_valid_response(balance_resp)
@@ -103,12 +101,8 @@ async def test_send_transaction_and_get_balance(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, sender.pubkey(), amount + 50_000
-    )
-    receiver_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, receiver, 1
-    )
+    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
+    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
     ixs = [
         sp.transfer(
             sp.TransferParams(
@@ -147,9 +141,7 @@ async def test_send_versioned_transaction_and_get_balance(
     sender_balance_before = await _ensure_minimum_balance(
         test_http_client_async, random_funded_keypair.pubkey(), amount + 50_000
     )
-    receiver_balance_before = await test_http_client_async.get_balance(
-        receiver.pubkey()
-    )
+    receiver_balance_before = await test_http_client_async.get_balance(receiver.pubkey())
     assert_valid_response(receiver_balance_before)
     transfer_ix = sp.transfer(
         sp.TransferParams(
@@ -158,9 +150,7 @@ async def test_send_versioned_transaction_and_get_balance(
             lamports=amount,
         )
     )
-    recent_blockhash = (
-        await test_http_client_async.get_latest_blockhash()
-    ).value.blockhash
+    recent_blockhash = (await test_http_client_async.get_latest_blockhash()).value.blockhash
     msg = MessageV0.try_compile(
         payer=random_funded_keypair.pubkey(),
         instructions=[transfer_ix],
@@ -178,9 +168,7 @@ async def test_send_versioned_transaction_and_get_balance(
     # Confirm transaction
     await test_http_client_async.confirm_transaction(resp.value)
     # Check balances
-    sender_balance_resp = await test_http_client_async.get_balance(
-        random_funded_keypair.pubkey()
-    )
+    sender_balance_resp = await test_http_client_async.get_balance(random_funded_keypair.pubkey())
     assert_valid_response(sender_balance_resp)
     assert sender_balance_resp.value == sender_balance_before - amount - fee_resp.value
     receiver_balance_resp = await test_http_client_async.get_balance(receiver.pubkey())
@@ -189,15 +177,11 @@ async def test_send_versioned_transaction_and_get_balance(
 
 
 @pytest.mark.integration
-async def test_send_bad_transaction(
-    stubbed_receiver: Pubkey, test_http_client_async: AsyncClient
-):
+async def test_send_bad_transaction(stubbed_receiver: Pubkey, test_http_client_async: AsyncClient):
     """Test sending a transaction that errors."""
     poor_account = Keypair()
     airdrop_amount = 1000000
-    airdrop_resp = await test_http_client_async.request_airdrop(
-        poor_account.pubkey(), airdrop_amount
-    )
+    airdrop_resp = await test_http_client_async.request_airdrop(poor_account.pubkey(), airdrop_amount)
     assert_valid_response(airdrop_resp)
     await test_http_client_async.confirm_transaction(airdrop_resp.value)
     balance = await test_http_client_async.get_balance(poor_account.pubkey())
@@ -231,12 +215,8 @@ async def test_send_transaction_prefetched_blockhash(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, sender.pubkey(), amount + 50_000
-    )
-    receiver_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, receiver, 1
-    )
+    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
+    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
     blockhash = (await test_http_client_async.get_latest_blockhash()).value.blockhash
     ixs = [
         sp.transfer(
@@ -272,12 +252,8 @@ async def test_send_raw_transaction_and_get_balance(test_http_client_async):
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, sender.pubkey(), amount + 50_000
-    )
-    receiver_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, receiver, 1
-    )
+    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
+    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
     resp = await test_http_client_async.get_latest_blockhash(Finalized)
     assert_valid_response(resp)
     recent_blockhash = resp.value.blockhash
@@ -321,12 +297,8 @@ async def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, sender.pubkey(), amount + 50_000
-    )
-    receiver_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, receiver, 1
-    )
+    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
+    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
     resp = await test_http_client_async.get_latest_blockhash(Finalized)
     assert_valid_response(resp)
     recent_blockhash = resp.value.blockhash
@@ -358,9 +330,7 @@ async def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
     )
     assert_valid_response(resp)
     # Confirm transaction
-    resp = await test_http_client_async.confirm_transaction(
-        resp.value, last_valid_block_height=last_valid_block_height
-    )
+    resp = await test_http_client_async.confirm_transaction(resp.value, last_valid_block_height=last_valid_block_height)
     # Check balances
     resp = await test_http_client_async.get_balance(sender.pubkey())
     assert_valid_response(resp)
@@ -371,9 +341,7 @@ async def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
 
 
 @pytest.mark.integration
-async def test_confirm_expired_transaction(
-    stubbed_sender, stubbed_receiver, test_http_client_async
-):
+async def test_confirm_expired_transaction(stubbed_sender, stubbed_receiver, test_http_client_async):
     """Test that RPCException is raised when trying to confirm a transaction that exceeded last valid block height."""
     # Get a recent blockhash
     resp = await test_http_client_async.get_latest_blockhash()
@@ -408,9 +376,7 @@ async def test_confirm_expired_transaction(
 
 
 @pytest.mark.integration
-async def test_get_fee_for_transaction_message(
-    stubbed_sender, stubbed_receiver, test_http_client_async: AsyncClient
-):
+async def test_get_fee_for_transaction_message(stubbed_sender, stubbed_receiver, test_http_client_async: AsyncClient):
     """Test that gets a fee for a transaction using get fee for message."""
     # Get latest blockhash
     resp = await test_http_client_async.get_latest_blockhash()
@@ -509,9 +475,7 @@ async def test_get_blocks(test_http_client_async):
 @pytest.mark.integration
 async def test_get_signatures_for_address(test_http_client_async: AsyncClient):
     """Test get signatures for addresses."""
-    resp = await test_http_client_async.get_signatures_for_address(
-        VOTE_PROGRAM_ID, limit=1, commitment=Confirmed
-    )
+    resp = await test_http_client_async.get_signatures_for_address(VOTE_PROGRAM_ID, limit=1, commitment=Confirmed)
     assert_valid_response(resp)
 
 
@@ -585,9 +549,7 @@ async def test_get_inflation_rate(test_http_client_async):
 @pytest.mark.integration
 async def test_get_inflation_reward(stubbed_sender, test_http_client_async):
     """Test get inflation reward."""
-    resp = await test_http_client_async.get_inflation_reward(
-        [stubbed_sender.pubkey()], commitment=Confirmed
-    )
+    resp = await test_http_client_async.get_inflation_reward([stubbed_sender.pubkey()], commitment=Confirmed)
     assert_valid_response(resp)
 
 
@@ -659,13 +621,9 @@ async def test_get_account_info(async_stubbed_sender, test_http_client_async):
     """Test get_account_info."""
     resp = await test_http_client_async.get_account_info(async_stubbed_sender.pubkey())
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_account_info(
-        async_stubbed_sender.pubkey(), encoding="jsonParsed"
-    )
+    resp = await test_http_client_async.get_account_info(async_stubbed_sender.pubkey(), encoding="jsonParsed")
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_account_info(
-        async_stubbed_sender.pubkey(), data_slice=DataSliceOpts(1, 1)
-    )
+    resp = await test_http_client_async.get_account_info(async_stubbed_sender.pubkey(), data_slice=DataSliceOpts(1, 1))
     assert_valid_response(resp)
 
 
@@ -675,13 +633,9 @@ async def test_get_multiple_accounts(async_stubbed_sender, test_http_client_asyn
     pubkeys = [async_stubbed_sender.pubkey()] * 2
     resp = await test_http_client_async.get_multiple_accounts(pubkeys)
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_multiple_accounts(
-        pubkeys, encoding="jsonParsed"
-    )
+    resp = await test_http_client_async.get_multiple_accounts(pubkeys, encoding="jsonParsed")
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_multiple_accounts(
-        pubkeys, data_slice=DataSliceOpts(1, 1)
-    )
+    resp = await test_http_client_async.get_multiple_accounts(pubkeys, data_slice=DataSliceOpts(1, 1))
     assert_valid_response(resp)
 
 
@@ -711,13 +665,9 @@ async def test_rate_limiter_throttles_requests(validator_rpc_url: str):
     n_requests = 500
     time_period = 1.0  # seconds (matches AsyncLimiter default)
 
-    async with AsyncClient(
-        endpoint=validator_rpc_url, commitment=Processed, rate_limit=rate_limit
-    ) as client:
+    async with AsyncClient(endpoint=validator_rpc_url, commitment=Processed, rate_limit=rate_limit) as client:
         start = monotonic()
-        responses = await asyncio.gather(
-            *[client.get_slot() for _ in range(n_requests)]
-        )
+        responses = await asyncio.gather(*[client.get_slot() for _ in range(n_requests)])
         elapsed = monotonic() - start
 
     for resp in responses:

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -1,5 +1,8 @@
 """Tests for the HTTP API Client."""
 
+import asyncio
+from time import monotonic
+
 import pytest
 import solders.system_program as sp
 from solders.keypair import Keypair
@@ -19,7 +22,9 @@ from solders.transaction import Transaction
 from ..utils import AIRDROP_AMOUNT, assert_valid_response
 
 
-async def _ensure_minimum_balance(client: AsyncClient, pubkey: Pubkey, minimum_balance: int) -> int:
+async def _ensure_minimum_balance(
+    client: AsyncClient, pubkey: Pubkey, minimum_balance: int
+) -> int:
     """Top up an account when needed and return its current balance."""
     balance_resp = await client.get_balance(pubkey)
     assert_valid_response(balance_resp)
@@ -98,8 +103,12 @@ async def test_send_transaction_and_get_balance(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
-    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
+    sender_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, sender.pubkey(), amount + 50_000
+    )
+    receiver_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, receiver, 1
+    )
     ixs = [
         sp.transfer(
             sp.TransferParams(
@@ -138,7 +147,9 @@ async def test_send_versioned_transaction_and_get_balance(
     sender_balance_before = await _ensure_minimum_balance(
         test_http_client_async, random_funded_keypair.pubkey(), amount + 50_000
     )
-    receiver_balance_before = await test_http_client_async.get_balance(receiver.pubkey())
+    receiver_balance_before = await test_http_client_async.get_balance(
+        receiver.pubkey()
+    )
     assert_valid_response(receiver_balance_before)
     transfer_ix = sp.transfer(
         sp.TransferParams(
@@ -147,7 +158,9 @@ async def test_send_versioned_transaction_and_get_balance(
             lamports=amount,
         )
     )
-    recent_blockhash = (await test_http_client_async.get_latest_blockhash()).value.blockhash
+    recent_blockhash = (
+        await test_http_client_async.get_latest_blockhash()
+    ).value.blockhash
     msg = MessageV0.try_compile(
         payer=random_funded_keypair.pubkey(),
         instructions=[transfer_ix],
@@ -165,7 +178,9 @@ async def test_send_versioned_transaction_and_get_balance(
     # Confirm transaction
     await test_http_client_async.confirm_transaction(resp.value)
     # Check balances
-    sender_balance_resp = await test_http_client_async.get_balance(random_funded_keypair.pubkey())
+    sender_balance_resp = await test_http_client_async.get_balance(
+        random_funded_keypair.pubkey()
+    )
     assert_valid_response(sender_balance_resp)
     assert sender_balance_resp.value == sender_balance_before - amount - fee_resp.value
     receiver_balance_resp = await test_http_client_async.get_balance(receiver.pubkey())
@@ -174,11 +189,15 @@ async def test_send_versioned_transaction_and_get_balance(
 
 
 @pytest.mark.integration
-async def test_send_bad_transaction(stubbed_receiver: Pubkey, test_http_client_async: AsyncClient):
+async def test_send_bad_transaction(
+    stubbed_receiver: Pubkey, test_http_client_async: AsyncClient
+):
     """Test sending a transaction that errors."""
     poor_account = Keypair()
     airdrop_amount = 1000000
-    airdrop_resp = await test_http_client_async.request_airdrop(poor_account.pubkey(), airdrop_amount)
+    airdrop_resp = await test_http_client_async.request_airdrop(
+        poor_account.pubkey(), airdrop_amount
+    )
     assert_valid_response(airdrop_resp)
     await test_http_client_async.confirm_transaction(airdrop_resp.value)
     balance = await test_http_client_async.get_balance(poor_account.pubkey())
@@ -212,8 +231,12 @@ async def test_send_transaction_prefetched_blockhash(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
-    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
+    sender_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, sender.pubkey(), amount + 50_000
+    )
+    receiver_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, receiver, 1
+    )
     blockhash = (await test_http_client_async.get_latest_blockhash()).value.blockhash
     ixs = [
         sp.transfer(
@@ -249,8 +272,12 @@ async def test_send_raw_transaction_and_get_balance(test_http_client_async):
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
-    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
+    sender_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, sender.pubkey(), amount + 50_000
+    )
+    receiver_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, receiver, 1
+    )
     resp = await test_http_client_async.get_latest_blockhash(Finalized)
     assert_valid_response(resp)
     recent_blockhash = resp.value.blockhash
@@ -294,8 +321,12 @@ async def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
-    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
+    sender_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, sender.pubkey(), amount + 50_000
+    )
+    receiver_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, receiver, 1
+    )
     resp = await test_http_client_async.get_latest_blockhash(Finalized)
     assert_valid_response(resp)
     recent_blockhash = resp.value.blockhash
@@ -327,7 +358,9 @@ async def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
     )
     assert_valid_response(resp)
     # Confirm transaction
-    resp = await test_http_client_async.confirm_transaction(resp.value, last_valid_block_height=last_valid_block_height)
+    resp = await test_http_client_async.confirm_transaction(
+        resp.value, last_valid_block_height=last_valid_block_height
+    )
     # Check balances
     resp = await test_http_client_async.get_balance(sender.pubkey())
     assert_valid_response(resp)
@@ -338,7 +371,9 @@ async def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
 
 
 @pytest.mark.integration
-async def test_confirm_expired_transaction(stubbed_sender, stubbed_receiver, test_http_client_async):
+async def test_confirm_expired_transaction(
+    stubbed_sender, stubbed_receiver, test_http_client_async
+):
     """Test that RPCException is raised when trying to confirm a transaction that exceeded last valid block height."""
     # Get a recent blockhash
     resp = await test_http_client_async.get_latest_blockhash()
@@ -373,7 +408,9 @@ async def test_confirm_expired_transaction(stubbed_sender, stubbed_receiver, tes
 
 
 @pytest.mark.integration
-async def test_get_fee_for_transaction_message(stubbed_sender, stubbed_receiver, test_http_client_async: AsyncClient):
+async def test_get_fee_for_transaction_message(
+    stubbed_sender, stubbed_receiver, test_http_client_async: AsyncClient
+):
     """Test that gets a fee for a transaction using get fee for message."""
     # Get latest blockhash
     resp = await test_http_client_async.get_latest_blockhash()
@@ -472,7 +509,9 @@ async def test_get_blocks(test_http_client_async):
 @pytest.mark.integration
 async def test_get_signatures_for_address(test_http_client_async: AsyncClient):
     """Test get signatures for addresses."""
-    resp = await test_http_client_async.get_signatures_for_address(VOTE_PROGRAM_ID, limit=1, commitment=Confirmed)
+    resp = await test_http_client_async.get_signatures_for_address(
+        VOTE_PROGRAM_ID, limit=1, commitment=Confirmed
+    )
     assert_valid_response(resp)
 
 
@@ -546,7 +585,9 @@ async def test_get_inflation_rate(test_http_client_async):
 @pytest.mark.integration
 async def test_get_inflation_reward(stubbed_sender, test_http_client_async):
     """Test get inflation reward."""
-    resp = await test_http_client_async.get_inflation_reward([stubbed_sender.pubkey()], commitment=Confirmed)
+    resp = await test_http_client_async.get_inflation_reward(
+        [stubbed_sender.pubkey()], commitment=Confirmed
+    )
     assert_valid_response(resp)
 
 
@@ -618,9 +659,13 @@ async def test_get_account_info(async_stubbed_sender, test_http_client_async):
     """Test get_account_info."""
     resp = await test_http_client_async.get_account_info(async_stubbed_sender.pubkey())
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_account_info(async_stubbed_sender.pubkey(), encoding="jsonParsed")
+    resp = await test_http_client_async.get_account_info(
+        async_stubbed_sender.pubkey(), encoding="jsonParsed"
+    )
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_account_info(async_stubbed_sender.pubkey(), data_slice=DataSliceOpts(1, 1))
+    resp = await test_http_client_async.get_account_info(
+        async_stubbed_sender.pubkey(), data_slice=DataSliceOpts(1, 1)
+    )
     assert_valid_response(resp)
 
 
@@ -630,9 +675,13 @@ async def test_get_multiple_accounts(async_stubbed_sender, test_http_client_asyn
     pubkeys = [async_stubbed_sender.pubkey()] * 2
     resp = await test_http_client_async.get_multiple_accounts(pubkeys)
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_multiple_accounts(pubkeys, encoding="jsonParsed")
+    resp = await test_http_client_async.get_multiple_accounts(
+        pubkeys, encoding="jsonParsed"
+    )
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_multiple_accounts(pubkeys, data_slice=DataSliceOpts(1, 1))
+    resp = await test_http_client_async.get_multiple_accounts(
+        pubkeys, data_slice=DataSliceOpts(1, 1)
+    )
     assert_valid_response(resp)
 
 
@@ -641,3 +690,42 @@ async def test_get_vote_accounts(test_http_client_async):
     """Test get vote accounts."""
     resp = await test_http_client_async.get_vote_accounts()
     assert_valid_response(resp)
+
+
+@pytest.mark.integration
+async def test_rate_limiter_throttles_requests(validator_rpc_url: str):
+    """Rate-limited AsyncClient should queue requests and throttle throughput.
+
+    Strategy: create a dedicated client with rate_limit=50 req/s, fire
+    500 requests concurrently via asyncio.gather, then assert the total wall
+    time is at least as long as the limiter's theoretical minimum.
+
+    With max_rate=50/s the first 50 slots are consumed immediately; each
+    subsequent request must wait an additional 1/50 s = 20 ms, so the minimum
+    total elapsed time for 500 requests is (500-50)/50 = 9.0 s. A 0.90
+    safety factor (10% jitter tolerance) keeps the assertion resilient to
+    scheduler variance while still catching a broken/missing limiter (which
+    would complete in < 0.1 s on localhost).
+    """
+    rate_limit = 50  # requests per second
+    n_requests = 500
+    time_period = 1.0  # seconds (matches AsyncLimiter default)
+
+    async with AsyncClient(
+        endpoint=validator_rpc_url, commitment=Processed, rate_limit=rate_limit
+    ) as client:
+        start = monotonic()
+        responses = await asyncio.gather(
+            *[client.get_slot() for _ in range(n_requests)]
+        )
+        elapsed = monotonic() - start
+
+    for resp in responses:
+        assert_valid_response(resp)
+
+    # Theoretical min: (n_requests - rate_limit) / rate_limit * time_period
+    expected_min = (n_requests - rate_limit) / rate_limit * time_period * 0.90
+    assert elapsed >= expected_min, (
+        f"Rate limiter did not throttle: elapsed={elapsed:.3f}s, expected >= {expected_min:.3f}s "
+        f"(rate_limit={rate_limit}/s, n_requests={n_requests})"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1210,7 +1210,7 @@ wheels = [
 
 [[package]]
 name = "solana"
-version = "0.36.12"
+version = "0.37.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiolimiter"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/23/b52debf471f7a1e42e362d959a3982bdcb4fe13a5d46e63d28868807a79c/aiolimiter-1.2.1.tar.gz", hash = "sha256:e02a37ea1a855d9e832252a105420ad4d15011505512a1a1d814647451b5cca9", size = 7185, upload-time = "2024-12-08T15:31:51.496Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/ba/df6e8e1045aebc4778d19b8a3a9bc1808adb1619ba94ca354d9ba17d86c3/aiolimiter-1.2.1-py3-none-any.whl", hash = "sha256:d3f249e9059a20badcb56b61601a83556133655c11d1eb3dd3e04ff069e5f3c7", size = 6711, upload-time = "2024-12-08T15:31:49.874Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -419,11 +428,11 @@ wheels = [
 
 [[package]]
 name = "griffelib"
-version = "2.0.2"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
 ]
 
 [[package]]
@@ -829,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "mkdocstrings-python"
-version = "2.0.4"
+version = "2.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffelib" },
@@ -837,9 +846,9 @@ dependencies = [
     { name = "mkdocstrings" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/b4/5fed370d8ebd96e4e399460a7146ae989263f16588b05a6facd6dbd51e60/mkdocstrings_python-2.0.4.tar.gz", hash = "sha256:58c73c5d358e64e9b1673447663f4a2f8a8941e392e225fc0a0c893758cc452f", size = 199219, upload-time = "2026-06-05T08:13:01.819Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/b6/e858701499d57eee8b3fd8e78168083956c6683ddbe727b46758b19e1119/mkdocstrings_python-2.0.5.tar.gz", hash = "sha256:3a4d92556ad39637e88af94a5374213af9a8e3040c3824ceaed04b486c017594", size = 199578, upload-time = "2026-06-19T10:41:08.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/e3/00ec594aef5f55522e6d373bc2ac53e53a8f5e9ae32f2d6854b0de4270f3/mkdocstrings_python-2.0.4-py3-none-any.whl", hash = "sha256:fd87c173e1e719a85997b6d4f852cdc55f36710e0ed08da3a7bd9abe79c9db00", size = 104790, upload-time = "2026-06-05T08:13:00.393Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/fc/10ab7e80650a9c9e8f4f1105f8c8e73567f88ed0c06ada589ab81d38687c/mkdocstrings_python-2.0.5-py3-none-any.whl", hash = "sha256:30c837bbff016549f659fcba6539ac351303f0fd7e713c89a040611072236e9d", size = 104951, upload-time = "2026-06-19T10:41:07.378Z" },
 ]
 
 [[package]]
@@ -979,7 +988,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.1.0"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -990,9 +999,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -1204,6 +1213,7 @@ name = "solana"
 version = "0.36.12"
 source = { editable = "." }
 dependencies = [
+    { name = "aiolimiter" },
     { name = "construct-typing" },
     { name = "httpx2", extra = ["http2"] },
     { name = "solders" },
@@ -1230,6 +1240,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiolimiter", specifier = ">=1.1.0" },
     { name = "construct-typing", specifier = ">=0.6.2,<0.8.0" },
     { name = "httpx2", extras = ["http2"], specifier = ">=2.4.0" },
     { name = "solders", specifier = ">=0.23,<0.28" },
@@ -1242,16 +1253,16 @@ dev = [
     { name = "asyncstdlib", specifier = ">=3.14.0" },
     { name = "bump2version", specifier = ">=1.0.1" },
     { name = "mkdocs-material", specifier = ">=9.7.6" },
-    { name = "mkdocstrings", specifier = ">=0.18.0" },
-    { name = "mkdocstrings-python", specifier = ">=0.14.0" },
-    { name = "mypy", specifier = ">=1.19" },
-    { name = "pytest", specifier = ">=8.4.2" },
-    { name = "pytest-asyncio", specifier = ">=0.18.3" },
+    { name = "mkdocstrings", specifier = ">=1.0.4" },
+    { name = "mkdocstrings-python", specifier = ">=2.0.5" },
+    { name = "mypy", specifier = ">=2.1" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-html", specifier = ">=4.2.0" },
-    { name = "pytest-xdist", specifier = ">=3.6.1" },
-    { name = "pyyaml", specifier = ">=6.0.2" },
-    { name = "ruff", specifier = ">=0.7.3" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "ruff", specifier = ">=0.15.18" },
 ]
 
 [[package]]


### PR DESCRIPTION
In years of production practice, we've found that the subscribed RPC platform imposes QPS limits, so high-density use of AsyncClient has required an external rate limiter. This PR integrates a configurable rate limiter directly into AsyncClient for internal concurrency control, enabling users to throttle requests and avoid hitting provider limits. It also bumps several dev dependencies and adds an integration test for the new feature.

**Async HTTP Client Rate Limiting:**

* Added a `rate_limit` parameter to `AsyncClient` and `AsyncHTTPProvider` to control the maximum number of requests per second (default is unlimited). This is implemented using the `aiolimiter` library. (`src/solana/rpc/async_api.py`, `src/solana/rpc/providers/async_http.py`)
* Updated the logic in `make_request_unparsed` and `make_batch_request_unparsed` to acquire the rate limiter before making HTTP requests, ensuring that the rate limit is enforced for both single and batch requests. (`src/solana/rpc/providers/async_http.py`)
* Added the `aiolimiter` library to the project dependencies. (`pyproject.toml`)

**Testing:**

* Added an integration test (`test_rate_limiter_throttles_requests`) that verifies the rate limiter queues and throttles requests as expected, ensuring the feature works under concurrent load. (`tests/integration/test_async_http_client.py`) 

**Development Environment:**

* Updated several development dependencies to newer versions, including `pytest`, `mypy`, `pyyaml`, `pytest-asyncio`, `pytest-xdist`, `mkdocstrings`, `mkdocstrings-python`, and `ruff`. (`pyproject.toml`)