### PR TITLE
Migrate internal call sites to Pydantic models (Part 4: vote program)

### DIFF
--- a/src/solana/vote_program.py
+++ b/src/solana/vote_program.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple
+from typing import NamedTuple, Union
 from typing_extensions import deprecated
 
 from solders.instruction import AccountMeta, Instruction
 from solders.pubkey import Pubkey
 
+from solana import models
 from solana.constants import VOTE_PROGRAM_ID
 from solana._layouts.vote_instructions import VOTE_INSTRUCTIONS_LAYOUT, InstructionType
 
@@ -27,12 +28,15 @@ class WithdrawFromVoteAccountParams(NamedTuple):
     """"""
 
 
-def withdraw_from_vote_account(params: WithdrawFromVoteAccountParams) -> Instruction:
+def withdraw_from_vote_account(
+    params: Union[WithdrawFromVoteAccountParams, models.WithdrawFromVoteAccountParams],
+) -> Instruction:
     """Generate an instruction that transfers lamports from a vote account to any other.
 
     Example:
         >>> from solders.pubkey import Pubkey
         >>> from solders.keypair import Keypair
+        >>> from solana.models import WithdrawFromVoteAccountParams
         >>> vote = Pubkey([0] * 31 + [1])
         >>> withdrawer = Keypair.from_seed(bytes([0]*32))
         >>> instruction = withdraw_from_vote_account(
@@ -49,6 +53,7 @@ def withdraw_from_vote_account(params: WithdrawFromVoteAccountParams) -> Instruc
     Returns:
         The generated instruction.
     """
+    params = models.WithdrawFromVoteAccountParams.from_namedtuple(params)
     data = VOTE_INSTRUCTIONS_LAYOUT.build(
         {
             "instruction_type": InstructionType.WITHDRAW_FROM_VOTE_ACCOUNT,

--- a/tests/unit/test_vote_program.py
+++ b/tests/unit/test_vote_program.py
@@ -2,14 +2,17 @@
 
 import base64
 
+import pytest
 from solders.hash import Hash
 from solders.keypair import Keypair
 from solders.message import Message
 from solders.pubkey import Pubkey
 import solana.vote_program as vp
+from solana import models
 
 
-def test_withdraw_from_vote_account():
+@pytest.mark.parametrize("params_cls", [vp.WithdrawFromVoteAccountParams, models.WithdrawFromVoteAccountParams])
+def test_withdraw_from_vote_account(params_cls):
     withdrawer_keypair = Keypair.from_bytes(
         [
             134,
@@ -84,7 +87,7 @@ def test_withdraw_from_vote_account():
     msg = Message.new_with_blockhash(
         [
             vp.withdraw_from_vote_account(
-                vp.WithdrawFromVoteAccountParams(
+                params_cls(
                     vote_account_from_pubkey=vote_account_pubkey,
                     to_pubkey=receiver_account_pubkey,
                     withdrawer=withdrawer_keypair.pubkey(),


### PR DESCRIPTION
Continues the Pydantic migration (Parts 1–3: #659, #660, #662) for the Solana vote program.

## What changed

**`src/solana/vote_program.py`**
- `withdraw_from_vote_account` now accepts `Union[WithdrawFromVoteAccountParams, models.WithdrawFromVoteAccountParams]` — the deprecated `NamedTuple` or the new Pydantic model.
- Coerces at the boundary via `models.WithdrawFromVoteAccountParams.from_namedtuple(params)`.
- Docstring example updated to import from `solana.models`.
- The deprecated `NamedTuple` remains defined locally for backwards compatibility.

**`tests/unit/test_vote_program.py`**
- Parametrized over both `vp.WithdrawFromVoteAccountParams` (deprecated) and `models.WithdrawFromVoteAccountParams` (Pydantic), asserting both produce identical wire bytes.

The `WithdrawFromVoteAccountParams` Pydantic model already exists in `solana.models` (added in #656), so no new model definition was needed.

## Verification
- ✅ Unit tests: 2 passed (both param classes)
- ✅ Doctest passed
- ✅ `ruff check` clean
- ✅ `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)