### PR TITLE
Migrate docs to Pydantic models instead of deprecated NamedTuples

### DIFF
--- a/docs/cookbook/token-operations/burn-tokens.md
+++ b/docs/cookbook/token-operations/burn-tokens.md
@@ -16,7 +16,8 @@ from solders.keypair import Keypair
 from solders.pubkey import Pubkey
 from solders.transaction import VersionedTransaction
 from solders.message import MessageV0
-from spl.token.instructions import burn, BurnParams
+from spl.token.instructions import burn
+from spl.token.models import BurnParams
 from spl.token.constants import TOKEN_PROGRAM_ID
 
 async def main():

--- a/docs/cookbook/token-operations/close-token-account.md
+++ b/docs/cookbook/token-operations/close-token-account.md
@@ -16,7 +16,8 @@ from solders.keypair import Keypair
 from solders.pubkey import Pubkey
 from solders.transaction import VersionedTransaction
 from solders.message import MessageV0
-from spl.token.instructions import close_account, CloseAccountParams
+from spl.token.instructions import close_account
+from spl.token.models import CloseAccountParams
 from spl.token.constants import TOKEN_PROGRAM_ID
 
 async def main():

--- a/docs/cookbook/token-operations/create-token.md
+++ b/docs/cookbook/token-operations/create-token.md
@@ -15,7 +15,8 @@ from solana.rpc.async_api import AsyncClient
 from solders.keypair import Keypair
 from solders.transaction import VersionedTransaction
 from solders.message import MessageV0
-from spl.token.instructions import initialize_mint, InitializeMintParams
+from spl.token.instructions import initialize_mint
+from spl.token.models import InitializeMintParams
 from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.system_program import create_account, CreateAccountParams
 

--- a/docs/cookbook/token-operations/delegate-token-account.md
+++ b/docs/cookbook/token-operations/delegate-token-account.md
@@ -17,11 +17,16 @@ from solders.transaction import VersionedTransaction
 from solders.message import MessageV0
 from solders.system_program import create_account, CreateAccountParams
 from spl.token.instructions import (
-    initialize_mint, InitializeMintParams,
-    create_associated_token_account, 
-    mint_to_checked, MintToCheckedParams,
-    approve_checked, ApproveCheckedParams,
+    initialize_mint,
+    create_associated_token_account,
+    mint_to_checked,
+    approve_checked,
     get_associated_token_address
+)
+from spl.token.models import (
+    InitializeMintParams,
+    MintToCheckedParams,
+    ApproveCheckedParams,
 )
 from spl.token.constants import TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID
 

--- a/docs/cookbook/token-operations/get-all-token-accounts-by-owner.md
+++ b/docs/cookbook/token-operations/get-all-token-accounts-by-owner.md
@@ -14,7 +14,7 @@ import asyncio
 from solana.rpc.async_api import AsyncClient
 from solders.pubkey import Pubkey
 from spl.token.constants import TOKEN_PROGRAM_ID
-from solana.rpc.types import TokenAccountOpts
+from solana.rpc.models import TokenAccountOpts
 
 async def main():
     rpc = AsyncClient("https://api.devnet.solana.com")

--- a/docs/cookbook/token-operations/mint-tokens.md
+++ b/docs/cookbook/token-operations/mint-tokens.md
@@ -16,7 +16,8 @@ from solders.keypair import Keypair
 from solders.pubkey import Pubkey
 from solders.transaction import VersionedTransaction
 from solders.message import MessageV0
-from spl.token.instructions import mint_to, MintToParams
+from spl.token.instructions import mint_to
+from spl.token.models import MintToParams
 from spl.token.constants import TOKEN_PROGRAM_ID
 
 async def main():

--- a/docs/cookbook/token-operations/revoke-delegate.md
+++ b/docs/cookbook/token-operations/revoke-delegate.md
@@ -17,11 +17,16 @@ from solders.transaction import VersionedTransaction
 from solders.message import MessageV0
 from solders.system_program import create_account, CreateAccountParams
 from spl.token.instructions import (
-    initialize_mint, InitializeMintParams,
-    create_associated_token_account, 
-    mint_to_checked, MintToCheckedParams,
-    revoke, RevokeParams,
+    initialize_mint,
+    create_associated_token_account,
+    mint_to_checked,
+    revoke,
     get_associated_token_address
+)
+from spl.token.models import (
+    InitializeMintParams,
+    MintToCheckedParams,
+    RevokeParams,
 )
 from spl.token.constants import TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID
 

