### PR TITLE
Migrate internal call sites to Pydantic models (Part 5: SPL token cli…

### DIFF
--- a/src/spl/token/async_client.py
+++ b/src/spl/token/async_client.py
@@ -18,9 +18,10 @@ from solders.rpc.responses import (
 )
 
 import spl.token.instructions as spl_token
+from solana.rpc import types
 from solana.rpc.async_api import AsyncClient
 from solana.rpc.commitment import Commitment
-from solana.rpc.models import TxOpts
+from solana.rpc.models import TxOpts as TxOptsModel
 from spl.token._layouts import ACCOUNT_LAYOUT, MINT_LAYOUT, MULTISIG_LAYOUT
 from spl.token.core import _TokenCore
 from spl.token.models import AccountInfo, MintInfo
@@ -352,7 +353,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         self,
         m: int,
         multi_signers: List[Pubkey],
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> Pubkey:  # pylint: disable=invalid-name
         """Create and initialize a new multisig.
@@ -371,7 +372,11 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
             (await self._conn.get_latest_blockhash()).value.blockhash if recent_blockhash is None else recent_blockhash
         )
         txn, multisig = self._create_multisig_args(m, multi_signers, balance_needed, recent_blockhash_to_use)
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         await self._conn.send_transaction(txn, opts=opts_to_use)
         return multisig.pubkey()
 
@@ -392,7 +397,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         owner: Union[Keypair, Pubkey],
         amount: int,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Transfer tokens to another account.
@@ -406,7 +411,11 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             (await self._conn.get_latest_blockhash()).value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -428,7 +437,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         owner: Pubkey,
         amount: int,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Grant a third-party permission to transfer up the specified number of tokens from an account.
@@ -442,7 +451,11 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             (await self._conn.get_latest_blockhash()).value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -462,7 +475,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         account: Pubkey,
         owner: Pubkey,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Revoke transfer authority for a given account.
@@ -474,7 +487,11 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             (await self._conn.get_latest_blockhash()).value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -490,7 +507,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         authority_type: spl_token.AuthorityType,
         new_authority: Optional[Pubkey] = None,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Assign a new authority to the account.
@@ -504,7 +521,11 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             (await self._conn.get_latest_blockhash()).value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -525,7 +546,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         mint_authority: Union[Keypair, Pubkey],
         amount: int,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Mint new tokens.
@@ -541,7 +562,11 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         If skip confirmation is set to `False`, this method will block for at most 30 seconds
         or until the transaction is confirmed.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             (await self._conn.get_latest_blockhash()).value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -561,7 +586,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         owner: Pubkey,
         amount: int,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Burn tokens.
@@ -574,7 +599,11 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             (await self._conn.get_latest_blockhash()).value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -587,7 +616,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         dest: Pubkey,
         authority: Pubkey,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Remove approval for the transfer of any remaining tokens.
@@ -600,7 +629,11 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             (await self._conn.get_latest_blockhash()).value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -619,7 +652,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         account: Pubkey,
         authority: Pubkey,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Freeze account.
@@ -631,7 +664,11 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             (await self._conn.get_latest_blockhash()).value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -643,7 +680,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         account: Pubkey,
         authority: Pubkey,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Thaw account.
@@ -655,7 +692,11 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             (await self._conn.get_latest_blockhash()).value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -670,7 +711,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         amount: int,
         decimals: int,
         multi_signers: Optional[List[Keypair]],
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Transfer tokens to another account, asserting the token mint and decimals.
@@ -685,7 +726,11 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             (await self._conn.get_latest_blockhash()).value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -709,7 +754,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         amount: int,
         decimals: int,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Grant a third-party permission to transfer up the specified number of tokens from an account.
@@ -726,7 +771,11 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash (optional): A prefetched blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             (await self._conn.get_latest_blockhash()).value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -749,7 +798,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         amount: int,
         decimals: int,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Mint new tokens, asserting the token mint and decimals.
@@ -763,7 +812,11 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash (optional): A prefetched blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             (await self._conn.get_latest_blockhash()).value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -785,7 +838,7 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
         amount: int,
         decimals: int,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Burn tokens, asserting the token mint and decimals.
@@ -799,7 +852,11 @@ class AsyncToken(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             (await self._conn.get_latest_blockhash()).value.blockhash if recent_blockhash is None else recent_blockhash
         )

--- a/src/spl/token/client.py
+++ b/src/spl/token/client.py
@@ -18,9 +18,10 @@ from solders.rpc.responses import (
 )
 
 import spl.token.instructions as spl_token
+from solana.rpc import types
 from solana.rpc.api import Client
 from solana.rpc.commitment import Commitment
-from solana.rpc.models import TxOpts
+from solana.rpc.models import TxOpts as TxOptsModel
 from spl.token._layouts import ACCOUNT_LAYOUT, MINT_LAYOUT, MULTISIG_LAYOUT
 from spl.token.core import _TokenCore
 from spl.token.models import AccountInfo, MintInfo
@@ -351,7 +352,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         self,
         m: int,
         multi_signers: List[Pubkey],
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> Pubkey:  # pylint: disable=invalid-name
         """Create and initialize a new multisig.
@@ -370,7 +371,11 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
             self._conn.get_latest_blockhash().value.blockhash if recent_blockhash is None else recent_blockhash
         )
         txn, multisig = self._create_multisig_args(m, multi_signers, balance_needed, recent_blockhash_to_use)
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         self._conn.send_transaction(txn, opts=opts_to_use)
         return multisig.pubkey()
 
