### PR TITLE
Migrate internal call sites to Pydantic models (Part 6: websocket_api…

### DIFF
--- a/src/solana/rpc/websocket_api.py
+++ b/src/solana/rpc/websocket_api.py
@@ -53,6 +53,7 @@ from websockets.asyncio.client import connect as ws_connect
 
 from solana.rpc import types
 from solana.rpc.commitment import Commitment
+from solana.rpc.models import DataSliceOpts as DataSliceOptsModel, MemcmpOpts as MemcmpOptsModel
 from solana.rpc.core import (
     _ACCOUNT_ENCODING_TO_SOLDERS,
     _COMMITMENT_TO_SOLDERS,
@@ -242,8 +243,8 @@ class SolanaWsClientProtocol(ClientConnection):
         program_id: Pubkey,
         commitment: Optional[Commitment] = None,
         encoding: Optional[str] = None,
-        data_slice: Optional[types.DataSliceOpts] = None,
-        filters: Optional[Sequence[Union[int, types.MemcmpOpts]]] = None,
+        data_slice: Optional[Union[types.DataSliceOpts, DataSliceOptsModel]] = None,
+        filters: Optional[Sequence[Union[int, types.MemcmpOpts, MemcmpOptsModel]]] = None,
     ) -> int:
         """Receive notifications when the lamports or data for a given account owned by the program changes.
 
@@ -271,7 +272,9 @@ class SolanaWsClientProtocol(ClientConnection):
                 data_slice=data_slice_to_use,
             )
             filters_to_use: Optional[List[Union[int, Memcmp]]] = (
-                None if filters is None else [x if isinstance(x, int) else Memcmp(*x) for x in filters]
+                None
+                if filters is None
+                else [x if isinstance(x, int) else Memcmp(offset=x.offset, bytes_=x.bytes) for x in filters]
             )
             config = RpcProgramAccountsConfig(account_config, filters_to_use)
         req = ProgramSubscribe(program_id, config, req_id)

--- a/tests/unit/test_websocket_api.py
+++ b/tests/unit/test_websocket_api.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 import itertools
 
+from solders.account_decoder import UiAccountEncoding, UiDataSliceConfig
+from solders.commitment_config import CommitmentLevel
 from solders.pubkey import Pubkey
+from solders.rpc.config import RpcAccountInfoConfig, RpcProgramAccountsConfig
+from solders.rpc.filter import Memcmp
 
+from solana.rpc import types
+from solana.rpc.commitment import Processed
+from solana.rpc.models import DataSliceOpts, MemcmpOpts
 from solana.rpc.websocket_api import SolanaWsClientProtocol, connect
 
 
@@ -41,6 +48,72 @@ async def test_slot_subscribe_returns_request_id(monkeypatch):
 
     assert request_id == 1
     assert sent_messages[0].id == request_id
+
+
+async def test_program_subscribe_with_config(monkeypatch):
+    """program_subscribe should accept Pydantic DataSliceOpts/MemcmpOpts models."""
+    protocol = SolanaWsClientProtocol.__new__(SolanaWsClientProtocol)
+    protocol.request_counter = itertools.count()
+    sent_messages = []
+
+    async def fake_send_request(self, message):
+        sent_messages.append(message)
+
+    monkeypatch.setattr(SolanaWsClientProtocol, "send_request", fake_send_request)
+
+    program_id = Pubkey.default()
+    request_id = await protocol.program_subscribe(
+        program_id,
+        commitment=Processed,
+        encoding="base64",
+        data_slice=DataSliceOpts(offset=1, length=2),
+        filters=[17, MemcmpOpts(offset=4, bytes="3Mc6vR")],
+    )
+
+    expected_config = RpcProgramAccountsConfig(
+        RpcAccountInfoConfig(
+            encoding=UiAccountEncoding.Base64,
+            commitment=CommitmentLevel.Processed,
+            data_slice=UiDataSliceConfig(offset=1, length=2),
+        ),
+        [17, Memcmp(offset=4, bytes_="3Mc6vR")],
+    )
+    assert request_id == 1
+    assert sent_messages[0].id == request_id
+    assert sent_messages[0].config == expected_config
+
+
+async def test_program_subscribe_with_config_from_deprecated_namedtuples(monkeypatch):
+    """program_subscribe should still accept the deprecated DataSliceOpts/MemcmpOpts NamedTuples."""
+    protocol = SolanaWsClientProtocol.__new__(SolanaWsClientProtocol)
+    protocol.request_counter = itertools.count()
+    sent_messages = []
+
+    async def fake_send_request(self, message):
+        sent_messages.append(message)
+
+    monkeypatch.setattr(SolanaWsClientProtocol, "send_request", fake_send_request)
+
+    program_id = Pubkey.default()
+    request_id = await protocol.program_subscribe(
+        program_id,
+        commitment=Processed,
+        encoding="base64",
+        data_slice=types.DataSliceOpts(offset=1, length=2),
+        filters=[17, types.MemcmpOpts(offset=4, bytes="3Mc6vR")],
+    )
+
+    expected_config = RpcProgramAccountsConfig(
+        RpcAccountInfoConfig(
+            encoding=UiAccountEncoding.Base64,
+            commitment=CommitmentLevel.Processed,
+            data_slice=UiDataSliceConfig(offset=1, length=2),
+        ),
+        [17, Memcmp(offset=4, bytes_="3Mc6vR")],
+    )
+    assert request_id == 1
+    assert sent_messages[0].id == request_id
+    assert sent_messages[0].config == expected_config
 
 
 async def test_connect_preserves_async_with_and_custom_connection(monkeypatch):


### PR DESCRIPTION
… program_subscribe)

Accept the Pydantic DataSliceOpts/MemcmpOpts models alongside the deprecated NamedTuples in SolanaWsClientProtocol.program_subscribe, mirroring the rpc client migration. Memcmp construction now uses attribute access so it works for both the NamedTuple and the model.