--- a/docs/cookbook/token-operations/set-authority.md
+++ b/docs/cookbook/token-operations/set-authority.md
@@ -16,9 +16,9 @@ from solders.keypair import Keypair
 from solders.pubkey import Pubkey
 from solders.transaction import VersionedTransaction
 from solders.message import MessageV0
-from spl.token.instructions import set_authority, SetAuthorityParams
+from spl.token.instructions import set_authority
 from spl.token.constants import TOKEN_PROGRAM_ID
-from spl.token.instructions import AuthorityType
+from spl.token.models import SetAuthorityParams, AuthorityType
 
 async def main():
     rpc = AsyncClient("https://api.devnet.solana.com")

--- a/docs/cookbook/token-operations/transfer-tokens.md
+++ b/docs/cookbook/token-operations/transfer-tokens.md
@@ -16,8 +16,9 @@ from solders.keypair import Keypair
 from solders.pubkey import Pubkey
 from solders.transaction import VersionedTransaction
 from solders.message import MessageV0
-from spl.token.instructions import transfer_checked, TransferCheckedParams
+from spl.token.instructions import transfer_checked
 from spl.token.instructions import get_associated_token_address
+from spl.token.models import TransferCheckedParams
 from spl.token.constants import TOKEN_PROGRAM_ID
 
 async def main():

--- a/docs/cookbook/token-operations/wrapped-sol.md
+++ b/docs/cookbook/token-operations/wrapped-sol.md
@@ -18,9 +18,13 @@ from solders.message import MessageV0
 from solders.system_program import transfer, TransferParams
 from spl.token.instructions import (
     create_associated_token_account,
-    sync_native, SyncNativeParams,
-    close_account, CloseAccountParams,
+    sync_native,
+    close_account,
     get_associated_token_address
+)
+from spl.token.models import (
+    SyncNativeParams,
+    CloseAccountParams,
 )
 from spl.token.constants import TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID
 from solders.pubkey import Pubkey

--- a/docs/cookbook/transaction-operations/add-memo-to-transaction.md
+++ b/docs/cookbook/transaction-operations/add-memo-to-transaction.md
@@ -16,7 +16,8 @@ from solders.keypair import Keypair
 from solders.system_program import transfer, TransferParams
 from solders.transaction import VersionedTransaction
 from solders.message import MessageV0
-from spl.memo.instructions import create_memo, MemoParams
+from spl.memo.instructions import create_memo
+from spl.memo.models import MemoParams
 from solders.pubkey import Pubkey
 
 async def main():

--- a/docs/cookbook/transaction-operations/send-tokens.md
+++ b/docs/cookbook/transaction-operations/send-tokens.md
@@ -16,7 +16,8 @@ from solders.keypair import Keypair
 from solders.pubkey import Pubkey
 from solders.transaction import VersionedTransaction
 from solders.message import MessageV0
-from spl.token.instructions import transfer_checked, TransferCheckedParams
+from spl.token.instructions import transfer_checked
+from spl.token.models import TransferCheckedParams
 from spl.token.constants import TOKEN_PROGRAM_ID
 
 async def main():

--- a/docs/rpc/types.md
+++ b/docs/rpc/types.md
@@ -1,3 +1,9 @@
 # RPC Types
 
+!!! warning "Deprecated"
+    The `NamedTuple` types in this module (`DataSliceOpts`, `MemcmpOpts`,
+    `TokenAccountOpts`, `TxOpts`) are deprecated. Use the Pydantic models in
+    [`solana.rpc.models`](models.md) instead — they carry the same field names
+    and defaults, so migrating is just a matter of changing the import path.
+
 :::solana.rpc.types


### PR DESCRIPTION
Update cookbook examples to import params/opts from the new models modules (spl.token.models, spl.memo.models, solana.rpc.models) instead of the deprecated NamedTuple locations, and add a deprecation note to the solana.rpc.types reference page pointing to solana.rpc.models.