### PR TITLE
Migrate internal call sites to Pydantic models (Part 3: rpc client data_slice/filters)

### DIFF
--- a/src/solana/rpc/api.py
+++ b/src/solana/rpc/api.py
@@ -66,7 +66,12 @@ from solders.signature import Signature
 from solders.transaction import Transaction, VersionedTransaction
 
 from solana.rpc import types
-from solana.rpc.models import TokenAccountOpts as TokenAccountOptsModel, TxOpts as TxOptsModel
+from solana.rpc.models import (
+    DataSliceOpts as DataSliceOptsModel,
+    MemcmpOpts as MemcmpOptsModel,
+    TokenAccountOpts as TokenAccountOptsModel,
+    TxOpts as TxOptsModel,
+)
 
 from .commitment import Commitment
 from .core import (
@@ -138,7 +143,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         pubkey: Pubkey,
         commitment: Optional[Commitment] = None,
         encoding: str = "base64",
-        data_slice: Optional[types.DataSliceOpts] = None,
+        data_slice: Optional[Union[types.DataSliceOpts, DataSliceOptsModel]] = None,
     ) -> GetAccountInfoResp:
         """Returns all the account info for the specified public key, encoded in either base58 or base64.
 
@@ -583,7 +588,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         pubkeys: List[Pubkey],
         commitment: Optional[Commitment] = None,
         encoding: str = "base64",
-        data_slice: Optional[types.DataSliceOpts] = None,
+        data_slice: Optional[Union[types.DataSliceOpts, DataSliceOptsModel]] = None,
     ) -> GetMultipleAccountsResp:
         """Returns all the account info for a list of public keys.
 
@@ -645,8 +650,8 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         pubkey: Pubkey,
         commitment: Optional[Commitment] = None,
         encoding: str = "base64",
-        data_slice: Optional[types.DataSliceOpts] = None,
-        filters: Optional[Sequence[Union[int, types.MemcmpOpts]]] = None,
+        data_slice: Optional[Union[types.DataSliceOpts, DataSliceOptsModel]] = None,
+        filters: Optional[Sequence[Union[int, types.MemcmpOpts, MemcmpOptsModel]]] = None,
     ) -> GetProgramAccountsResp:
         """Returns all accounts owned by the provided program Pubkey.
 
@@ -682,7 +687,7 @@ class Client(_ClientCore):  # pylint: disable=too-many-public-methods
         self,
         pubkey: Pubkey,
         commitment: Optional[Commitment] = None,
-        filters: Optional[Sequence[Union[int, types.MemcmpOpts]]] = None,
+        filters: Optional[Sequence[Union[int, types.MemcmpOpts, MemcmpOptsModel]]] = None,
     ) -> GetProgramAccountsMaybeJsonParsedResp:
         """Returns all accounts owned by the provided program Pubkey.
 

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -66,7 +66,12 @@ from solders.signature import Signature
 from solders.transaction import Transaction, VersionedTransaction
 
 from solana.rpc import types
-from solana.rpc.models import TokenAccountOpts as TokenAccountOptsModel, TxOpts as TxOptsModel
+from solana.rpc.models import (
+    DataSliceOpts as DataSliceOptsModel,
+    MemcmpOpts as MemcmpOptsModel,
+    TokenAccountOpts as TokenAccountOptsModel,
+    TxOpts as TxOptsModel,
+)
 
 from .commitment import Commitment
 from .core import (
@@ -157,7 +162,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         pubkey: Pubkey,
         commitment: Optional[Commitment] = None,
         encoding: str = "base64",
-        data_slice: Optional[types.DataSliceOpts] = None,
+        data_slice: Optional[Union[types.DataSliceOpts, DataSliceOptsModel]] = None,
     ) -> GetAccountInfoResp:
         """Returns all the account info for the specified public key.
 
@@ -610,7 +615,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         pubkeys: List[Pubkey],
         commitment: Optional[Commitment] = None,
         encoding: str = "base64",
-        data_slice: Optional[types.DataSliceOpts] = None,
+        data_slice: Optional[Union[types.DataSliceOpts, DataSliceOptsModel]] = None,
     ) -> GetMultipleAccountsResp:
         """Returns all the account info for a list of public keys.
 
@@ -671,8 +676,8 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         pubkey: Pubkey,
         commitment: Optional[Commitment] = None,
         encoding: Optional[str] = None,