@@ -391,7 +396,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         owner: Union[Keypair, Pubkey],
         amount: int,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Transfer tokens to another account.
@@ -405,7 +410,11 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             self._conn.get_latest_blockhash().value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -427,7 +436,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         owner: Pubkey,
         amount: int,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Grant a third-party permission to transfer up the specified number of tokens from an account.
@@ -441,7 +450,11 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             self._conn.get_latest_blockhash().value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -461,7 +474,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         account: Pubkey,
         owner: Pubkey,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Revoke transfer authority for a given account.
@@ -473,7 +486,11 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             self._conn.get_latest_blockhash().value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -489,7 +506,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         authority_type: spl_token.AuthorityType,
         new_authority: Optional[Pubkey] = None,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Assign a new authority to the account.
@@ -503,7 +520,11 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             self._conn.get_latest_blockhash().value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -524,7 +545,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         mint_authority: Union[Keypair, Pubkey],
         amount: int,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Mint new tokens.
@@ -540,7 +561,11 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         If skip confirmation is set to `False`, this method will block for at most 30 seconds
         or until the transaction is confirmed.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             self._conn.get_latest_blockhash().value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -560,7 +585,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         owner: Pubkey,
         amount: int,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Burn tokens.
@@ -573,7 +598,11 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             self._conn.get_latest_blockhash().value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -586,7 +615,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         dest: Pubkey,
         authority: Union[Keypair, Pubkey],
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Remove approval for the transfer of any remaining tokens.
@@ -599,7 +628,11 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             self._conn.get_latest_blockhash().value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -618,7 +651,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         account: Pubkey,
         authority: Union[Pubkey, Keypair],
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Freeze account.
@@ -630,7 +663,11 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             self._conn.get_latest_blockhash().value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -642,7 +679,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         account: Pubkey,
         authority: Pubkey,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Thaw account.
@@ -654,7 +691,11 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             self._conn.get_latest_blockhash().value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -669,7 +710,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         amount: int,
         decimals: int,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Transfer tokens to another account, asserting the token mint and decimals.
@@ -684,7 +725,11 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             self._conn.get_latest_blockhash().value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -708,7 +753,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         amount: int,
         decimals: int,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Grant a third-party permission to transfer up the specified number of tokens from an account.
@@ -725,7 +770,11 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             self._conn.get_latest_blockhash().value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -748,7 +797,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         amount: int,
         decimals: int,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Mint new tokens, asserting the token mint and decimals.
@@ -762,7 +811,11 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             self._conn.get_latest_blockhash().value.blockhash if recent_blockhash is None else recent_blockhash
         )
@@ -784,7 +837,7 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
         amount: int,
         decimals: int,
         multi_signers: Optional[List[Keypair]] = None,
-        opts: Optional[TxOpts] = None,
+        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
         recent_blockhash: Optional[Blockhash] = None,
     ) -> SendTransactionResp:
         """Burn tokens, asserting the token mint and decimals.
@@ -798,7 +851,11 @@ class Token(_TokenCore):  # pylint: disable=too-many-public-methods
             opts: (optional) Transaction options.
             recent_blockhash: (optional) a prefetched Blockhash for the transaction.
         """
-        opts_to_use = TxOpts(preflight_commitment=self._conn.commitment) if opts is None else opts
+        opts_to_use = (
+            TxOptsModel(preflight_commitment=self._conn.commitment)
+            if opts is None
+            else TxOptsModel.from_namedtuple(opts)
+        )
         recent_blockhash_to_use = (
             self._conn.get_latest_blockhash().value.blockhash if recent_blockhash is None else recent_blockhash
         )


### PR DESCRIPTION
…ents)

Widen the public `opts` parameter on all 14 transaction methods of spl.token.client.Token and spl.token.async_client.AsyncToken to accept both the deprecated types.TxOpts NamedTuple and the Pydantic TxOpts model, consistent with the other migrated boundaries.

Part 1 migrated these clients' internal usage to the Pydantic model but left the public boundary model-only, making the still-supported deprecated NamedTuple a type error. Each method now coerces via TxOptsModel.from_namedtuple before passing opts to the internal _TokenCore helpers.