### PR TITLE
Deprecate all NamedTuple classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Deprecate all `NamedTuple` classes (params/options/info types in `solana` and `spl`); they will be replaced by Pydantic models in a future release. Usage now emits a `DeprecationWarning` and is flagged by type checkers.
+
 ## [0.37.1] - 2026-06-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
 ]
 dependencies = [
     "construct-typing>=0.6.2,<0.8.0",
-    "typing-extensions>=4.2.0",
+    "typing-extensions>=4.5.0",
     "websockets>=14.0",
     "solders>=0.23,<0.28",
     "httpx2[http2]>=2.4.0",

--- a/src/solana/rpc/types.py
+++ b/src/solana/rpc/types.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import NamedTuple, NewType
 
 from solders.pubkey import Pubkey
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, deprecated
 
 from .commitment import Commitment, Finalized
 
@@ -25,6 +25,7 @@ class RPCError(TypedDict):
     """Error message."""
 
 
+@deprecated("DataSliceOpts is deprecated and will be replaced by a Pydantic model.")
 class DataSliceOpts(NamedTuple):
     """Option to limit the returned account data, only available for "base58" or "base64" encoding."""
 
@@ -34,6 +35,7 @@ class DataSliceOpts(NamedTuple):
     """Limit the returned account data using the provided length: <usize>."""
 
 
+@deprecated("MemcmpOpts is deprecated and will be replaced by a Pydantic model.")
 class MemcmpOpts(NamedTuple):
     """Option to compare a provided series of bytes with program account data at a particular offset."""
 
@@ -43,6 +45,7 @@ class MemcmpOpts(NamedTuple):
     """Data to match, as base-58 encoded string: <string>."""
 
 
+@deprecated("TokenAccountOpts is deprecated and will be replaced by a Pydantic model.")
 class TokenAccountOpts(NamedTuple):
     """Options when querying token accounts.
 
@@ -59,6 +62,7 @@ class TokenAccountOpts(NamedTuple):
     """Option to limit the returned account data, only available for "base58" or "base64" encoding."""
 
 
+@deprecated("TxOpts is deprecated and will be replaced by a Pydantic model.")
 class TxOpts(NamedTuple):
     """Options to specify when broadcasting a transaction."""
 

--- a/src/solana/utils/cluster.py
+++ b/src/solana/utils/cluster.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from typing import Literal, NamedTuple
+from typing_extensions import deprecated
 
 
+@deprecated("ClusterUrls is deprecated and will be replaced by a Pydantic model.")
 class ClusterUrls(NamedTuple):
     """A collection of urls for each cluster."""
 
@@ -13,6 +15,7 @@ class ClusterUrls(NamedTuple):
     mainnet_beta: str
 
 
+@deprecated("Endpoint is deprecated and will be replaced by a Pydantic model.")
 class Endpoint(NamedTuple):
     """Container for http and https cluster urls."""
 

--- a/src/solana/vote_program.py
+++ b/src/solana/vote_program.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import NamedTuple
+from typing_extensions import deprecated
 
 from solders.instruction import AccountMeta, Instruction
 from solders.pubkey import Pubkey
@@ -12,6 +13,7 @@ from solana._layouts.vote_instructions import VOTE_INSTRUCTIONS_LAYOUT, Instruct
 
 
 # Instruction Params
+@deprecated("WithdrawFromVoteAccountParams is deprecated and will be replaced by a Pydantic model.")
 class WithdrawFromVoteAccountParams(NamedTuple):
     """Transfer SOL from vote account to identity."""
 

--- a/src/spl/memo/instructions.py
+++ b/src/spl/memo/instructions.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from typing import NamedTuple
+from typing_extensions import deprecated
 
 from solders.instruction import AccountMeta, Instruction
 from solders.pubkey import Pubkey
 
 
+@deprecated("MemoParams is deprecated and will be replaced by a Pydantic model.")
 class MemoParams(NamedTuple):
     """Create memo transaction params."""
 

--- a/src/spl/token/core.py
+++ b/src/spl/token/core.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, NamedTuple, Optional, Tuple, Type, Union
+from typing_extensions import deprecated
 
 import solders.system_program as sp
 from solders.keypair import Keypair
@@ -26,6 +27,7 @@ if TYPE_CHECKING:
     from spl.token.client import Token
 
 
+@deprecated("AccountInfo is deprecated and will be replaced by a Pydantic model.")
 class AccountInfo(NamedTuple):
     """Information about an account."""
 
@@ -55,6 +57,7 @@ class AccountInfo(NamedTuple):
     """Optional authority to close the account."""
 
 
+@deprecated("MintInfo is deprecated and will be replaced by a Pydantic model.")
 class MintInfo(NamedTuple):
     """Information about the mint."""
 

--- a/src/spl/token/instructions.py
+++ b/src/spl/token/instructions.py
@@ -2,6 +2,7 @@
 
 from enum import IntEnum
 from typing import Any, List, NamedTuple, Optional, Union
+from typing_extensions import deprecated
 
 from solders.instruction import AccountMeta, Instruction
 from solders.pubkey import Pubkey
@@ -27,6 +28,7 @@ class AuthorityType(IntEnum):
 
 
 # Instruction Params
+@deprecated("InitializeMintParams is deprecated and will be replaced by a Pydantic model.")
 class InitializeMintParams(NamedTuple):
     """Initialize token mint transaction params."""
 
@@ -42,6 +44,7 @@ class InitializeMintParams(NamedTuple):
     """The freeze authority/multisignature of the mint."""
 
 
+@deprecated("InitializeMint2Params is deprecated and will be replaced by a Pydantic model.")
 class InitializeMint2Params(NamedTuple):
     """Initialize token mint transaction params without Rent sysvar."""
 
@@ -57,6 +60,7 @@ class InitializeMint2Params(NamedTuple):
     """The freeze authority/multisignature of the mint."""
 
 
+@deprecated("InitializeAccountParams is deprecated and will be replaced by a Pydantic model.")
 class InitializeAccountParams(NamedTuple):
     """Initialize token account transaction params."""
 
@@ -70,6 +74,7 @@ class InitializeAccountParams(NamedTuple):
     """Owner of the new account."""
 
 
+@deprecated("InitializeAccount2Params is deprecated and will be replaced by a Pydantic model.")
 class InitializeAccount2Params(NamedTuple):
     """Initialize token account transaction params with owner in instruction data."""
 
@@ -83,6 +88,7 @@ class InitializeAccount2Params(NamedTuple):
     """Owner of the new account."""
 
 
+@deprecated("InitializeAccount3Params is deprecated and will be replaced by a Pydantic model.")
 class InitializeAccount3Params(NamedTuple):
     """Initialize token account transaction params with owner in instruction data and no Rent sysvar."""
 
@@ -96,6 +102,7 @@ class InitializeAccount3Params(NamedTuple):
     """Owner of the new account."""
 
 
+@deprecated("InitializeMultisigParams is deprecated and will be replaced by a Pydantic model.")
 class InitializeMultisigParams(NamedTuple):
     """Initialize multisig token account transaction params."""
 
@@ -109,6 +116,7 @@ class InitializeMultisigParams(NamedTuple):
     """Addresses of multisig signers."""
 
 
+@deprecated("InitializeMultisig2Params is deprecated and will be replaced by a Pydantic model.")
 class InitializeMultisig2Params(NamedTuple):
     """Initialize multisig token account transaction params without Rent sysvar."""
 
@@ -122,6 +130,7 @@ class InitializeMultisig2Params(NamedTuple):
     """Addresses of multisig signers."""
 
 
+@deprecated("TransferParams is deprecated and will be replaced by a Pydantic model.")
 class TransferParams(NamedTuple):
     """Transfer token transaction params."""
 
@@ -139,6 +148,7 @@ class TransferParams(NamedTuple):
     """Signing accounts if `owner` is a multiSig."""
 
 
+@deprecated("ApproveParams is deprecated and will be replaced by a Pydantic model.")
 class ApproveParams(NamedTuple):
     """Approve token transaction params."""
 
@@ -156,6 +166,7 @@ class ApproveParams(NamedTuple):
     """Signing accounts if `owner` is a multiSig."""
 
 
+@deprecated("RevokeParams is deprecated and will be replaced by a Pydantic model.")
 class RevokeParams(NamedTuple):
     """Revoke token transaction params."""
 
@@ -169,6 +180,7 @@ class RevokeParams(NamedTuple):
     """Signing accounts if `owner` is a multiSig."""
 
 
+@deprecated("SetAuthorityParams is deprecated and will be replaced by a Pydantic model.")
 class SetAuthorityParams(NamedTuple):
     """Set token authority transaction params."""
 
@@ -186,6 +198,7 @@ class SetAuthorityParams(NamedTuple):
     """New authority of the account."""
 
 
+@deprecated("MintToParams is deprecated and will be replaced by a Pydantic model.")
 class MintToParams(NamedTuple):
     """Mint token transaction params."""
 
@@ -203,6 +216,7 @@ class MintToParams(NamedTuple):
     """Signing accounts if `mint_authority` is a multiSig."""
 
 
+@deprecated("BurnParams is deprecated and will be replaced by a Pydantic model.")
 class BurnParams(NamedTuple):
     """Burn token transaction params."""
 
@@ -220,6 +234,7 @@ class BurnParams(NamedTuple):
     """Signing accounts if `owner` is a multiSig"""
 
 
+@deprecated("CloseAccountParams is deprecated and will be replaced by a Pydantic model.")
 class CloseAccountParams(NamedTuple):
     """Close token account transaction params."""
 
@@ -235,6 +250,7 @@ class CloseAccountParams(NamedTuple):
     """Signing accounts if `owner` is a multiSig"""
 
 
+@deprecated("FreezeAccountParams is deprecated and will be replaced by a Pydantic model.")
 class FreezeAccountParams(NamedTuple):
     """Freeze token account transaction params."""
 
@@ -250,6 +266,7 @@ class FreezeAccountParams(NamedTuple):
     """Signing accounts if `authority` is a multiSig"""
 
 
+@deprecated("ThawAccountParams is deprecated and will be replaced by a Pydantic model.")
 class ThawAccountParams(NamedTuple):
     """Thaw token account transaction params."""
 
@@ -265,6 +282,7 @@ class ThawAccountParams(NamedTuple):
     """Signing accounts if `authority` is a multiSig"""
 
 
+@deprecated("TransferCheckedParams is deprecated and will be replaced by a Pydantic model.")
 class TransferCheckedParams(NamedTuple):
     """TransferChecked token transaction params."""
 
@@ -286,6 +304,7 @@ class TransferCheckedParams(NamedTuple):
     """Signing accounts if `owner` is a multiSig."""
 
 
+@deprecated("ApproveCheckedParams is deprecated and will be replaced by a Pydantic model.")
 class ApproveCheckedParams(NamedTuple):
     """ApproveChecked token transaction params."""
 
@@ -307,6 +326,7 @@ class ApproveCheckedParams(NamedTuple):
     """Signing accounts if `owner` is a multiSig."""
 
 
+@deprecated("MintToCheckedParams is deprecated and will be replaced by a Pydantic model.")
 class MintToCheckedParams(NamedTuple):
     """MintToChecked token transaction params."""
 
@@ -326,6 +346,7 @@ class MintToCheckedParams(NamedTuple):
     """Signing accounts if `mint_authority` is a multiSig."""
 
 
+@deprecated("BurnCheckedParams is deprecated and will be replaced by a Pydantic model.")
 class BurnCheckedParams(NamedTuple):
     """BurnChecked token transaction params."""
 
@@ -345,6 +366,7 @@ class BurnCheckedParams(NamedTuple):
     """Signing accounts if `owner` is a multiSig"""
 
 
+@deprecated("SyncNativeParams is deprecated and will be replaced by a Pydantic model.")
 class SyncNativeParams(NamedTuple):
     """BurnChecked token transaction params."""
 
@@ -354,6 +376,7 @@ class SyncNativeParams(NamedTuple):
     """Account to sync."""
 
 
+@deprecated("GetAccountDataSizeParams is deprecated and will be replaced by a Pydantic model.")
 class GetAccountDataSizeParams(NamedTuple):
     """GetAccountDataSize token transaction params."""
 
@@ -363,6 +386,7 @@ class GetAccountDataSizeParams(NamedTuple):
     """Mint to calculate account size for."""
 
 
+@deprecated("InitializeImmutableOwnerParams is deprecated and will be replaced by a Pydantic model.")
 class InitializeImmutableOwnerParams(NamedTuple):
     """InitializeImmutableOwner token transaction params."""
 
@@ -372,6 +396,7 @@ class InitializeImmutableOwnerParams(NamedTuple):
     """Token account to initialize immutable owner for."""
 
 
+@deprecated("InitializeTransferFeeConfigParams is deprecated and will be replaced by a Pydantic model.")
 class InitializeTransferFeeConfigParams(NamedTuple):
     """InitializeTransferFeeConfig token transaction params."""
 
@@ -389,6 +414,7 @@ class InitializeTransferFeeConfigParams(NamedTuple):
     """Maximum fee assessed on transfers."""
 
 
+@deprecated("WithdrawWithheldTokensFromAccountsParams is deprecated and will be replaced by a Pydantic model.")
 class WithdrawWithheldTokensFromAccountsParams(NamedTuple):
     """WithdrawWithheldTokensFromAccounts token transaction params."""
 
@@ -406,6 +432,7 @@ class WithdrawWithheldTokensFromAccountsParams(NamedTuple):
     """Token accounts to withdraw withheld tokens from."""
 
 
+@deprecated("WithdrawWithheldTokensFromMintParams is deprecated and will be replaced by a Pydantic model.")
 class WithdrawWithheldTokensFromMintParams(NamedTuple):
     """WithdrawWithheldTokensFromMint token transaction params."""
 
@@ -421,6 +448,7 @@ class WithdrawWithheldTokensFromMintParams(NamedTuple):
     """Signing accounts if `authority` is a multiSig."""
 
 
+@deprecated("HarvestWithheldTokensToMintParams is deprecated and will be replaced by a Pydantic model.")
 class HarvestWithheldTokensToMintParams(NamedTuple):
     """HarvestWithheldTokensToMint token transaction params."""
 
@@ -432,6 +460,7 @@ class HarvestWithheldTokensToMintParams(NamedTuple):
     """Token accounts to harvest withheld tokens from."""
 
 
+@deprecated("AmountToUiAmountParams is deprecated and will be replaced by a Pydantic model.")
 class AmountToUiAmountParams(NamedTuple):
     """AmountToUiAmount token transaction params."""
 
@@ -443,6 +472,7 @@ class AmountToUiAmountParams(NamedTuple):
     """Amount of tokens to reformat."""
 
 
+@deprecated("UiAmountToAmountParams is deprecated and will be replaced by a Pydantic model.")
 class UiAmountToAmountParams(NamedTuple):
     """UiAmountToAmount token transaction params."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -1244,7 +1244,7 @@ requires-dist = [
     { name = "construct-typing", specifier = ">=0.6.2,<0.8.0" },
     { name = "httpx2", extras = ["http2"], specifier = ">=2.4.0" },
     { name = "solders", specifier = ">=0.23,<0.28" },
-    { name = "typing-extensions", specifier = ">=4.2.0" },
+    { name = "typing-extensions", specifier = ">=4.5.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]
 


### PR DESCRIPTION
## Summary

Marks every `NamedTuple` class in `solana` and `spl` as deprecated via `typing_extensions.deprecated` (PEP 702). This is the first step toward replacing them with Pydantic models in a subsequent PR. No Pydantic dependency is introduced here.

Deprecated classes (39 total):

| File | Classes |
|------|---------|
| `solana/rpc/types.py` | `DataSliceOpts`, `MemcmpOpts`, `TokenAccountOpts`, `TxOpts` |
| `spl/token/core.py` | `AccountInfo`, `MintInfo` |
| `solana/utils/cluster.py` | `ClusterUrls`, `Endpoint` |
| `solana/vote_program.py` | `WithdrawFromVoteAccountParams` |
| `spl/memo/instructions.py` | `MemoParams` |
| `spl/token/instructions.py` | 29 `*Params` classes |

## Why `@deprecated`

It's the standard PEP 702 mechanism and works cleanly on `NamedTuple`: instances still behave as tuples, type checkers flag usage in users' IDEs/CI, and a `DeprecationWarning` fires at runtime on construction. `DeprecationWarning` is silenced by default for end users, so normal production usage stays quiet despite the library constructing some of these types internally.

## Changes

- Add `@deprecated(...)` to all `NamedTuple` classes.
- Bump `typing-extensions` floor `>=4.2.0` → `>=4.5.0` (where `@deprecated` lands).
- Add an Unreleased CHANGELOG entry.

## Verification

- `ruff check` / `ruff format --check`: clean
- `mypy src/`: no issues
- Doctests on all touched modules: 19 passed (deprecation warnings shown, not errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)