-        data_slice: Optional[types.DataSliceOpts] = None,
-        filters: Optional[Sequence[Union[int, types.MemcmpOpts]]] = None,
+        data_slice: Optional[Union[types.DataSliceOpts, DataSliceOptsModel]] = None,
+        filters: Optional[Sequence[Union[int, types.MemcmpOpts, MemcmpOptsModel]]] = None,
     ) -> GetProgramAccountsResp:
         """Returns all accounts owned by the provided program Pubkey.
 
@@ -709,7 +714,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         self,
         pubkey: Pubkey,
         commitment: Optional[Commitment] = None,
-        filters: Optional[Sequence[Union[int, types.MemcmpOpts]]] = None,
+        filters: Optional[Sequence[Union[int, types.MemcmpOpts, MemcmpOptsModel]]] = None,
     ) -> GetProgramAccountsMaybeJsonParsedResp:
         """Returns all accounts owned by the provided program Pubkey.
 

--- a/src/solana/rpc/core.py
+++ b/src/solana/rpc/core.py
@@ -88,7 +88,7 @@ from solders.transaction import Transaction, VersionedTransaction
 from solders.transaction_status import UiTransactionEncoding
 
 from solana.rpc import types
-from solana.rpc.models import DataSliceOpts, TokenAccountOpts, TxOpts as TxOptsModel
+from solana.rpc.models import DataSliceOpts, MemcmpOpts, TokenAccountOpts, TxOpts as TxOptsModel
 
 from .commitment import Commitment, Confirmed, Finalized, Processed
 
@@ -176,7 +176,7 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         pubkey: Pubkey,
         commitment: Optional[Commitment],
         encoding: str,
-        data_slice: Optional[types.DataSliceOpts],
+        data_slice: Optional[Union[types.DataSliceOpts, DataSliceOpts]],
     ) -> GetAccountInfo:
         data_slice_to_use = (
             None if data_slice is None else UiDataSliceConfig(offset=data_slice.offset, length=data_slice.length)
@@ -297,7 +297,7 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         pubkeys: List[Pubkey],
         commitment: Optional[Commitment],
         encoding: str,
-        data_slice: Optional[types.DataSliceOpts],
+        data_slice: Optional[Union[types.DataSliceOpts, DataSliceOpts]],
     ) -> GetMultipleAccounts:
         encoding_to_use = _ACCOUNT_ENCODING_TO_SOLDERS[encoding]
         commitment_to_use = _COMMITMENT_TO_SOLDERS[commitment or self._commitment]
@@ -316,8 +316,8 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         pubkey: Pubkey,
         commitment: Optional[Commitment],
         encoding: Optional[str],
-        data_slice: Optional[types.DataSliceOpts],
-        filters: Optional[Sequence[Union[int, types.MemcmpOpts]]] = None,
+        data_slice: Optional[Union[types.DataSliceOpts, DataSliceOpts]],
+        filters: Optional[Sequence[Union[int, types.MemcmpOpts, MemcmpOpts]]] = None,
     ) -> GetProgramAccounts:  # pylint: disable=too-many-arguments
         encoding_to_use = None if encoding is None else _ACCOUNT_ENCODING_TO_SOLDERS[encoding]
         commitment_to_use = _COMMITMENT_TO_SOLDERS[commitment or self._commitment]

--- a/tests/unit/test_async_client.py
+++ b/tests/unit/test_async_client.py
@@ -4,15 +4,29 @@ from unittest.mock import patch
 
 import pytest
 from httpx2 import ReadTimeout
+from solders.account_decoder import UiAccountEncoding, UiDataSliceConfig
 from solders.commitment_config import CommitmentLevel
 from solders.pubkey import Pubkey
-from solders.rpc.config import RpcSignaturesForAddressConfig
-from solders.rpc.requests import GetSignaturesForAddress
+from solders.rpc.config import (
+    RpcAccountInfoConfig,
+    RpcProgramAccountsConfig,
+    RpcSignaturesForAddressConfig,
+    RpcTokenAccountsFilterProgramId,
+)
+from solders.rpc.filter import Memcmp
+from solders.rpc.requests import (
+    GetAccountInfo,
+    GetMultipleAccounts,
+    GetProgramAccounts,
+    GetSignaturesForAddress,
+    GetTokenAccountsByOwner,
+)
 from solders.signature import Signature
 
 from solana.constants import SYSTEM_PROGRAM_ID
 from solana.exceptions import SolanaRpcException
 from solana.rpc.commitment import Finalized
+from solana.rpc.models import DataSliceOpts, MemcmpOpts, TokenAccountOpts
 
 
 async def test_async_client_http_exception(unit_test_http_client_async):
