### PR TITLE
Remove batch request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Removed
 
-- Add deprecated mark to `batch request`
+- **BREAKING**: Remove `make_batch_request`, `make_batch_request_unparsed`, and all batch-related type aliases from `solana.rpc.providers`. Use individual requests with `asyncio.gather` (async) or sequential calls (sync) instead.
 - Add deprecated marks to `Client`, `Token`, and `AsyncToken`
 
 ## [0.38.0] - 2026-06-21

--- a/src/solana/rpc/providers/async_http.py
+++ b/src/solana/rpc/providers/async_http.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import warnings
-from typing import Dict, Optional, Tuple, Type, overload
+from typing import Dict, Optional, Type
 
 import httpx2
 from aiolimiter import AsyncLimiter
 from solders.rpc.requests import Body
-from solders.rpc.responses import RPCResult
 
 from ...exceptions import SolanaRpcException, handle_async_exceptions
 from .async_base import AsyncBaseProvider
@@ -17,28 +15,8 @@ from .core import (
     DEFAULT_TIMEOUT,
     T,
     _after_request_unparsed,
-    _BodiesTup,
-    _BodiesTup1,
-    _BodiesTup2,
-    _BodiesTup3,
-    _BodiesTup4,
-    _BodiesTup5,
     _HTTPProviderCore,
     _parse_raw,
-    _parse_raw_batch,
-    _RespTup,
-    _RespTup1,
-    _RespTup2,
-    _RespTup3,
-    _RespTup4,
-    _RespTup5,
-    _Tup,
-    _Tup1,
-    _Tup2,
-    _Tup3,
-    _Tup4,
-    _Tup5,
-    _Tuples,
 )
 
 
@@ -101,95 +79,6 @@ class AsyncHTTPProvider(AsyncBaseProvider, _HTTPProviderCore):
             # closes the connection mid-response under load.
             raw_response = await self.session.post(**request_kwargs)
         return _after_request_unparsed(raw_response)
