### PR TITLE
add deprecated mark on batch request

### DIFF
--- a/src/solana/rpc/providers/async_http.py
+++ b/src/solana/rpc/providers/async_http.py
@@ -102,7 +102,7 @@ class AsyncHTTPProvider(AsyncBaseProvider, _HTTPProviderCore):
             raw_response = await self.session.post(**request_kwargs)
         return _after_request_unparsed(raw_response)
 
-    async def make_batch_request_unparsed(self, reqs: Tuple[Body, ...]) -> str:
+    async def _make_batch_request_unparsed(self, reqs: Tuple[Body, ...]) -> str:
         """Make an async HTTP batch request to an http rpc endpoint."""
         if self._limiter is not None:
             async with self._limiter:
@@ -118,6 +118,23 @@ class AsyncHTTPProvider(AsyncBaseProvider, _HTTPProviderCore):
         except (httpx2.RemoteProtocolError, httpx2.ReadError):
             raw_response = await self.session.post(**request_kwargs)
         return _after_request_unparsed(raw_response)
+
+    async def make_batch_request_unparsed(self, reqs: Tuple[Body, ...]) -> str:
+        """Make an async HTTP batch request to an http rpc endpoint.
+
+        .. deprecated::
+            ``make_batch_request_unparsed`` is deprecated and will be removed in a future release.
+            Use individual requests with ``asyncio.gather`` instead.
+            See https://github.com/michaelhly/solana-py/issues/645 for details.
+        """
+        warnings.warn(
+            "make_batch_request_unparsed is deprecated and will be removed in a future release. "
+            "Use individual requests with asyncio.gather instead. "
+            "See https://github.com/michaelhly/solana-py/issues/645 for details.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return await self._make_batch_request_unparsed(reqs)
 
     @overload
     async def make_batch_request(self, reqs: _BodiesTup, parsers: _Tup) -> _RespTup: ...
@@ -171,7 +188,7 @@ class AsyncHTTPProvider(AsyncBaseProvider, _HTTPProviderCore):
             DeprecationWarning,
             stacklevel=2,
         )
-        raw = await self.make_batch_request_unparsed(reqs)
+        raw = await self._make_batch_request_unparsed(reqs)
         return _parse_raw_batch(raw, parsers)
 
     async def __aenter__(self) -> "AsyncHTTPProvider":

--- a/src/solana/rpc/providers/http.py
+++ b/src/solana/rpc/providers/http.py
@@ -83,7 +83,7 @@ class HTTPProvider(BaseProvider, _HTTPProviderCore):
             raw_response = self.session.post(**request_kwargs)
         return _after_request_unparsed(raw_response)
 
-    def make_batch_request_unparsed(self, reqs: Tuple[Body, ...]) -> str:
+    def _make_batch_request_unparsed(self, reqs: Tuple[Body, ...]) -> str:
         """Make an HTTP batch request to an http rpc endpoint."""
         request_kwargs = self._before_batch_request(reqs)
         try:
@@ -91,6 +91,23 @@ class HTTPProvider(BaseProvider, _HTTPProviderCore):
         except (httpx2.RemoteProtocolError, httpx2.ReadError):
             raw_response = self.session.post(**request_kwargs)
         return _after_request_unparsed(raw_response)
+
+    def make_batch_request_unparsed(self, reqs: Tuple[Body, ...]) -> str:
+        """Make an HTTP batch request to an http rpc endpoint.
+
+        .. deprecated::
+            ``make_batch_request_unparsed`` is deprecated and will be removed in a future release.
+            Use individual requests instead.
+            See https://github.com/michaelhly/solana-py/issues/645 for details.
+        """
+        warnings.warn(
+            "make_batch_request_unparsed is deprecated and will be removed in a future release. "
+            "Use individual requests instead. "
+            "See https://github.com/michaelhly/solana-py/issues/645 for details.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._make_batch_request_unparsed(reqs)
 
     @overload
     def make_batch_request(self, reqs: _BodiesTup, parsers: _Tup) -> _RespTup: ...
@@ -144,5 +161,5 @@ class HTTPProvider(BaseProvider, _HTTPProviderCore):
             DeprecationWarning,
             stacklevel=2,
         )
-        raw = self.make_batch_request_unparsed(reqs)
+        raw = self._make_batch_request_unparsed(reqs)
         return _parse_raw_batch(raw, parsers)

--- a/uv.lock
+++ b/uv.lock
@@ -1335,7 +1335,7 @@ wheels = [
 
 [[package]]
 name = "solana"
-version = "0.37.1"
+version = "0.38.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },


### PR DESCRIPTION
This pull request deprecates the `make_batch_request_unparsed` method in both the async and sync HTTP providers, guiding users to use individual requests instead. The original batch methods are now private helpers, and the public methods emit deprecation warnings. Additionally, internal calls are updated to use the new private helpers.

### Deprecation and API Guidance

* Added deprecation warnings to the public `make_batch_request_unparsed` methods in both `AsyncHTTPProvider` (`src/solana/rpc/providers/async_http.py`) and `HTTPProvider` (`src/solana/rpc/providers/http.py`), advising users to use individual requests (with `asyncio.gather` for async) and referencing issue #645 for more details. 

### Internal Refactoring

* Renamed the original batch request methods to `_make_batch_request_unparsed` to make them private helpers in both providers.
* Updated internal calls within `make_batch_request` to use the new private `_make_batch_request_unparsed` methods instead of the deprecated public ones.

#645 