@@ -53,5 +67,81 @@ def test_client_address_sig_args_with_commitment(unit_test_http_client_async):
     )
     actual = unit_test_http_client_async._get_signatures_for_address_body(
         Pubkey([0] * 31 + [0]), None, None, 5, Finalized
+    )
+    assert expected == actual
+
+
+def test_get_account_info_body(unit_test_http_client_async):
+    """Test generating getAccountInfo body with a data slice."""
+    pubkey = Pubkey([0] * 31 + [0])
+    expected = GetAccountInfo(
+        pubkey,
+        RpcAccountInfoConfig(
+            encoding=UiAccountEncoding.Base64,
+            data_slice=UiDataSliceConfig(offset=1, length=2),
+            commitment=CommitmentLevel.Processed,
+        ),
+    )
+    actual = unit_test_http_client_async._get_account_info_body(
+        pubkey=pubkey, commitment=None, encoding="base64", data_slice=DataSliceOpts(offset=1, length=2)
+    )
+    assert expected == actual
+
+
+def test_get_multiple_accounts_body(unit_test_http_client_async):
+    """Test generating getMultipleAccounts body with a data slice."""
+    pubkeys = [Pubkey([0] * 31 + [0])]
+    expected = GetMultipleAccounts(
+        pubkeys,
+        RpcAccountInfoConfig(
+            encoding=UiAccountEncoding.Base64,
+            commitment=CommitmentLevel.Processed,
+            data_slice=UiDataSliceConfig(offset=1, length=2),
+        ),
+    )
+    actual = unit_test_http_client_async._get_multiple_accounts_body(
+        pubkeys=pubkeys, commitment=None, encoding="base64", data_slice=DataSliceOpts(offset=1, length=2)
+    )
+    assert expected == actual
+
+
+def test_get_program_accounts_body(unit_test_http_client_async):
+    """Test generating getProgramAccounts body with a data slice and memcmp filters."""
+    pubkey = Pubkey([0] * 31 + [0])
+    expected = GetProgramAccounts(
+        pubkey,
+        RpcProgramAccountsConfig(
+            RpcAccountInfoConfig(
+                encoding=UiAccountEncoding.Base64,
+                commitment=CommitmentLevel.Processed,
+                data_slice=UiDataSliceConfig(offset=1, length=2),
+            ),
+            [17, Memcmp(offset=4, bytes_="3Mc6vR")],
+        ),
+    )
+    actual = unit_test_http_client_async._get_program_accounts_body(
+        pubkey=pubkey,
+        commitment=None,
+        encoding="base64",
+        data_slice=DataSliceOpts(offset=1, length=2),
+        filters=[17, MemcmpOpts(offset=4, bytes="3Mc6vR")],
+    )
+    assert expected == actual
+
+
+def test_get_token_accounts_by_owner_body(unit_test_http_client_async):
+    """Test generating getTokenAccountsByOwner body from token account opts."""
+    owner = Pubkey([0] * 31 + [0])
+    expected = GetTokenAccountsByOwner(
+        owner,
+        RpcTokenAccountsFilterProgramId(SYSTEM_PROGRAM_ID),
+        RpcAccountInfoConfig(
+            encoding=UiAccountEncoding.Base64,
+            commitment=CommitmentLevel.Processed,
+            data_slice=None,
+        ),
+    )
+    actual = unit_test_http_client_async._get_token_accounts_by_owner_body(
+        owner, TokenAccountOpts(program_id=SYSTEM_PROGRAM_ID), None
     )
     assert expected == actual

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -4,15 +4,29 @@ from unittest.mock import patch
 
 import pytest
 from httpx2 import ReadTimeout
+from solders.account_decoder import UiAccountEncoding, UiDataSliceConfig
 from solders.commitment_config import CommitmentLevel
 from solders.pubkey import Pubkey
-from solders.rpc.config import RpcSignaturesForAddressConfig
-from solders.rpc.requests import GetSignaturesForAddress
+from solders.rpc.config import (
+    RpcAccountInfoConfig,
+    RpcProgramAccountsConfig,
+    RpcSignaturesForAddressConfig,
+    RpcTokenAccountsFilterProgramId,
+)
+from solders.rpc.filter import Memcmp
+from solders.rpc.requests import (
+    GetAccountInfo,
+    GetMultipleAccounts,
+    GetProgramAccounts,
+    GetSignaturesForAddress,
+    GetTokenAccountsByOwner,
+)
 from solders.signature import Signature
 
 from solana.constants import SYSTEM_PROGRAM_ID
 from solana.exceptions import SolanaRpcException
 from solana.rpc.commitment import Finalized
+from solana.rpc.models import DataSliceOpts, MemcmpOpts, TokenAccountOpts
 
 
 def test_client_http_exception(unit_test_http_client):
@@ -52,4 +66,80 @@ def test_client_address_sig_args_with_commitment(unit_test_http_client):
         RpcSignaturesForAddressConfig(limit=5, commitment=CommitmentLevel.Finalized),
     )
     actual = unit_test_http_client._get_signatures_for_address_body(Pubkey([0] * 31 + [0]), None, None, 5, Finalized)