-
-    async def _make_batch_request_unparsed(self, reqs: Tuple[Body, ...]) -> str:
-        """Make an async HTTP batch request to an http rpc endpoint."""
-        if self._limiter is not None:
-            async with self._limiter:
-                request_kwargs = self._before_batch_request(reqs)
-                try:
-                    raw_response = await self.session.post(**request_kwargs)
-                except (httpx2.RemoteProtocolError, httpx2.ReadError):
-                    raw_response = await self.session.post(**request_kwargs)
-                return _after_request_unparsed(raw_response)
-        request_kwargs = self._before_batch_request(reqs)
-        try:
-            raw_response = await self.session.post(**request_kwargs)
-        except (httpx2.RemoteProtocolError, httpx2.ReadError):
-            raw_response = await self.session.post(**request_kwargs)
-        return _after_request_unparsed(raw_response)
-
-    async def make_batch_request_unparsed(self, reqs: Tuple[Body, ...]) -> str:
-        """Make an async HTTP batch request to an http rpc endpoint.
-
-        .. deprecated::
-            ``make_batch_request_unparsed`` is deprecated and will be removed in a future release.
-            Use individual requests with ``asyncio.gather`` instead.
-            See https://github.com/michaelhly/solana-py/issues/645 for details.
-        """
-        warnings.warn(
-            "make_batch_request_unparsed is deprecated and will be removed in a future release. "
-            "Use individual requests with asyncio.gather instead. "
-            "See https://github.com/michaelhly/solana-py/issues/645 for details.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return await self._make_batch_request_unparsed(reqs)
-
-    @overload
-    async def make_batch_request(self, reqs: _BodiesTup, parsers: _Tup) -> _RespTup: ...
-
-    @overload
-    async def make_batch_request(self, reqs: _BodiesTup1, parsers: _Tup1) -> _RespTup1: ...
-
-    @overload
-    async def make_batch_request(self, reqs: _BodiesTup2, parsers: _Tup2) -> _RespTup2: ...
-
-    @overload
-    async def make_batch_request(self, reqs: _BodiesTup3, parsers: _Tup3) -> _RespTup3: ...
-
-    @overload
-    async def make_batch_request(self, reqs: _BodiesTup4, parsers: _Tup4) -> _RespTup4: ...
-
-    @overload
-    async def make_batch_request(self, reqs: _BodiesTup5, parsers: _Tup5) -> _RespTup5: ...
-
-    async def make_batch_request(self, reqs: Tuple[Body, ...], parsers: _Tuples) -> Tuple[RPCResult, ...]:
-        """Make an async HTTP batch request to an http rpc endpoint.
-
-        .. deprecated::
-            ``make_batch_request`` is deprecated and will be removed in a future release.
-            Use individual requests with ``asyncio.gather`` instead.
-            See https://github.com/michaelhly/solana-py/issues/645 for details.
-
-        Args:
-            reqs: A tuple of request objects from ``solders.rpc.requests``.
-            parsers: A tuple of response classes from ``solders.rpc.responses``.
-                Note: ``parsers`` should line up with ``reqs``.
-
-        Example:
-            >>> from solana.rpc.providers.async_http import AsyncHTTPProvider
-            >>> from solders.rpc.requests import GetBlockHeight, GetFirstAvailableBlock
-            >>> from solders.rpc.responses import GetBlockHeightResp, GetFirstAvailableBlockResp
-            >>> provider = AsyncHTTPProvider("https://api.devnet.solana.com")
-            >>> reqs = (GetBlockHeight(), GetFirstAvailableBlock())
-            >>> parsers = (GetBlockHeightResp, GetFirstAvailableBlockResp)
-            >>> await provider.make_batch_request(reqs, parsers) # doctest: +SKIP
-            (GetBlockHeightResp(
-                158613909,
-            ), GetFirstAvailableBlockResp(
-                86753592,
-            ))
-        """
-        warnings.warn(
-            "make_batch_request is deprecated and will be removed in a future release. "
-            "Use individual requests with asyncio.gather instead. "
-            "See https://github.com/michaelhly/solana-py/issues/645 for details.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        raw = await self._make_batch_request_unparsed(reqs)
-        return _parse_raw_batch(raw, parsers)
 
     async def __aenter__(self) -> "AsyncHTTPProvider":
         """Use as a context manager."""

--- a/src/solana/rpc/providers/core.py
+++ b/src/solana/rpc/providers/core.py
@@ -5,13 +5,11 @@ from __future__ import annotations
 import itertools
 import logging
 import os
-from typing import Any, Dict, Optional, Tuple, Type, TypeVar, Union, overload
+from typing import Any, Dict, Optional, Type, TypeVar
 
 import httpx2
 from solders.rpc.requests import Body
-from solders.rpc.requests import batch_to_json as batch_req_json
-from solders.rpc.responses import Resp, RPCError, RPCResult
-from solders.rpc.responses import batch_from_json as batch_resp_json
+from solders.rpc.responses import RPCError, RPCResult
 
 from ..core import RPCException
 from ..types import URI
@@ -26,34 +24,6 @@ DEFAULT_LIMITS = httpx2.Limits(max_connections=10, max_keepalive_connections=5)
 
 
 T = TypeVar("T", bound=RPCResult)
-# hacky solution for parsing batches of up to six
-_T1 = TypeVar("_T1", bound=RPCResult)
-_T2 = TypeVar("_T2", bound=RPCResult)
-_T3 = TypeVar("_T3", bound=RPCResult)
-_T4 = TypeVar("_T4", bound=RPCResult)
-_T5 = TypeVar("_T5", bound=RPCResult)
-
-_Tup = Tuple[Type[T]]
-_Tup1 = Tuple[Type[T], Type[_T1]]
-_Tup2 = Tuple[Type[T], Type[_T1], Type[_T2]]
-_Tup3 = Tuple[Type[T], Type[_T1], Type[_T2], Type[_T3]]
-_Tup4 = Tuple[Type[T], Type[_T1], Type[_T2], Type[_T3], Type[_T4]]
-_Tup5 = Tuple[Type[T], Type[_T1], Type[_T2], Type[_T3], Type[_T4], Type[_T5]]
-_Tuples = Union[_Tup, _Tup1, _Tup2, _Tup3, _Tup4, _Tup5]
-
-_RespTup = Tuple[Resp[T]]
-_RespTup1 = Tuple[Resp[T], Resp[_T1]]
-_RespTup2 = Tuple[Resp[T], Resp[_T1], Resp[_T2]]
-_RespTup3 = Tuple[Resp[T], Resp[_T1], Resp[_T2], Resp[_T3]]
-_RespTup4 = Tuple[Resp[T], Resp[_T1], Resp[_T2], Resp[_T3], Resp[_T4]]
-_RespTup5 = Tuple[Resp[T], Resp[_T1], Resp[_T2], Resp[_T3], Resp[_T4], Resp[_T5]]
-
-_BodiesTup = Tuple[Body]
-_BodiesTup1 = Tuple[Body, Body]
-_BodiesTup2 = Tuple[Body, Body, Body]
-_BodiesTup3 = Tuple[Body, Body, Body, Body]
-_BodiesTup4 = Tuple[Body, Body, Body, Body, Body]
-_BodiesTup5 = Tuple[Body, Body, Body, Body, Body, Body]
 
 
 def get_default_endpoint() -> URI:
@@ -88,16 +58,8 @@ class _HTTPProviderCore:  # pylint: disable=too-few-public-methods
         data = body.to_json()
         return {**common_kwargs, "content": data}
 
-    def _build_batch_request_kwargs(self, reqs: Tuple[Body, ...]) -> Dict[str, Any]:
-        common_kwargs = self._build_common_request_kwargs()
-        data = batch_req_json(reqs)
-        return {**common_kwargs, "content": data}
-
     def _before_request(self, body: Body) -> Dict[str, Any]:
         return self._build_request_kwargs(body=body)
-
-    def _before_batch_request(self, reqs: Tuple[Body, ...]) -> Dict[str, Any]:
-        return self._build_batch_request_kwargs(reqs)
 
 
 def _parse_raw(raw: str, parser: Type[T]) -> T:
@@ -107,63 +69,6 @@ def _parse_raw(raw: str, parser: Type[T]) -> T:
     return parsed  # type: ignore
 
 
-@overload
-def _parse_raw_batch(raw: str, parsers: _Tup) -> _RespTup: ...
-
-
-@overload
-def _parse_raw_batch(raw: str, parsers: _Tup1) -> _RespTup1: ...
-
-
-@overload
-def _parse_raw_batch(raw: str, parsers: _Tup2) -> _RespTup2: ...
-
-
-@overload
-def _parse_raw_batch(raw: str, parsers: _Tup3) -> _RespTup3: ...
-
-
-@overload
-def _parse_raw_batch(raw: str, parsers: _Tup4) -> _RespTup4: ...
-
-
-@overload
-def _parse_raw_batch(raw: str, parsers: _Tup5) -> _RespTup5: ...
-
-
-def _parse_raw_batch(raw: str, parsers: _Tuples) -> Tuple[RPCResult, ...]:
-    return tuple(batch_resp_json(raw, parsers))
-
-
 def _after_request_unparsed(raw_response: httpx2.Response) -> str:
     raw_response.raise_for_status()
     return raw_response.text
-
-
-@overload
-def _after_batch_request(raw_response: httpx2.Response, parsers: _Tup) -> _RespTup: ...
-
-
-@overload
-def _after_batch_request(raw_response: httpx2.Response, parsers: _Tup1) -> _RespTup1: ...
-
-
-@overload
-def _after_batch_request(raw_response: httpx2.Response, parsers: _Tup2) -> _RespTup2: ...
-
-
-@overload
-def _after_batch_request(raw_response: httpx2.Response, parsers: _Tup3) -> _RespTup3: ...
-
-
-@overload
-def _after_batch_request(raw_response: httpx2.Response, parsers: _Tup4) -> _RespTup4: ...
-
-
-@overload
-def _after_batch_request(raw_response: httpx2.Response, parsers: _Tup5) -> _RespTup5: ...
-
-
-def _after_batch_request(raw_response: httpx2.Response, parsers: _Tuples) -> Tuple[RPCResult, ...]:
-    text = _after_request_unparsed(raw_response)
-    return _parse_raw_batch(text, parsers)  # type: ignore

--- a/src/solana/rpc/providers/http.py
+++ b/src/solana/rpc/providers/http.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-import warnings
-from typing import Dict, Optional, Tuple, Type, overload
+from typing import Dict, Optional, Type
 
 import httpx2
 from solders.rpc.requests import Body
-from solders.rpc.responses import RPCResult
 
 from ...exceptions import SolanaRpcException, handle_exceptions
 from .base import BaseProvider
@@ -16,28 +14,8 @@ from .core import (
     DEFAULT_TIMEOUT,
     T,
     _after_request_unparsed,
-    _BodiesTup,
-    _BodiesTup1,
-    _BodiesTup2,
-    _BodiesTup3,
-    _BodiesTup4,
-    _BodiesTup5,
     _HTTPProviderCore,
     _parse_raw,
-    _parse_raw_batch,
-    _RespTup,
-    _RespTup1,
-    _RespTup2,
-    _RespTup3,
-    _RespTup4,
-    _RespTup5,
-    _Tup,
-    _Tup1,
-    _Tup2,
-    _Tup3,
-    _Tup4,
-    _Tup5,
-    _Tuples,
 )
 
 
@@ -82,84 +60,3 @@ class HTTPProvider(BaseProvider, _HTTPProviderCore):
             # closes the connection mid-response under load.
             raw_response = self.session.post(**request_kwargs)
         return _after_request_unparsed(raw_response)
-
-    def _make_batch_request_unparsed(self, reqs: Tuple[Body, ...]) -> str:
-        """Make an HTTP batch request to an http rpc endpoint."""
-        request_kwargs = self._before_batch_request(reqs)
-        try:
-            raw_response = self.session.post(**request_kwargs)
-        except (httpx2.RemoteProtocolError, httpx2.ReadError):
-            raw_response = self.session.post(**request_kwargs)
-        return _after_request_unparsed(raw_response)
-
-    def make_batch_request_unparsed(self, reqs: Tuple[Body, ...]) -> str:
-        """Make an HTTP batch request to an http rpc endpoint.
-
-        .. deprecated::
-            ``make_batch_request_unparsed`` is deprecated and will be removed in a future release.
-            Use individual requests instead.
-            See https://github.com/michaelhly/solana-py/issues/645 for details.
-        """
-        warnings.warn(
-            "make_batch_request_unparsed is deprecated and will be removed in a future release. "
-            "Use individual requests instead. "
-            "See https://github.com/michaelhly/solana-py/issues/645 for details.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._make_batch_request_unparsed(reqs)
-
-    @overload
-    def make_batch_request(self, reqs: _BodiesTup, parsers: _Tup) -> _RespTup: ...
-
-    @overload
-    def make_batch_request(self, reqs: _BodiesTup1, parsers: _Tup1) -> _RespTup1: ...
-
-    @overload
-    def make_batch_request(self, reqs: _BodiesTup2, parsers: _Tup2) -> _RespTup2: ...
-
-    @overload
-    def make_batch_request(self, reqs: _BodiesTup3, parsers: _Tup3) -> _RespTup3: ...
-
-    @overload
-    def make_batch_request(self, reqs: _BodiesTup4, parsers: _Tup4) -> _RespTup4: ...
-
-    @overload
-    def make_batch_request(self, reqs: _BodiesTup5, parsers: _Tup5) -> _RespTup5: ...
-
-    def make_batch_request(self, reqs: Tuple[Body, ...], parsers: _Tuples) -> Tuple[RPCResult, ...]:
-        """Make a HTTP batch request to an http rpc endpoint.
-
-        .. deprecated::
-            ``make_batch_request`` is deprecated and will be removed in a future release.
-            Use individual requests with ``asyncio.gather`` (async) or sequential calls (sync) instead.
-            See https://github.com/michaelhly/solana-py/issues/645 for details.
-
-        Args:
-            reqs: A tuple of request objects from ``solders.rpc.requests``.
-            parsers: A tuple of response classes from ``solders.rpc.responses``.
-                Note: ``parsers`` should line up with ``reqs``.
-
-        Example:
-            >>> from solana.rpc.providers.http import HTTPProvider
-            >>> from solders.rpc.requests import GetBlockHeight, GetFirstAvailableBlock
-            >>> from solders.rpc.responses import GetBlockHeightResp, GetFirstAvailableBlockResp
-            >>> provider = HTTPProvider("https://api.devnet.solana.com")
-            >>> reqs = (GetBlockHeight(), GetFirstAvailableBlock())
-            >>> parsers = (GetBlockHeightResp, GetFirstAvailableBlockResp)
-            >>> provider.make_batch_request(reqs, parsers) # doctest: +SKIP
-            (GetBlockHeightResp(
-                158613909,
-            ), GetFirstAvailableBlockResp(
-                86753592,
-            ))
-        """
-        warnings.warn(
-            "make_batch_request is deprecated and will be removed in a future release. "
-            "Use individual requests instead. "
-            "See https://github.com/michaelhly/solana-py/issues/645 for details.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        raw = self._make_batch_request_unparsed(reqs)
-        return _parse_raw_batch(raw, parsers)

--- a/uv.lock
+++ b/uv.lock
@@ -1002,15 +1002,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/67/f1e79672a5f91985577c7984c9709ca110e4fd37fe7fd167b60422e6ccc2/pymdown_extensions-11.0.tar.gz", hash = "sha256:8269cef0247f9e2d0a62fcea10860aba05c1cbab5470fd4b63230b96434dc589", size = 857049, upload-time = "2026-06-23T02:27:45.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b6/1ae53367e28b9cffa3be7574e13fbe4589694272fd47710fbdbafd3d63c6/pymdown_extensions-11.0-py3-none-any.whl", hash = "sha256:fbc4acb641814fa9d17521bbd21a5240ef739a662f11c06330c4b78c93e954d6", size = 269415, upload-time = "2026-06-23T02:27:43.826Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request removes all batch request support from the `solana.rpc.providers` module, including both async and sync variants, as well as all related type aliases and helpers. Developers should now use individual requests, with `asyncio.gather` for async use cases or sequential calls for sync, as described in the changelog.

### Breaking Changes

* Removed the `make_batch_request`, `make_batch_request_unparsed`, and all batch-related type aliases and helpers from both `async_http.py` and `http.py`. This includes all overloads, helper methods, and type definitions for batch requests. Developers should migrate to individual requests. 

### API and Type Cleanup

* Removed all batch-related type aliases (e.g., `_BodiesTup`, `_Tup`, `_RespTup`, etc.) and related overloads from `core.py` and their imports from `async_http.py` and `http.py`. 
* Removed batch request construction and parsing helpers (`_build_batch_request_kwargs`, `_before_batch_request`, `_parse_raw_batch`, `_after_batch_request`) from `core.py`. 

### Documentation

* Updated `CHANGELOG.md` to note the breaking removal of batch request support and to provide migration guidance.

These removals simplify the codebase and clarify the supported usage patterns for RPC providers.