+    assert expected == actual
+
+
+def test_get_account_info_body(unit_test_http_client):
+    """Test generating getAccountInfo body with a data slice."""
+    pubkey = Pubkey([0] * 31 + [0])
+    expected = GetAccountInfo(
+        pubkey,
+        RpcAccountInfoConfig(
+            encoding=UiAccountEncoding.Base64,
+            data_slice=UiDataSliceConfig(offset=1, length=2),
+            commitment=CommitmentLevel.Processed,
+        ),
+    )
+    actual = unit_test_http_client._get_account_info_body(
+        pubkey=pubkey, commitment=None, encoding="base64", data_slice=DataSliceOpts(offset=1, length=2)
+    )
+    assert expected == actual
+
+
+def test_get_multiple_accounts_body(unit_test_http_client):
+    """Test generating getMultipleAccounts body with a data slice."""
+    pubkeys = [Pubkey([0] * 31 + [0])]
+    expected = GetMultipleAccounts(
+        pubkeys,
+        RpcAccountInfoConfig(
+            encoding=UiAccountEncoding.Base64,
+            commitment=CommitmentLevel.Processed,
+            data_slice=UiDataSliceConfig(offset=1, length=2),
+        ),
+    )
+    actual = unit_test_http_client._get_multiple_accounts_body(
+        pubkeys=pubkeys, commitment=None, encoding="base64", data_slice=DataSliceOpts(offset=1, length=2)
+    )
+    assert expected == actual
+
+
+def test_get_program_accounts_body(unit_test_http_client):
+    """Test generating getProgramAccounts body with a data slice and memcmp filters."""
+    pubkey = Pubkey([0] * 31 + [0])
+    expected = GetProgramAccounts(
+        pubkey,
+        RpcProgramAccountsConfig(
+            RpcAccountInfoConfig(
+                encoding=UiAccountEncoding.Base64,
+                commitment=CommitmentLevel.Processed,
+                data_slice=UiDataSliceConfig(offset=1, length=2),
+            ),
+            [17, Memcmp(offset=4, bytes_="3Mc6vR")],
+        ),
+    )
+    actual = unit_test_http_client._get_program_accounts_body(
+        pubkey=pubkey,
+        commitment=None,
+        encoding="base64",
+        data_slice=DataSliceOpts(offset=1, length=2),
+        filters=[17, MemcmpOpts(offset=4, bytes="3Mc6vR")],
+    )
+    assert expected == actual
+
+
+def test_get_token_accounts_by_owner_body(unit_test_http_client):
+    """Test generating getTokenAccountsByOwner body from token account opts."""
+    owner = Pubkey([0] * 31 + [0])
+    expected = GetTokenAccountsByOwner(
+        owner,
+        RpcTokenAccountsFilterProgramId(SYSTEM_PROGRAM_ID),
+        RpcAccountInfoConfig(
+            encoding=UiAccountEncoding.Base64,
+            commitment=CommitmentLevel.Processed,
+            data_slice=None,
+        ),
+    )
+    actual = unit_test_http_client._get_token_accounts_by_owner_body(
+        owner, TokenAccountOpts(program_id=SYSTEM_PROGRAM_ID), None
+    )
     assert expected == actual


### PR DESCRIPTION
Continues the Pydantic migration (after #659 / #660) for the RPC clients' `data_slice` and `filters` call sites, covering both the sync `Client` and the `AsyncClient`. Pydantic models are accepted alongside the deprecated `NamedTuple` equivalents and prioritized as first-class support, since the `NamedTuple` types are slated for removal in an upcoming release.

## Changes

**`solana.rpc.api.Client` (sync) & `solana.rpc.async_api.AsyncClient`**
- `get_account_info` / `get_multiple_accounts`: `data_slice` now accepts `Union[types.DataSliceOpts, DataSliceOpts]` (Pydantic).
- `get_program_accounts` / `get_program_accounts_json_parsed`: `filters` now accepts the Pydantic `MemcmpOpts` (`Union[int, types.MemcmpOpts, MemcmpOpts]`); `get_program_accounts` `data_slice` accepts the Pydantic `DataSliceOpts`.

**`solana.rpc.core._ClientCore` (shared)**
- Body builders (`_get_account_info_body`, `_get_multiple_accounts_body`, `_get_program_accounts_body`) updated to the same `Union` types so both clients build request bodies from either variant.

**Tests**
- New body-builder unit tests in `tests/unit/test_client.py` and `tests/unit/test_async_client.py` for `get_account_info`, `get_multiple_accounts`, `get_program_accounts`, and `get_token_accounts_by_owner`, constructing opts from the Pydantic models and asserting the exact solders request objects. These also add the first coverage for the `get_program_accounts` (filters) and `get_token_accounts_*` (opts) call sites.

Existing sync/async integration tests already pass the Pydantic `DataSliceOpts` / `TxOpts` (migrated in #659); no test exercises the deprecated `NamedTuple` opts through these code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)