### PR TITLE
Remove Named Tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@
 - **BREAKING**: Remove deprecated `Token` (sync SPL Token client) and `AsyncToken` (async SPL Token client) — use `AsyncClient` with `spl.token.instructions` directly instead.
 - **BREAKING**: Remove deprecated `_TokenCore`, `AccountInfo`, and `MintInfo` from `spl.token.core` — use `spl.token.models` instead.
 - **BREAKING**: Remove sync HTTP provider (`solana.rpc.providers.http.HTTPProvider`) and sync base provider (`solana.rpc.providers.base.BaseProvider`) — use `solana.rpc.providers.async_http.AsyncHTTPProvider` instead.
+- **BREAKING**: Remove deprecated `NamedTuple` compatibility types from `solana.rpc.types`, `solana.vote_program`, `spl.memo.instructions`, and `spl.token.instructions`. Use model types from `solana.rpc.models`, `solana.models`, `spl.memo.models`, and `spl.token.models`.
+- **BREAKING**: Remove `PydanticModel.from_namedtuple` and all API boundary coercion paths. RPC and instruction helpers now accept only the Pydantic model params/options types.
 - Remove integration test `test_http_client.py` and unit test `test_client.py`.
 - Remove obsolete documentation pages (`docs/rpc/api.md`, `docs/spl/token/client.md`, `docs/spl/token/async_client.md`, `docs/spl/token/core.md`).
+- Remove obsolete `docs/rpc/types.md`.
 - Update `random_funded_keypair` fixture to be async.
 
 ### Changed

--- a/docs/rpc/types.md
+++ b/docs/rpc/types.md
@@ -1,9 +1,0 @@
-# RPC Types
-
-!!! warning "Deprecated"
-    The `NamedTuple` types in this module (`DataSliceOpts`, `MemcmpOpts`,
-    `TokenAccountOpts`, `TxOpts`) are deprecated. Use the Pydantic models in
-    [`solana.rpc.models`](models.md) instead — they carry the same field names
-    and defaults, so migrating is just a matter of changing the import path.
-
-:::solana.rpc.types

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,7 +47,6 @@ nav:
       - rpc/async_api.md
       - rpc/websocket.md
       - rpc/commitment.md
-      - rpc/types.md
       - rpc/models.md
       - rpc/providers.md
   - Core API:

--- a/src/solana/_pydantic.py
+++ b/src/solana/_pydantic.py
@@ -2,24 +2,21 @@
 
 from __future__ import annotations
 
-from typing import Any, TypeVar
 
 from pydantic import BaseModel, ConfigDict
-
-_T = TypeVar("_T", bound="PydanticModel")
 
 
 class PydanticModel(BaseModel):
     """Base class for solana-py Pydantic models.
 
-    These models are the successors to the deprecated ``NamedTuple`` types. They are
-    configured to:
+    Shared behavior for all solana-py data models.
+
+    Models are configured to:
 
     - allow arbitrary types, so fields can hold non-Pydantic objects such as the
       solders ``Pubkey``/``Keypair`` types;
-    - be immutable (``frozen``), matching the ``NamedTuple`` types they replace;
-    - read field descriptions from attribute docstrings, so the documentation that
-      previously lived next to ``NamedTuple`` fields is preserved.
+        - be immutable (``frozen``);
+        - read field descriptions from attribute docstrings.
     """
 
     model_config = ConfigDict(
@@ -27,25 +24,3 @@ class PydanticModel(BaseModel):
         frozen=True,
         use_attribute_docstrings=True,
     )
-
-    @classmethod
-    def from_namedtuple(cls: type[_T], value: Any) -> _T:
-        """Coerce the deprecated ``NamedTuple`` equivalent into this Pydantic model.
-
-        The deprecated ``NamedTuple`` types and these models share the same field names,
-        so conversion is a straightforward field-by-field copy via ``NamedTuple._asdict``.
-
-        If ``value`` is already an instance of this model it is returned unchanged, which
-        makes this safe to call at API boundaries that accept either the deprecated
-        ``NamedTuple`` or the new model.
-
-        Args:
-            value: A deprecated ``NamedTuple`` instance (or an existing instance of this
-                model).
-
-        Returns:
-            An instance of this model.
-        """
-        if isinstance(value, cls):
-            return value
-        return cls(**value._asdict())

--- a/src/solana/models.py
+++ b/src/solana/models.py
@@ -1,9 +1,4 @@
-"""Pydantic models for the solana package.
-
-These are the Pydantic successors to the deprecated ``NamedTuple`` types defined directly
-under the :mod:`solana` package (currently the vote program params in
-:mod:`solana.vote_program`).
-"""
+"""Pydantic models for the solana package."""
 
 from __future__ import annotations
 

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -65,7 +65,6 @@ from solders.rpc.responses import (
 from solders.signature import Signature
 from solders.transaction import VersionedTransaction
 
-from solana.rpc import types
 from solana.rpc.models import (
     DataSliceOpts as DataSliceOptsModel,
     MemcmpOpts as MemcmpOptsModel,
@@ -162,7 +161,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         pubkey: Pubkey,
         commitment: Optional[Commitment] = None,
         encoding: str = "base64",
-        data_slice: Optional[Union[types.DataSliceOpts, DataSliceOptsModel]] = None,
+        data_slice: Optional[DataSliceOptsModel] = None,
     ) -> GetAccountInfoResp:
         """Returns all the account info for the specified public key.
 
@@ -620,7 +619,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         pubkeys: List[Pubkey],
         commitment: Optional[Commitment] = None,
         encoding: str = "base64",
-        data_slice: Optional[Union[types.DataSliceOpts, DataSliceOptsModel]] = None,
+        data_slice: Optional[DataSliceOptsModel] = None,
     ) -> GetMultipleAccountsResp:
         """Returns all the account info for a list of public keys.
 
@@ -681,8 +680,8 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         pubkey: Pubkey,
         commitment: Optional[Commitment] = None,
         encoding: Optional[str] = None,
-        data_slice: Optional[Union[types.DataSliceOpts, DataSliceOptsModel]] = None,
-        filters: Optional[Sequence[Union[int, types.MemcmpOpts, MemcmpOptsModel]]] = None,
+        data_slice: Optional[DataSliceOptsModel] = None,
+        filters: Optional[Sequence[Union[int, MemcmpOptsModel]]] = None,
     ) -> GetProgramAccountsResp:
         """Returns all accounts owned by the provided program Pubkey.
 
@@ -719,7 +718,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         self,
         pubkey: Pubkey,
         commitment: Optional[Commitment] = None,
-        filters: Optional[Sequence[Union[int, types.MemcmpOpts, MemcmpOptsModel]]] = None,
+        filters: Optional[Sequence[Union[int, MemcmpOptsModel]]] = None,
     ) -> GetProgramAccountsMaybeJsonParsedResp:
         """Returns all accounts owned by the provided program Pubkey.
 
@@ -873,7 +872,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
     async def get_token_accounts_by_delegate(
         self,
         delegate: Pubkey,
-        opts: Union[types.TokenAccountOpts, TokenAccountOptsModel],
+        opts: TokenAccountOptsModel,
         commitment: Optional[Commitment] = None,
     ) -> GetTokenAccountsByDelegateResp:
         """Returns all SPL Token accounts by approved Delegate (UNSTABLE).
@@ -889,7 +888,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
     async def get_token_accounts_by_delegate_json_parsed(
         self,
         delegate: Pubkey,
-        opts: Union[types.TokenAccountOpts, TokenAccountOptsModel],
+        opts: TokenAccountOptsModel,
         commitment: Optional[Commitment] = None,
     ) -> GetTokenAccountsByDelegateJsonParsedResp:
         """Returns all SPL Token accounts by approved delegate in JSON format (UNSTABLE).
@@ -905,7 +904,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
     async def get_token_accounts_by_owner_json_parsed(
         self,
         owner: Pubkey,
-        opts: Union[types.TokenAccountOpts, TokenAccountOptsModel],
+        opts: TokenAccountOptsModel,
         commitment: Optional[Commitment] = None,
     ) -> GetTokenAccountsByOwnerJsonParsedResp:
         """Returns all SPL Token accounts by token owner in JSON format (UNSTABLE).
@@ -921,7 +920,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
     async def get_token_accounts_by_owner(
         self,
         owner: Pubkey,
-        opts: Union[types.TokenAccountOpts, TokenAccountOptsModel],
+        opts: TokenAccountOptsModel,
         commitment: Optional[Commitment] = None,
     ) -> GetTokenAccountsByOwnerResp:
         """Returns all SPL Token accounts by token owner (UNSTABLE).
@@ -1029,9 +1028,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         body = self._request_airdrop_body(pubkey, lamports, commitment)
         return await self._provider.make_request(body, RequestAirdropResp)
 
-    async def send_raw_transaction(
-        self, txn: bytes, opts: Optional[Union[types.TxOpts, TxOptsModel]] = None
-    ) -> SendTransactionResp:
+    async def send_raw_transaction(self, txn: bytes, opts: Optional[TxOptsModel] = None) -> SendTransactionResp:
         """Send a transaction that has already been signed and serialized into the wire format.
 
         Args:
@@ -1072,7 +1069,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
     async def send_transaction(
         self,
         txn: VersionedTransaction,
-        opts: Optional[Union[types.TxOpts, TxOptsModel]] = None,
+        opts: Optional[TxOptsModel] = None,
     ) -> SendTransactionResp:
         """Send a transaction.
 

--- a/src/solana/rpc/core.py
+++ b/src/solana/rpc/core.py
@@ -86,7 +86,6 @@ from solders.signature import Signature
 from solders.transaction import VersionedTransaction
 from solders.transaction_status import UiTransactionEncoding
 
-from solana.rpc import types
 from solana.rpc.models import (
     DataSliceOpts,
     MemcmpOpts,
@@ -180,7 +179,7 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         pubkey: Pubkey,
         commitment: Optional[Commitment],
         encoding: str,
-        data_slice: Optional[Union[types.DataSliceOpts, DataSliceOpts]],
+        data_slice: Optional[DataSliceOpts],
     ) -> GetAccountInfo:
         data_slice_to_use = (
             None if data_slice is None else UiDataSliceConfig(offset=data_slice.offset, length=data_slice.length)
@@ -296,7 +295,7 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         pubkeys: List[Pubkey],
         commitment: Optional[Commitment],
         encoding: str,
-        data_slice: Optional[Union[types.DataSliceOpts, DataSliceOpts]],
+        data_slice: Optional[DataSliceOpts],
     ) -> GetMultipleAccounts:
         encoding_to_use = _ACCOUNT_ENCODING_TO_SOLDERS[encoding]
         commitment_to_use = _COMMITMENT_TO_SOLDERS[commitment or self._commitment]
@@ -315,8 +314,8 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         pubkey: Pubkey,
         commitment: Optional[Commitment],
         encoding: Optional[str],
-        data_slice: Optional[Union[types.DataSliceOpts, DataSliceOpts]],
-        filters: Optional[Sequence[Union[int, types.MemcmpOpts, MemcmpOpts]]] = None,
+        data_slice: Optional[DataSliceOpts],
+        filters: Optional[Sequence[Union[int, MemcmpOpts]]] = None,
     ) -> GetProgramAccounts:  # pylint: disable=too-many-arguments
         encoding_to_use = None if encoding is None else _ACCOUNT_ENCODING_TO_SOLDERS[encoding]
         commitment_to_use = _COMMITMENT_TO_SOLDERS[commitment or self._commitment]
@@ -401,7 +400,7 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
     def _get_token_accounts_convert(
         self,
         pubkey: Pubkey,
-        opts: Union[types.TokenAccountOpts, TokenAccountOpts],
+        opts: TokenAccountOpts,
         commitment: Optional[Commitment],
     ) -> Tuple[
         Pubkey,
@@ -435,7 +434,7 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
     def _get_token_accounts_by_delegate_body(
         self,
         delegate: Pubkey,
-        opts: Union[types.TokenAccountOpts, TokenAccountOpts],
+        opts: TokenAccountOpts,
         commitment: Optional[Commitment],
     ) -> GetTokenAccountsByDelegate:
         pubkey, filter_, config = self._get_token_accounts_convert(delegate, opts, commitment)
@@ -444,7 +443,7 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
     def _get_token_accounts_by_owner_body(
         self,
         owner: Pubkey,
-        opts: Union[types.TokenAccountOpts, TokenAccountOpts],
+        opts: TokenAccountOpts,
         commitment: Optional[Commitment],
     ) -> GetTokenAccountsByOwner:
         pubkey, filter_, config = self._get_token_accounts_convert(owner, opts, commitment)
@@ -453,14 +452,14 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
     def _get_token_accounts_by_delegate_json_parsed_body(
         self,
         delegate: Pubkey,
-        opts: Union[types.TokenAccountOpts, TokenAccountOpts],
+        opts: TokenAccountOpts,
         commitment: Optional[Commitment],
     ) -> GetTokenAccountsByDelegate:
         opts_to_use = TokenAccountOpts(
             mint=opts.mint,
             program_id=opts.program_id,
             encoding="jsonParsed",
-            data_slice=(None if opts.data_slice is None else DataSliceOpts.from_namedtuple(opts.data_slice)),
+            data_slice=opts.data_slice,
         )
         pubkey, filter_, config = self._get_token_accounts_convert(delegate, opts_to_use, commitment)
         return GetTokenAccountsByDelegate(pubkey, filter_, config)
@@ -468,14 +467,14 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
     def _get_token_accounts_by_owner_json_parsed_body(
         self,
         owner: Pubkey,
-        opts: Union[types.TokenAccountOpts, TokenAccountOpts],
+        opts: TokenAccountOpts,
         commitment: Optional[Commitment],
     ) -> GetTokenAccountsByOwner:
         opts_to_use = TokenAccountOpts(
             mint=opts.mint,
             program_id=opts.program_id,
             encoding="jsonParsed",
-            data_slice=(None if opts.data_slice is None else DataSliceOpts.from_namedtuple(opts.data_slice)),
+            data_slice=opts.data_slice,
         )
         pubkey, filter_, config = self._get_token_accounts_convert(owner, opts_to_use, commitment)
         return GetTokenAccountsByOwner(pubkey, filter_, config)
@@ -514,7 +513,7 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         commitment_to_use = _COMMITMENT_TO_SOLDERS[commitment or self._commitment]
         return RequestAirdrop(pubkey, lamports, RpcRequestAirdropConfig(commitment=commitment_to_use))
 
-    def _send_raw_transaction_body(self, txn: bytes, opts: Union[types.TxOpts, TxOptsModel]) -> SendRawTransaction:
+    def _send_raw_transaction_body(self, txn: bytes, opts: TxOptsModel) -> SendRawTransaction:
         preflight_commitment_to_use = _COMMITMENT_TO_SOLDERS[opts.preflight_commitment or self._commitment]
         config = RpcSendTransactionConfig(
             skip_preflight=opts.skip_preflight,
@@ -528,7 +527,7 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def _send_raw_transaction_post_send_args(
-        resp: SendTransactionResp, opts: Union[types.TxOpts, TxOptsModel]
+        resp: SendTransactionResp, opts: TxOptsModel
     ) -> Tuple[SendTransactionResp, Commitment, Optional[int]]:
         return resp, opts.preflight_commitment, opts.last_valid_block_height
 

--- a/src/solana/rpc/models.py
+++ b/src/solana/rpc/models.py
@@ -1,9 +1,4 @@
-"""Pydantic models for RPC types.
-
-These are the Pydantic successors to the deprecated ``NamedTuple`` types in
-:mod:`solana.rpc.types`. They carry the same field names and defaults, so migrating is
-a matter of changing the import path.
-"""
+"""Pydantic models for RPC types."""
 
 from __future__ import annotations
 

--- a/src/solana/rpc/types.py
+++ b/src/solana/rpc/types.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, NewType
+from typing import NewType
 
-from solders.pubkey import Pubkey
-from typing_extensions import TypedDict, deprecated
+from typing_extensions import TypedDict
 
-from .commitment import Commitment, Finalized
 
 URI = NewType("URI", str)
 """Type for endpoint URI."""
@@ -23,65 +21,3 @@ class RPCError(TypedDict):
     """HTTP status code."""
     message: str
     """Error message."""
-
-
-@deprecated("DataSliceOpts is deprecated; use solana.rpc.models instead.")
-class DataSliceOpts(NamedTuple):
-    """Option to limit the returned account data, only available for "base58" or "base64" encoding."""
-
-    offset: int
-    """Limit the returned account data using the provided offset: <usize>."""
-    length: int
-    """Limit the returned account data using the provided length: <usize>."""
-
-
-@deprecated("MemcmpOpts is deprecated; use solana.rpc.models instead.")
-class MemcmpOpts(NamedTuple):
-    """Option to compare a provided series of bytes with program account data at a particular offset."""
-
-    offset: int
-    """Offset into program account data to start comparison: <usize>."""
-    bytes: str
-    """Data to match, as base-58 encoded string: <string>."""
-
-
-@deprecated("TokenAccountOpts is deprecated; use solana.rpc.models instead.")
-class TokenAccountOpts(NamedTuple):
-    """Options when querying token accounts.
-
-    Provide one of mint or program_id.
-    """
-
-    mint: Pubkey | None = None
-    """Public key of the specific token Mint to limit accounts to."""
-    program_id: Pubkey | None = None
-    """Public key of the Token program ID that owns the accounts."""
-    encoding: str = "base64"
-    """Encoding for Account data, either "base58" (slow) or "base64"."""
-    data_slice: DataSliceOpts | None = None
-    """Option to limit the returned account data, only available for "base58" or "base64" encoding."""
-
-
-@deprecated("TxOpts is deprecated; use solana.rpc.models instead.")
-class TxOpts(NamedTuple):
-    """Options to specify when broadcasting a transaction."""
-
-    skip_confirmation: bool = True
-    """If false, `send_transaction` will try to confirm that the transaction was successfully broadcasted.
-
-    When confirming a transaction, `send_transaction` will block for a maximum of 30 seconds. Wrap the call
-    inside a thread to make it asynchronous.
-    """
-    skip_preflight: bool = False
-    """If true, skip the preflight transaction checks."""
-    preflight_commitment: Commitment = Finalized
-    """Commitment level to use for preflight."""
-    max_retries: int | None = None
-    """Maximum number of times for the RPC node to retry sending the transaction to the leader.
-    If this parameter not provided, the RPC node will retry the transaction until it is finalized
-    or until the blockhash expires.
-    """
-    last_valid_block_height: int | None = None
-    """Pass the latest valid block height here, to be consumed by confirm_transaction.
-    Valid only if skip_confirmation is False.
-    """

--- a/src/solana/rpc/websocket_api.py
+++ b/src/solana/rpc/websocket_api.py
@@ -51,9 +51,11 @@ from solders.transaction_status import TransactionDetails
 from websockets.asyncio.client import ClientConnection
 from websockets.asyncio.client import connect as ws_connect
 
-from solana.rpc import types
 from solana.rpc.commitment import Commitment
-from solana.rpc.models import DataSliceOpts as DataSliceOptsModel, MemcmpOpts as MemcmpOptsModel
+from solana.rpc.models import (
+    DataSliceOpts as DataSliceOptsModel,
+    MemcmpOpts as MemcmpOptsModel,
+)
 from solana.rpc.core import (
     _ACCOUNT_ENCODING_TO_SOLDERS,
     _COMMITMENT_TO_SOLDERS,
@@ -243,8 +245,8 @@ class SolanaWsClientProtocol(ClientConnection):
         program_id: Pubkey,
         commitment: Optional[Commitment] = None,
         encoding: Optional[str] = None,
-        data_slice: Optional[Union[types.DataSliceOpts, DataSliceOptsModel]] = None,
-        filters: Optional[Sequence[Union[int, types.MemcmpOpts, MemcmpOptsModel]]] = None,
+        data_slice: Optional[DataSliceOptsModel] = None,
+        filters: Optional[Sequence[Union[int, MemcmpOptsModel]]] = None,
     ) -> int:
         """Receive notifications when the lamports or data for a given account owned by the program changes.
 

--- a/src/solana/utils/cluster.py
+++ b/src/solana/utils/cluster.py
@@ -2,36 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Literal, NamedTuple
-from typing_extensions import deprecated
+from typing import Literal
 
-from solana.rpc.models import ClusterUrls as ClusterUrlsModel, Endpoint as EndpointModel
+from solana.rpc.models import ClusterUrls, Endpoint
 
-
-@deprecated("ClusterUrls is deprecated; use solana.rpc.models instead.")
-class ClusterUrls(NamedTuple):
-    """A collection of urls for each cluster."""
-
-    devnet: str
-    testnet: str
-    mainnet_beta: str
-
-
-@deprecated("Endpoint is deprecated; use solana.rpc.models instead.")
-class Endpoint(NamedTuple):
-    """Container for http and https cluster urls."""
-
-    http: ClusterUrls
-    https: ClusterUrls
-
-
-ENDPOINT = EndpointModel(
-    http=ClusterUrlsModel(
+ENDPOINT = Endpoint(
+    http=ClusterUrls(
         devnet="http://api.devnet.solana.com",
         testnet="http://api.testnet.solana.com",
         mainnet_beta="http://api.mainnet-beta.solana.com/",
     ),
-    https=ClusterUrlsModel(
+    https=ClusterUrls(
         devnet="https://api.devnet.solana.com",
         testnet="https://api.testnet.solana.com",
         mainnet_beta="https://api.mainnet-beta.solana.com/",

--- a/src/solana/vote_program.py
+++ b/src/solana/vote_program.py
@@ -2,34 +2,15 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, Union
-from typing_extensions import deprecated
-
 from solders.instruction import AccountMeta, Instruction
-from solders.pubkey import Pubkey
 
 from solana import models
 from solana.constants import VOTE_PROGRAM_ID
 from solana._layouts.vote_instructions import VOTE_INSTRUCTIONS_LAYOUT, InstructionType
 
 
-# Instruction Params
-@deprecated("WithdrawFromVoteAccountParams is deprecated; use solana.models instead.")
-class WithdrawFromVoteAccountParams(NamedTuple):
-    """Transfer SOL from vote account to identity."""
-
-    vote_account_from_pubkey: Pubkey
-    """"""
-    to_pubkey: Pubkey
-    """"""
-    lamports: int
-    """"""
-    withdrawer: Pubkey
-    """"""
-
-
 def withdraw_from_vote_account(
-    params: Union[WithdrawFromVoteAccountParams, models.WithdrawFromVoteAccountParams],
+    params: models.WithdrawFromVoteAccountParams,
 ) -> Instruction:
     """Generate an instruction that transfers lamports from a vote account to any other.
 
@@ -53,7 +34,6 @@ def withdraw_from_vote_account(
     Returns:
         The generated instruction.
     """
-    params = models.WithdrawFromVoteAccountParams.from_namedtuple(params)
     data = VOTE_INSTRUCTIONS_LAYOUT.build(
         {
             "instruction_type": InstructionType.WITHDRAW_FROM_VOTE_ACCOUNT,

--- a/src/spl/memo/instructions.py
+++ b/src/spl/memo/instructions.py
@@ -2,25 +2,9 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple, Union
-from typing_extensions import deprecated
-
 from solders.instruction import AccountMeta, Instruction
-from solders.pubkey import Pubkey
 
 from spl.memo import models
-
-
-@deprecated("MemoParams is deprecated; use spl.memo.models instead.")
-class MemoParams(NamedTuple):
-    """Create memo transaction params."""
-
-    program_id: Pubkey
-    """Memo program account."""
-    signer: Pubkey
-    """Signing account."""
-    message: bytes
-    """Memo message in bytes."""
 
 
 def decode_create_memo(instruction: Instruction) -> models.MemoParams:
@@ -39,7 +23,7 @@ def decode_create_memo(instruction: Instruction) -> models.MemoParams:
     )
 
 
-def create_memo(params: Union[MemoParams, models.MemoParams]) -> Instruction:
+def create_memo(params: models.MemoParams) -> Instruction:
     """Creates a transaction instruction that creates a memo.
 
     Message need to be encoded in bytes.

--- a/src/spl/memo/models.py
+++ b/src/spl/memo/models.py
@@ -1,8 +1,4 @@
-"""Pydantic models for memo program instructions.
-
-These are the Pydantic successors to the deprecated ``NamedTuple`` types in
-:mod:`spl.memo.instructions`.
-"""
+"""Pydantic models for memo program instructions."""
 
 from __future__ import annotations
 

--- a/src/spl/token/instructions.py
+++ b/src/spl/token/instructions.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, List, NamedTuple, Optional, Union
-from typing_extensions import deprecated
-
+from typing import Any, List, Union
 from solders.instruction import AccountMeta, Instruction
 from solders.pubkey import Pubkey
 from solders.system_program import ID as SYS_PROGRAM_ID
@@ -12,468 +10,19 @@ from solders.sysvar import RENT
 
 from solana.utils.validate import validate_instruction_keys, validate_instruction_type
 from spl.token import models
-from spl.token._layouts import INSTRUCTIONS_LAYOUT, InstructionType, TransferFeeInstructionType
-from spl.token.constants import ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID
+from spl.token._layouts import (
+    INSTRUCTIONS_LAYOUT,
+    InstructionType,
+    TransferFeeInstructionType,
+)
+from spl.token.constants import (
+    ASSOCIATED_TOKEN_PROGRAM_ID,
+    TOKEN_PROGRAM_ID,
+    TOKEN_2022_PROGRAM_ID,
+)
 
 # Re-exported for backwards compatibility; the canonical definition now lives in spl.token.models.
 from spl.token.models import AuthorityType
-
-
-# Instruction Params
-@deprecated("InitializeMintParams is deprecated; use spl.token.models instead.")
-class InitializeMintParams(NamedTuple):
-    """Initialize token mint transaction params."""
-
-    decimals: int
-    """Number of base 10 digits to the right of the decimal place."""
-    program_id: Pubkey
-    """SPL Token program account."""
-    mint: Pubkey
-    """Public key of the minter account."""
-    mint_authority: Pubkey
-    """The authority/multisignature to mint tokens."""
-    freeze_authority: Optional[Pubkey] = None
-    """The freeze authority/multisignature of the mint."""
-
-
-@deprecated("InitializeMint2Params is deprecated; use spl.token.models instead.")
-class InitializeMint2Params(NamedTuple):
-    """Initialize token mint transaction params without Rent sysvar."""
-
-    decimals: int
-    """Number of base 10 digits to the right of the decimal place."""
-    program_id: Pubkey
-    """SPL Token program account."""
-    mint: Pubkey
-    """Public key of the minter account."""
-    mint_authority: Pubkey
-    """The authority/multisignature to mint tokens."""
-    freeze_authority: Optional[Pubkey] = None
-    """The freeze authority/multisignature of the mint."""
-
-
-@deprecated("InitializeAccountParams is deprecated; use spl.token.models instead.")
-class InitializeAccountParams(NamedTuple):
-    """Initialize token account transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    account: Pubkey
-    """Public key of the new account."""
-    mint: Pubkey
-    """Public key of the minter account."""
-    owner: Pubkey
-    """Owner of the new account."""
-
-
-@deprecated("InitializeAccount2Params is deprecated; use spl.token.models instead.")
-class InitializeAccount2Params(NamedTuple):
-    """Initialize token account transaction params with owner in instruction data."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    account: Pubkey
-    """Public key of the new account."""
-    mint: Pubkey
-    """Public key of the minter account."""
-    owner: Pubkey
-    """Owner of the new account."""
-
-
-@deprecated("InitializeAccount3Params is deprecated; use spl.token.models instead.")
-class InitializeAccount3Params(NamedTuple):
-    """Initialize token account transaction params with owner in instruction data and no Rent sysvar."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    account: Pubkey
-    """Public key of the new account."""
-    mint: Pubkey
-    """Public key of the minter account."""
-    owner: Pubkey
-    """Owner of the new account."""
-
-
-@deprecated("InitializeMultisigParams is deprecated; use spl.token.models instead.")
-class InitializeMultisigParams(NamedTuple):
-    """Initialize multisig token account transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    multisig: Pubkey
-    """New multisig account address."""
-    m: int
-    """The number of signers (M) required to validate this multisignature account."""
-    signers: List[Pubkey] = []
-    """Addresses of multisig signers."""
-
-
-@deprecated("InitializeMultisig2Params is deprecated; use spl.token.models instead.")
-class InitializeMultisig2Params(NamedTuple):
-    """Initialize multisig token account transaction params without Rent sysvar."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    multisig: Pubkey
-    """New multisig account address."""
-    m: int
-    """The number of signers (M) required to validate this multisignature account."""
-    signers: List[Pubkey] = []
-    """Addresses of multisig signers."""
-
-
-@deprecated("TransferParams is deprecated; use spl.token.models instead.")
-class TransferParams(NamedTuple):
-    """Transfer token transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    source: Pubkey
-    """Source account."""
-    dest: Pubkey
-    """Destination account."""
-    owner: Pubkey
-    """Owner of the source account."""
-    amount: int
-    """Number of tokens to transfer."""
-    signers: List[Pubkey] = []
-    """Signing accounts if `owner` is a multiSig."""
-
-
-@deprecated("ApproveParams is deprecated; use spl.token.models instead.")
-class ApproveParams(NamedTuple):
-    """Approve token transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    source: Pubkey
-    """Source account."""
-    delegate: Pubkey
-    """Delegate account authorized to perform a transfer of tokens from the source account."""
-    owner: Pubkey
-    """Owner of the source account."""
-    amount: int
-    """Maximum number of tokens the delegate may transfer."""
-    signers: List[Pubkey] = []
-    """Signing accounts if `owner` is a multiSig."""
-
-
-@deprecated("RevokeParams is deprecated; use spl.token.models instead.")
-class RevokeParams(NamedTuple):
-    """Revoke token transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    account: Pubkey
-    """Source account for which transfer authority is being revoked."""
-    owner: Pubkey
-    """Owner of the source account."""
-    signers: List[Pubkey] = []
-    """Signing accounts if `owner` is a multiSig."""
-
-
-@deprecated("SetAuthorityParams is deprecated; use spl.token.models instead.")
-class SetAuthorityParams(NamedTuple):
-    """Set token authority transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    account: Pubkey
-    """Public key of the token account."""
-    authority: AuthorityType
-    """The type of authority to update."""
-    current_authority: Pubkey
-    """Current authority of the specified type."""
-    signers: List[Pubkey] = []
-    """Signing accounts if `current_authority` is a multiSig."""
-    new_authority: Optional[Pubkey] = None
-    """New authority of the account."""
-
-
-@deprecated("MintToParams is deprecated; use spl.token.models instead.")
-class MintToParams(NamedTuple):
-    """Mint token transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    mint: Pubkey
-    """Public key of the minter account."""
-    dest: Pubkey
-    """Public key of the account to mint to."""
-    mint_authority: Pubkey
-    """The mint authority."""
-    amount: int
-    """Amount to mint."""
-    signers: List[Pubkey] = []
-    """Signing accounts if `mint_authority` is a multiSig."""
-
-
-@deprecated("BurnParams is deprecated; use spl.token.models instead.")
-class BurnParams(NamedTuple):
-    """Burn token transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    account: Pubkey
-    """Account to burn tokens from."""
-    mint: Pubkey
-    """Public key of the minter account."""
-    owner: Pubkey
-    """Owner of the account."""
-    amount: int
-    """Amount to burn."""
-    signers: List[Pubkey] = []
-    """Signing accounts if `owner` is a multiSig"""
-
-
-@deprecated("CloseAccountParams is deprecated; use spl.token.models instead.")
-class CloseAccountParams(NamedTuple):
-    """Close token account transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    account: Pubkey
-    """Address of account to close."""
-    dest: Pubkey
-    """Address of account to receive the remaining balance of the closed account."""
-    owner: Pubkey
-    """Owner of the account."""
-    signers: List[Pubkey] = []
-    """Signing accounts if `owner` is a multiSig"""
-
-
-@deprecated("FreezeAccountParams is deprecated; use spl.token.models instead.")
-class FreezeAccountParams(NamedTuple):
-    """Freeze token account transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    account: Pubkey
-    """Account to freeze."""
-    mint: Pubkey
-    """Public key of the minter account."""
-    authority: Pubkey
-    """Mint freeze authority"""
-    multi_signers: List[Pubkey] = []
-    """Signing accounts if `authority` is a multiSig"""
-
-
-@deprecated("ThawAccountParams is deprecated; use spl.token.models instead.")
-class ThawAccountParams(NamedTuple):
-    """Thaw token account transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    account: Pubkey
-    """Account to thaw."""
-    mint: Pubkey
-    """Public key of the minter account."""
-    authority: Pubkey
-    """Mint freeze authority"""
-    multi_signers: List[Pubkey] = []
-    """Signing accounts if `authority` is a multiSig"""
-
-
-@deprecated("TransferCheckedParams is deprecated; use spl.token.models instead.")
-class TransferCheckedParams(NamedTuple):
-    """TransferChecked token transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    source: Pubkey
-    """Source account."""
-    mint: Pubkey
-    """Public key of the minter account."""
-    dest: Pubkey
-    """Destination account."""
-    owner: Pubkey
-    """Owner of the source account."""
-    amount: int
-    """Number of tokens to transfer."""
-    decimals: int
-    """Amount decimals."""
-    signers: List[Pubkey] = []
-    """Signing accounts if `owner` is a multiSig."""
-
-
-@deprecated("ApproveCheckedParams is deprecated; use spl.token.models instead.")
-class ApproveCheckedParams(NamedTuple):
-    """ApproveChecked token transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    source: Pubkey
-    """Source account."""
-    mint: Pubkey
-    """Public key of the minter account."""
-    delegate: Pubkey
-    """Delegate account authorized to perform a transfer of tokens from the source account."""
-    owner: Pubkey
-    """Owner of the source account."""
-    amount: int
-    """Maximum number of tokens the delegate may transfer."""
-    decimals: int
-    """Amount decimals."""
-    signers: List[Pubkey] = []
-    """Signing accounts if `owner` is a multiSig."""
-
-
-@deprecated("MintToCheckedParams is deprecated; use spl.token.models instead.")
-class MintToCheckedParams(NamedTuple):
-    """MintToChecked token transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    mint: Pubkey
-    """Public key of the minter account."""
-    dest: Pubkey
-    """Public key of the account to mint to."""
-    mint_authority: Pubkey
-    """The mint authority."""
-    amount: int
-    """Amount to mint."""
-    decimals: int
-    """Amount decimals."""
-    signers: List[Pubkey] = []
-    """Signing accounts if `mint_authority` is a multiSig."""
-
-
-@deprecated("BurnCheckedParams is deprecated; use spl.token.models instead.")
-class BurnCheckedParams(NamedTuple):
-    """BurnChecked token transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    mint: Pubkey
-    """Public key of the minter account."""
-    account: Pubkey
-    """Account to burn tokens from."""
-    owner: Pubkey
-    """Owner of the account."""
-    amount: int
-    """Amount to burn."""
-    decimals: int
-    """Amount decimals."""
-    signers: List[Pubkey] = []
-    """Signing accounts if `owner` is a multiSig"""
-
-
-@deprecated("SyncNativeParams is deprecated; use spl.token.models instead.")
-class SyncNativeParams(NamedTuple):
-    """BurnChecked token transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    account: Pubkey
-    """Account to sync."""
-
-
-@deprecated("GetAccountDataSizeParams is deprecated; use spl.token.models instead.")
-class GetAccountDataSizeParams(NamedTuple):
-    """GetAccountDataSize token transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    mint: Pubkey
-    """Mint to calculate account size for."""
-
-
-@deprecated("InitializeImmutableOwnerParams is deprecated; use spl.token.models instead.")
-class InitializeImmutableOwnerParams(NamedTuple):
-    """InitializeImmutableOwner token transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    account: Pubkey
-    """Token account to initialize immutable owner for."""
-
-
-@deprecated("InitializeTransferFeeConfigParams is deprecated; use spl.token.models instead.")
-class InitializeTransferFeeConfigParams(NamedTuple):
-    """InitializeTransferFeeConfig token transaction params."""
-
-    program_id: Pubkey
-    """SPL Token 2022 program account."""
-    mint: Pubkey
-    """Mint to initialize transfer fee config for."""
-    transfer_fee_config_authority: Optional[Pubkey]
-    """Authority that may update the transfer fee config."""
-    withdraw_withheld_authority: Optional[Pubkey]
-    """Authority that may withdraw withheld tokens."""
-    transfer_fee_basis_points: int
-    """Amount of transfer collected as fees, expressed in basis points."""
-    maximum_fee: int
-    """Maximum fee assessed on transfers."""
-
-
-@deprecated("WithdrawWithheldTokensFromAccountsParams is deprecated; use spl.token.models instead.")
-class WithdrawWithheldTokensFromAccountsParams(NamedTuple):
-    """WithdrawWithheldTokensFromAccounts token transaction params."""
-
-    program_id: Pubkey
-    """SPL Token 2022 program account."""
-    mint: Pubkey
-    """Mint that includes the TransferFeeConfig extension."""
-    dest: Pubkey
-    """Fee receiver token account."""
-    authority: Pubkey
-    """Withdraw withheld authority."""
-    signers: List[Pubkey] = []
-    """Signing accounts if `authority` is a multiSig."""
-    sources: List[Pubkey] = []
-    """Token accounts to withdraw withheld tokens from."""
-
-
-@deprecated("WithdrawWithheldTokensFromMintParams is deprecated; use spl.token.models instead.")
-class WithdrawWithheldTokensFromMintParams(NamedTuple):
-    """WithdrawWithheldTokensFromMint token transaction params."""
-
-    program_id: Pubkey
-    """SPL Token 2022 program account."""
-    mint: Pubkey
-    """Mint that includes the TransferFeeConfig extension."""
-    dest: Pubkey
-    """Fee receiver token account."""
-    authority: Pubkey
-    """Withdraw withheld authority."""
-    signers: List[Pubkey] = []
-    """Signing accounts if `authority` is a multiSig."""
-
-
-@deprecated("HarvestWithheldTokensToMintParams is deprecated; use spl.token.models instead.")
-class HarvestWithheldTokensToMintParams(NamedTuple):
-    """HarvestWithheldTokensToMint token transaction params."""
-
-    program_id: Pubkey
-    """SPL Token 2022 program account."""
-    mint: Pubkey
-    """Mint to harvest withheld tokens to."""
-    sources: List[Pubkey] = []
-    """Token accounts to harvest withheld tokens from."""
-
-
-@deprecated("AmountToUiAmountParams is deprecated; use spl.token.models instead.")
-class AmountToUiAmountParams(NamedTuple):
-    """AmountToUiAmount token transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    mint: Pubkey
-    """Mint to use for conversion."""
-    amount: int
-    """Amount of tokens to reformat."""
-
-
-@deprecated("UiAmountToAmountParams is deprecated; use spl.token.models instead.")
-class UiAmountToAmountParams(NamedTuple):
-    """UiAmountToAmount token transaction params."""
-
-    program_id: Pubkey
-    """SPL Token program account."""
-    mint: Pubkey
-    """Mint to use for conversion."""
-    ui_amount: str
-    """The ui_amount string to convert."""
 
 
 def __parse_and_validate_instruction(
@@ -502,9 +51,9 @@ def decode_initialize_mint(instruction: Instruction) -> models.InitializeMintPar
         program_id=instruction.program_id,
         mint=instruction.accounts[0].pubkey,
         mint_authority=Pubkey(parsed_data.args.mint_authority),
-        freeze_authority=Pubkey(parsed_data.args.freeze_authority)
-        if parsed_data.args.freeze_authority_option
-        else None,
+        freeze_authority=(
+            Pubkey(parsed_data.args.freeze_authority) if parsed_data.args.freeze_authority_option else None
+        ),
     )
 
 
@@ -516,13 +65,15 @@ def decode_initialize_mint2(instruction: Instruction) -> models.InitializeMint2P
         program_id=instruction.program_id,
         mint=instruction.accounts[0].pubkey,
         mint_authority=Pubkey(parsed_data.args.mint_authority),
-        freeze_authority=Pubkey(parsed_data.args.freeze_authority)
-        if parsed_data.args.freeze_authority_option
-        else None,
+        freeze_authority=(
+            Pubkey(parsed_data.args.freeze_authority) if parsed_data.args.freeze_authority_option else None
+        ),
     )
 
 
-def decode_initialize_account(instruction: Instruction) -> models.InitializeAccountParams:
+def decode_initialize_account(
+    instruction: Instruction,
+) -> models.InitializeAccountParams:
     """Decode an initialize account token instruction and retrieve the instruction params.
 
     Args:
@@ -540,7 +91,9 @@ def decode_initialize_account(instruction: Instruction) -> models.InitializeAcco
     )
 
 
-def decode_initialize_account2(instruction: Instruction) -> models.InitializeAccount2Params:
+def decode_initialize_account2(
+    instruction: Instruction,
+) -> models.InitializeAccount2Params:
     """Decode an initialize account2 token instruction and retrieve the instruction params."""
     parsed_data = __parse_and_validate_instruction(instruction, 3, InstructionType.INITIALIZE_ACCOUNT2)
     return models.InitializeAccount2Params(
@@ -551,7 +104,9 @@ def decode_initialize_account2(instruction: Instruction) -> models.InitializeAcc
     )
 
 
-def decode_initialize_account3(instruction: Instruction) -> models.InitializeAccount3Params:
+def decode_initialize_account3(
+    instruction: Instruction,
+) -> models.InitializeAccount3Params:
     """Decode an initialize account3 token instruction and retrieve the instruction params."""
     parsed_data = __parse_and_validate_instruction(instruction, 2, InstructionType.INITIALIZE_ACCOUNT3)
     return models.InitializeAccount3Params(
@@ -562,7 +117,9 @@ def decode_initialize_account3(instruction: Instruction) -> models.InitializeAcc
     )
 
 
-def decode_initialize_multisig(instruction: Instruction) -> models.InitializeMultisigParams:
+def decode_initialize_multisig(
+    instruction: Instruction,
+) -> models.InitializeMultisigParams:
     """Decode an initialize multisig account token instruction and retrieve the instruction params.
 
     Args:
@@ -582,7 +139,9 @@ def decode_initialize_multisig(instruction: Instruction) -> models.InitializeMul
     )
 
 
-def decode_initialize_multisig2(instruction: Instruction) -> models.InitializeMultisig2Params:
+def decode_initialize_multisig2(
+    instruction: Instruction,
+) -> models.InitializeMultisig2Params:
     """Decode an initialize multisig2 account token instruction and retrieve the instruction params."""
     parsed_data = __parse_and_validate_instruction(instruction, 1, InstructionType.INITIALIZE_MULTISIG2)
     num_signers = parsed_data.args.m
@@ -668,7 +227,7 @@ def decode_set_authority(instruction: Instruction) -> models.SetAuthorityParams:
         program_id=instruction.program_id,
         account=instruction.accounts[0].pubkey,
         authority=AuthorityType(parsed_data.args.authority_type),
-        new_authority=Pubkey(parsed_data.args.new_authority) if parsed_data.args.new_authority_option else None,
+        new_authority=(Pubkey(parsed_data.args.new_authority) if parsed_data.args.new_authority_option else None),
         current_authority=instruction.accounts[1].pubkey,
         signers=[signer.pubkey for signer in instruction.accounts[2:]],
     )
@@ -872,7 +431,9 @@ def decode_sync_native(instruction: Instruction) -> models.SyncNativeParams:
     )
 
 
-def decode_get_account_data_size(instruction: Instruction) -> models.GetAccountDataSizeParams:
+def decode_get_account_data_size(
+    instruction: Instruction,
+) -> models.GetAccountDataSizeParams:
     """Decode a get_account_data_size token transaction and retrieve the instruction params."""
     _ = __parse_and_validate_instruction(instruction, 1, InstructionType.GET_ACCOUNT_DATA_SIZE)
     return models.GetAccountDataSizeParams(
@@ -881,7 +442,9 @@ def decode_get_account_data_size(instruction: Instruction) -> models.GetAccountD
     )
 
 
-def decode_initialize_immutable_owner(instruction: Instruction) -> models.InitializeImmutableOwnerParams:
+def decode_initialize_immutable_owner(
+    instruction: Instruction,
+) -> models.InitializeImmutableOwnerParams:
     """Decode an initialize_immutable_owner token transaction and retrieve the instruction params."""
     _ = __parse_and_validate_instruction(instruction, 1, InstructionType.INITIALIZE_IMMUTABLE_OWNER)
     return models.InitializeImmutableOwnerParams(
@@ -890,7 +453,9 @@ def decode_initialize_immutable_owner(instruction: Instruction) -> models.Initia
     )
 
 
-def decode_initialize_transfer_fee_config(instruction: Instruction) -> models.InitializeTransferFeeConfigParams:
+def decode_initialize_transfer_fee_config(
+    instruction: Instruction,
+) -> models.InitializeTransferFeeConfigParams:
     """Decode an initialize_transfer_fee_config token transaction and retrieve the instruction params."""
     parsed_data = __parse_and_validate_instruction(instruction, 1, InstructionType.TRANSFER_FEE_EXTENSION)
     if parsed_data.args.transfer_fee_instruction_type != TransferFeeInstructionType.INITIALIZE_TRANSFER_FEE_CONFIG:
@@ -901,12 +466,12 @@ def decode_initialize_transfer_fee_config(instruction: Instruction) -> models.In
     return models.InitializeTransferFeeConfigParams(
         program_id=instruction.program_id,
         mint=instruction.accounts[0].pubkey,
-        transfer_fee_config_authority=Pubkey(transfer_fee_config_authority.pubkey)
-        if transfer_fee_config_authority.option
-        else None,
-        withdraw_withheld_authority=Pubkey(withdraw_withheld_authority.pubkey)
-        if withdraw_withheld_authority.option
-        else None,
+        transfer_fee_config_authority=(
+            Pubkey(transfer_fee_config_authority.pubkey) if transfer_fee_config_authority.option else None
+        ),
+        withdraw_withheld_authority=(
+            Pubkey(withdraw_withheld_authority.pubkey) if withdraw_withheld_authority.option else None
+        ),
         transfer_fee_basis_points=args.transfer_fee_basis_points,
         maximum_fee=args.maximum_fee,
     )
@@ -952,7 +517,9 @@ def decode_withdraw_withheld_tokens_from_mint(
     )
 
 
-def decode_harvest_withheld_tokens_to_mint(instruction: Instruction) -> models.HarvestWithheldTokensToMintParams:
+def decode_harvest_withheld_tokens_to_mint(
+    instruction: Instruction,
+) -> models.HarvestWithheldTokensToMintParams:
     """Decode a harvest_withheld_tokens_to_mint token transaction and retrieve the instruction params."""
     parsed_data = __parse_and_validate_instruction(instruction, 1, InstructionType.TRANSFER_FEE_EXTENSION)
     if parsed_data.args.transfer_fee_instruction_type != TransferFeeInstructionType.HARVEST_WITHHELD_TOKENS_TO_MINT:
@@ -964,7 +531,9 @@ def decode_harvest_withheld_tokens_to_mint(instruction: Instruction) -> models.H
     )
 
 
-def decode_amount_to_ui_amount(instruction: Instruction) -> models.AmountToUiAmountParams:
+def decode_amount_to_ui_amount(
+    instruction: Instruction,
+) -> models.AmountToUiAmountParams:
     """Decode an amount_to_ui_amount token transaction and retrieve the instruction params."""
     parsed_data = __parse_and_validate_instruction(instruction, 1, InstructionType.AMOUNT_TO_UI_AMOUNT)
     return models.AmountToUiAmountParams(
@@ -974,7 +543,9 @@ def decode_amount_to_ui_amount(instruction: Instruction) -> models.AmountToUiAmo
     )
 
 
-def decode_ui_amount_to_amount(instruction: Instruction) -> models.UiAmountToAmountParams:
+def decode_ui_amount_to_amount(
+    instruction: Instruction,
+) -> models.UiAmountToAmountParams:
     """Decode a ui_amount_to_amount token transaction and retrieve the instruction params."""
     parsed_data = __parse_and_validate_instruction(instruction, 1, InstructionType.UI_AMOUNT_TO_AMOUNT)
     ui_amount_bytes: bytes = parsed_data.args.ui_amount
@@ -1036,7 +607,7 @@ def __mint_to_instruction(params: Union[models.MintToParams, models.MintToChecke
     return Instruction(accounts=keys, program_id=params.program_id, data=data)
 
 
-def initialize_mint(params: Union[InitializeMintParams, models.InitializeMintParams]) -> Instruction:
+def initialize_mint(params: models.InitializeMintParams) -> Instruction:
     """Creates a transaction instruction to initialize a new mint newly.
 
     This instruction requires no signers and MUST be included within the same Transaction as
@@ -1063,7 +634,6 @@ def initialize_mint(params: Union[InitializeMintParams, models.InitializeMintPar
     Returns:
         The instruction to initialize the mint.
     """
-    params = models.InitializeMintParams.from_namedtuple(params)
     freeze_authority, opt = (params.freeze_authority, 1) if params.freeze_authority else (Pubkey([0] * 31 + [0]), 0)
     data = INSTRUCTIONS_LAYOUT.build(
         {
@@ -1086,9 +656,8 @@ def initialize_mint(params: Union[InitializeMintParams, models.InitializeMintPar
     )
 
 
-def initialize_mint2(params: Union[InitializeMint2Params, models.InitializeMint2Params]) -> Instruction:
+def initialize_mint2(params: models.InitializeMint2Params) -> Instruction:
     """Creates a transaction instruction to initialize a new mint without providing the Rent sysvar."""
-    params = models.InitializeMint2Params.from_namedtuple(params)
     freeze_authority, opt = (params.freeze_authority, 1) if params.freeze_authority else (Pubkey([0] * 31 + [0]), 0)
     data = INSTRUCTIONS_LAYOUT.build(
         {
@@ -1110,7 +679,7 @@ def initialize_mint2(params: Union[InitializeMint2Params, models.InitializeMint2
     )
 
 
-def initialize_account(params: Union[InitializeAccountParams, models.InitializeAccountParams]) -> Instruction:
+def initialize_account(params: models.InitializeAccountParams) -> Instruction:
     """Creates a transaction instruction to initialize a new account to hold tokens.
 
     This instruction requires no signers and MUST be included within the same Transaction as
@@ -1134,7 +703,6 @@ def initialize_account(params: Union[InitializeAccountParams, models.InitializeA
     Returns:
         The instruction to initialize the account.
     """
-    params = models.InitializeAccountParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build({"instruction_type": InstructionType.INITIALIZE_ACCOUNT, "args": None})
     return Instruction(
         accounts=[
@@ -1148,9 +716,8 @@ def initialize_account(params: Union[InitializeAccountParams, models.InitializeA
     )
 
 
-def initialize_account2(params: Union[InitializeAccount2Params, models.InitializeAccount2Params]) -> Instruction:
+def initialize_account2(params: models.InitializeAccount2Params) -> Instruction:
     """Creates a transaction instruction to initialize a new account with owner passed in data."""
-    params = models.InitializeAccount2Params.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build(
         {
             "instruction_type": InstructionType.INITIALIZE_ACCOUNT2,
@@ -1168,9 +735,8 @@ def initialize_account2(params: Union[InitializeAccount2Params, models.Initializ
     )
 
 
-def initialize_account3(params: Union[InitializeAccount3Params, models.InitializeAccount3Params]) -> Instruction:
+def initialize_account3(params: models.InitializeAccount3Params) -> Instruction:
     """Creates a transaction instruction to initialize a new account with owner passed in data and no Rent sysvar."""
-    params = models.InitializeAccount3Params.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build(
         {
             "instruction_type": InstructionType.INITIALIZE_ACCOUNT3,
@@ -1187,7 +753,7 @@ def initialize_account3(params: Union[InitializeAccount3Params, models.Initializ
     )
 
 
-def initialize_multisig(params: Union[InitializeMultisigParams, models.InitializeMultisigParams]) -> Instruction:
+def initialize_multisig(params: models.InitializeMultisigParams) -> Instruction:
     """Creates a transaction instruction to initialize a multisignature account with N provided signers.
 
     This instruction requires no signers and MUST be included within the same Transaction as
@@ -1212,7 +778,6 @@ def initialize_multisig(params: Union[InitializeMultisigParams, models.Initializ
     Returns:
         The instruction to initialize the multisig.
     """
-    params = models.InitializeMultisigParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build(
         {
             "instruction_type": InstructionType.INITIALIZE_MULTISIG,
@@ -1230,10 +795,9 @@ def initialize_multisig(params: Union[InitializeMultisigParams, models.Initializ
 
 
 def initialize_multisig2(
-    params: Union[InitializeMultisig2Params, models.InitializeMultisig2Params],
+    params: models.InitializeMultisig2Params,
 ) -> Instruction:
     """Creates a transaction instruction to initialize a multisignature account without providing the Rent sysvar."""
-    params = models.InitializeMultisig2Params.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build(
         {
             "instruction_type": InstructionType.INITIALIZE_MULTISIG2,
@@ -1248,7 +812,7 @@ def initialize_multisig2(
     return Instruction(accounts=keys, program_id=params.program_id, data=data)
 
 
-def transfer(params: Union[TransferParams, models.TransferParams]) -> Instruction:
+def transfer(params: models.TransferParams) -> Instruction:
     """Creates a transaction instruction to transfers tokens from one account to another.
 
     Either directly or via a delegate.
@@ -1271,7 +835,6 @@ def transfer(params: Union[TransferParams, models.TransferParams]) -> Instructio
     Returns:
         The transfer instruction.
     """
-    params = models.TransferParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build(
         {
             "instruction_type": InstructionType.TRANSFER,
@@ -1287,7 +850,7 @@ def transfer(params: Union[TransferParams, models.TransferParams]) -> Instructio
     return Instruction(accounts=keys, program_id=params.program_id, data=data)
 
 
-def approve(params: Union[ApproveParams, models.ApproveParams]) -> Instruction:
+def approve(params: models.ApproveParams) -> Instruction:
     """Creates a transaction instruction to approve a delegate.
 
     Example:
@@ -1308,7 +871,6 @@ def approve(params: Union[ApproveParams, models.ApproveParams]) -> Instruction:
     Returns:
         The approve instruction.
     """
-    params = models.ApproveParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build({"instruction_type": InstructionType.APPROVE, "args": {"amount": params.amount}})
     keys = [
         AccountMeta(pubkey=params.source, is_signer=False, is_writable=True),
@@ -1319,7 +881,7 @@ def approve(params: Union[ApproveParams, models.ApproveParams]) -> Instruction:
     return Instruction(accounts=keys, program_id=params.program_id, data=data)
 
 
-def revoke(params: Union[RevokeParams, models.RevokeParams]) -> Instruction:
+def revoke(params: models.RevokeParams) -> Instruction:
     """Creates a transaction instruction that revokes delegate authority for a given account.
 
     Example:
@@ -1336,7 +898,6 @@ def revoke(params: Union[RevokeParams, models.RevokeParams]) -> Instruction:
     Returns:
         The revoke instruction.
     """
-    params = models.RevokeParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build({"instruction_type": InstructionType.REVOKE, "args": None})
     keys = [AccountMeta(pubkey=params.account, is_signer=False, is_writable=True)]
     __add_signers(keys, params.owner, params.signers)
@@ -1344,7 +905,7 @@ def revoke(params: Union[RevokeParams, models.RevokeParams]) -> Instruction:
     return Instruction(accounts=keys, program_id=params.program_id, data=data)
 
 
-def set_authority(params: Union[SetAuthorityParams, models.SetAuthorityParams]) -> Instruction:
+def set_authority(params: models.SetAuthorityParams) -> Instruction:
     """Creates a transaction instruction to sets a new authority of a mint or account.
 
     Example:
@@ -1365,7 +926,6 @@ def set_authority(params: Union[SetAuthorityParams, models.SetAuthorityParams]) 
     Returns:
         The set authority instruction.
     """
-    params = models.SetAuthorityParams.from_namedtuple(params)
     new_authority, opt = (params.new_authority, 1) if params.new_authority else (Pubkey([0] * 31 + [0]), 0)
     data = INSTRUCTIONS_LAYOUT.build(
         {
@@ -1383,7 +943,7 @@ def set_authority(params: Union[SetAuthorityParams, models.SetAuthorityParams]) 
     return Instruction(accounts=keys, program_id=params.program_id, data=data)
 
 
-def mint_to(params: Union[MintToParams, models.MintToParams]) -> Instruction:
+def mint_to(params: models.MintToParams) -> Instruction:
     """Creates a transaction instruction to mint new tokens to an account.
 
     The native mint does not support minting.
@@ -1406,12 +966,11 @@ def mint_to(params: Union[MintToParams, models.MintToParams]) -> Instruction:
     Returns:
         The mint-to instruction.
     """
-    params = models.MintToParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build({"instruction_type": InstructionType.MINT_TO, "args": {"amount": params.amount}})
     return __mint_to_instruction(params, data)
 
 
-def burn(params: Union[BurnParams, models.BurnParams]) -> Instruction:
+def burn(params: models.BurnParams) -> Instruction:
     """Creates a transaction instruction to burns tokens by removing them from an account.
 
     Example:
@@ -1428,12 +987,11 @@ def burn(params: Union[BurnParams, models.BurnParams]) -> Instruction:
     Returns:
         The burn instruction.
     """
-    params = models.BurnParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build({"instruction_type": InstructionType.BURN, "args": {"amount": params.amount}})
     return __burn_instruction(params, data)
 
 
-def close_account(params: Union[CloseAccountParams, models.CloseAccountParams]) -> Instruction:
+def close_account(params: models.CloseAccountParams) -> Instruction:
     """Creates a transaction instruction to close an account by transferring all its SOL to the destination account.
 
     Non-native accounts may only be closed if its token amount is zero.
@@ -1451,7 +1009,6 @@ def close_account(params: Union[CloseAccountParams, models.CloseAccountParams]) 
     Returns:
         The close-account instruction.
     """
-    params = models.CloseAccountParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build({"instruction_type": InstructionType.CLOSE_ACCOUNT, "args": None})
     keys = [
         AccountMeta(pubkey=params.account, is_signer=False, is_writable=True),
@@ -1462,7 +1019,7 @@ def close_account(params: Union[CloseAccountParams, models.CloseAccountParams]) 
     return Instruction(accounts=keys, program_id=params.program_id, data=data)
 
 
-def freeze_account(params: Union[FreezeAccountParams, models.FreezeAccountParams]) -> Instruction:
+def freeze_account(params: models.FreezeAccountParams) -> Instruction:
     """Creates a transaction instruction to freeze an initialized account using the mint's freeze_authority (if set).
 
     Example:
@@ -1478,11 +1035,10 @@ def freeze_account(params: Union[FreezeAccountParams, models.FreezeAccountParams
     Returns:
         The freeze-account instruction.
     """
-    params = models.FreezeAccountParams.from_namedtuple(params)
     return __freeze_or_thaw_instruction(params, InstructionType.FREEZE_ACCOUNT)
 
 
-def thaw_account(params: Union[ThawAccountParams, models.ThawAccountParams]) -> Instruction:
+def thaw_account(params: models.ThawAccountParams) -> Instruction:
     """Creates a transaction instruction to thaw a frozen account using the Mint's freeze_authority (if set).
 
     Example:
@@ -1498,11 +1054,10 @@ def thaw_account(params: Union[ThawAccountParams, models.ThawAccountParams]) -> 
     Returns:
         The thaw-account instruction.
     """
-    params = models.ThawAccountParams.from_namedtuple(params)
     return __freeze_or_thaw_instruction(params, InstructionType.THAW_ACCOUNT)
 
 
-def transfer_checked(params: Union[TransferCheckedParams, models.TransferCheckedParams]) -> Instruction:
+def transfer_checked(params: models.TransferCheckedParams) -> Instruction:
     """This instruction differs from `transfer` in that the token mint and decimals value is asserted by the caller.
 
     Example:
@@ -1525,7 +1080,6 @@ def transfer_checked(params: Union[TransferCheckedParams, models.TransferChecked
     Returns:
         The transfer-checked instruction.
     """
-    params = models.TransferCheckedParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build(
         {
             "instruction_type": InstructionType.TRANSFER2,
@@ -1542,7 +1096,7 @@ def transfer_checked(params: Union[TransferCheckedParams, models.TransferChecked
     return Instruction(accounts=keys, program_id=params.program_id, data=data)
 
 
-def approve_checked(params: Union[ApproveCheckedParams, models.ApproveCheckedParams]) -> Instruction:
+def approve_checked(params: models.ApproveCheckedParams) -> Instruction:
     """This instruction differs from `approve` in that the token mint and decimals value is asserted by the caller.
 
     Example:
@@ -1565,7 +1119,6 @@ def approve_checked(params: Union[ApproveCheckedParams, models.ApproveCheckedPar
     Returns:
         The approve-checked instruction.
     """
-    params = models.ApproveCheckedParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build(
         {
             "instruction_type": InstructionType.APPROVE2,
@@ -1582,7 +1135,7 @@ def approve_checked(params: Union[ApproveCheckedParams, models.ApproveCheckedPar
     return Instruction(accounts=keys, program_id=params.program_id, data=data)
 
 
-def mint_to_checked(params: Union[MintToCheckedParams, models.MintToCheckedParams]) -> Instruction:
+def mint_to_checked(params: models.MintToCheckedParams) -> Instruction:
     """This instruction differs from `mint_to` in that the decimals value is asserted by the caller.
 
     Example:
@@ -1604,7 +1157,6 @@ def mint_to_checked(params: Union[MintToCheckedParams, models.MintToCheckedParam
     Returns:
         The mint-to-checked instruction.
     """
-    params = models.MintToCheckedParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build(
         {
             "instruction_type": InstructionType.MINT_TO2,
@@ -1614,7 +1166,7 @@ def mint_to_checked(params: Union[MintToCheckedParams, models.MintToCheckedParam
     return __mint_to_instruction(params, data)
 
 
-def burn_checked(params: Union[BurnCheckedParams, models.BurnCheckedParams]) -> Instruction:
+def burn_checked(params: models.BurnCheckedParams) -> Instruction:
     """This instruction differs from `burn` in that the decimals value is asserted by the caller.
 
     Example:
@@ -1631,7 +1183,6 @@ def burn_checked(params: Union[BurnCheckedParams, models.BurnCheckedParams]) -> 
     Returns:
         The burn-checked instruction.
     """
-    params = models.BurnCheckedParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build(
         {
             "instruction_type": InstructionType.BURN2,
@@ -1641,7 +1192,7 @@ def burn_checked(params: Union[BurnCheckedParams, models.BurnCheckedParams]) -> 
     return __burn_instruction(params, data)
 
 
-def sync_native(params: Union[SyncNativeParams, models.SyncNativeParams]) -> Instruction:
+def sync_native(params: models.SyncNativeParams) -> Instruction:
     """Syncs the amount field with the number of lamports of the account.
 
     Example:
@@ -1656,7 +1207,6 @@ def sync_native(params: Union[SyncNativeParams, models.SyncNativeParams]) -> Ins
     Returns:
         The sync-native instruction.
     """
-    params = models.SyncNativeParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build(
         {
             "instruction_type": InstructionType.SYNC_NATIVE,
@@ -1667,10 +1217,9 @@ def sync_native(params: Union[SyncNativeParams, models.SyncNativeParams]) -> Ins
 
 
 def get_account_data_size(
-    params: Union[GetAccountDataSizeParams, models.GetAccountDataSizeParams],
+    params: models.GetAccountDataSizeParams,
 ) -> Instruction:
     """Gets the required size of an account for the given mint as a little-endian u64."""
-    params = models.GetAccountDataSizeParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build({"instruction_type": InstructionType.GET_ACCOUNT_DATA_SIZE, "args": None})
     return Instruction(
         accounts=[AccountMeta(pubkey=params.mint, is_signer=False, is_writable=False)],
@@ -1680,10 +1229,9 @@ def get_account_data_size(
 
 
 def initialize_immutable_owner(
-    params: Union[InitializeImmutableOwnerParams, models.InitializeImmutableOwnerParams],
+    params: models.InitializeImmutableOwnerParams,
 ) -> Instruction:
     """Initializes the Immutable Owner extension for a token account."""
-    params = models.InitializeImmutableOwnerParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build({"instruction_type": InstructionType.INITIALIZE_IMMUTABLE_OWNER, "args": None})
     return Instruction(
         accounts=[AccountMeta(pubkey=params.account, is_signer=False, is_writable=True)],
@@ -1693,10 +1241,9 @@ def initialize_immutable_owner(
 
 
 def initialize_transfer_fee_config(
-    params: Union[InitializeTransferFeeConfigParams, models.InitializeTransferFeeConfigParams],
+    params: models.InitializeTransferFeeConfigParams,
 ) -> Instruction:
     """Initializes the TransferFeeConfig extension for a mint."""
-    params = models.InitializeTransferFeeConfigParams.from_namedtuple(params)
     transfer_fee_config_authority = (
         {"option": 1, "pubkey": bytes(params.transfer_fee_config_authority)}
         if params.transfer_fee_config_authority
@@ -1729,10 +1276,9 @@ def initialize_transfer_fee_config(
 
 
 def withdraw_withheld_tokens_from_accounts(
-    params: Union[WithdrawWithheldTokensFromAccountsParams, models.WithdrawWithheldTokensFromAccountsParams],
+    params: models.WithdrawWithheldTokensFromAccountsParams,
 ) -> Instruction:
     """Withdraws withheld tokens from token accounts to a fee receiver account."""
-    params = models.WithdrawWithheldTokensFromAccountsParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build(
         {
             "instruction_type": InstructionType.TRANSFER_FEE_EXTENSION,
@@ -1756,10 +1302,9 @@ def withdraw_withheld_tokens_from_accounts(
 
 
 def withdraw_withheld_tokens_from_mint(
-    params: Union[WithdrawWithheldTokensFromMintParams, models.WithdrawWithheldTokensFromMintParams],
+    params: models.WithdrawWithheldTokensFromMintParams,
 ) -> Instruction:
     """Withdraws withheld tokens from a mint to a fee receiver account."""
-    params = models.WithdrawWithheldTokensFromMintParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build(
         {
             "instruction_type": InstructionType.TRANSFER_FEE_EXTENSION,
@@ -1782,10 +1327,9 @@ def withdraw_withheld_tokens_from_mint(
 
 
 def harvest_withheld_tokens_to_mint(
-    params: Union[HarvestWithheldTokensToMintParams, models.HarvestWithheldTokensToMintParams],
+    params: models.HarvestWithheldTokensToMintParams,
 ) -> Instruction:
     """Harvests withheld tokens from token accounts to the mint."""
-    params = models.HarvestWithheldTokensToMintParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build(
         {
             "instruction_type": InstructionType.TRANSFER_FEE_EXTENSION,
@@ -1804,11 +1348,13 @@ def harvest_withheld_tokens_to_mint(
     )
 
 
-def amount_to_ui_amount(params: Union[AmountToUiAmountParams, models.AmountToUiAmountParams]) -> Instruction:
+def amount_to_ui_amount(params: models.AmountToUiAmountParams) -> Instruction:
     """Converts a raw token amount to a UiAmount string using the given mint."""
-    params = models.AmountToUiAmountParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build(
-        {"instruction_type": InstructionType.AMOUNT_TO_UI_AMOUNT, "args": {"amount": params.amount}}
+        {
+            "instruction_type": InstructionType.AMOUNT_TO_UI_AMOUNT,
+            "args": {"amount": params.amount},
+        }
     )
     return Instruction(
         accounts=[AccountMeta(pubkey=params.mint, is_signer=False, is_writable=False)],
@@ -1817,9 +1363,8 @@ def amount_to_ui_amount(params: Union[AmountToUiAmountParams, models.AmountToUiA
     )
 
 
-def ui_amount_to_amount(params: Union[UiAmountToAmountParams, models.UiAmountToAmountParams]) -> Instruction:
+def ui_amount_to_amount(params: models.UiAmountToAmountParams) -> Instruction:
     """Converts a UiAmount string to a raw u64 token amount using the given mint."""
-    params = models.UiAmountToAmountParams.from_namedtuple(params)
     data = INSTRUCTIONS_LAYOUT.build(
         {
             "instruction_type": InstructionType.UI_AMOUNT_TO_AMOUNT,
@@ -1858,7 +1403,10 @@ def get_associated_token_address(owner: Pubkey, mint: Pubkey, token_program_id: 
 
 
 def create_associated_token_account(
-    payer: Pubkey, owner: Pubkey, mint: Pubkey, token_program_id: Pubkey = TOKEN_PROGRAM_ID
+    payer: Pubkey,
+    owner: Pubkey,
+    mint: Pubkey,
+    token_program_id: Pubkey = TOKEN_PROGRAM_ID,
 ) -> Instruction:
     """Creates a transaction instruction to create an associated token account.
 
@@ -1894,7 +1442,10 @@ def create_associated_token_account(
 
 
 def create_idempotent_associated_token_account(
-    payer: Pubkey, owner: Pubkey, mint: Pubkey, token_program_id: Pubkey = TOKEN_PROGRAM_ID
+    payer: Pubkey,
+    owner: Pubkey,
+    mint: Pubkey,
+    token_program_id: Pubkey = TOKEN_PROGRAM_ID,
 ) -> Instruction:
     """Creates an associated token account for the given address/token mint if it not exists.
 

--- a/src/spl/token/models.py
+++ b/src/spl/token/models.py
@@ -1,10 +1,4 @@
-"""Pydantic models for SPL token types.
-
-These are the Pydantic successors to the deprecated ``NamedTuple`` types in
-:mod:`spl.token.core` (account/mint info) and :mod:`spl.token.instructions` (instruction
-params). They carry the same field names and defaults, so migrating is a matter of
-changing the import path.
-"""
+"""Pydantic models for SPL token types."""
 
 from __future__ import annotations
 

--- a/tests/unit/test_pydantic_models.py
+++ b/tests/unit/test_pydantic_models.py
@@ -1,4 +1,4 @@
-"""Tests for the Pydantic models that supersede the deprecated NamedTuple types."""
+"""Tests for solana-py Pydantic models."""
 
 from typing import cast
 
@@ -11,45 +11,40 @@ import solana.rpc.models as rpc_models
 import spl.memo.models as memo_models
 import spl.token.models as token_models
 from solana.rpc.commitment import Finalized
-from solana.rpc.types import DataSliceOpts as DeprecatedDataSliceOpts
-from solana.rpc.types import MemcmpOpts as DeprecatedMemcmpOpts
-from solana.rpc.types import TokenAccountOpts as DeprecatedTokenAccountOpts
-from solana.rpc.types import TxOpts as DeprecatedTxOpts
-from solana.utils.cluster import ClusterUrls as DeprecatedClusterUrls
-from solana.utils.cluster import Endpoint as DeprecatedEndpoint
-from solana.vote_program import (
-    WithdrawFromVoteAccountParams as DeprecatedWithdrawFromVoteAccountParams,
+
+
+@pytest.mark.parametrize(
+    "model_cls, expected_fields",
+    [
+        (rpc_models.DataSliceOpts, ["offset", "length"]),
+        (rpc_models.MemcmpOpts, ["offset", "bytes"]),
+        (rpc_models.TokenAccountOpts, ["mint", "program_id", "encoding", "data_slice"]),
+        (
+            rpc_models.TxOpts,
+            [
+                "skip_confirmation",
+                "skip_preflight",
+                "preflight_commitment",
+                "max_retries",
+                "last_valid_block_height",
+            ],
+        ),
+        (rpc_models.ClusterUrls, ["devnet", "testnet", "mainnet_beta"]),
+        (rpc_models.Endpoint, ["http", "https"]),
+        (
+            solana_models.WithdrawFromVoteAccountParams,
+            ["vote_account_from_pubkey", "to_pubkey", "lamports", "withdrawer"],
+        ),
+        (memo_models.MemoParams, ["program_id", "signer", "message"]),
+        (
+            token_models.TransferParams,
+            ["program_id", "source", "dest", "owner", "amount", "signers"],
+        ),
+    ],
 )
-from spl.memo.instructions import MemoParams as DeprecatedMemoParams
-from spl.token import instructions as token_instructions
-
-# (deprecated NamedTuple, new Pydantic model) pairs that should be field-compatible.
-_PARITY_PAIRS = [
-    (DeprecatedDataSliceOpts, rpc_models.DataSliceOpts),
-    (DeprecatedMemcmpOpts, rpc_models.MemcmpOpts),
-    (DeprecatedTokenAccountOpts, rpc_models.TokenAccountOpts),
-    (DeprecatedTxOpts, rpc_models.TxOpts),
-    (DeprecatedClusterUrls, rpc_models.ClusterUrls),
-    (DeprecatedEndpoint, rpc_models.Endpoint),
-    (
-        DeprecatedWithdrawFromVoteAccountParams,
-        solana_models.WithdrawFromVoteAccountParams,
-    ),
-    (DeprecatedMemoParams, memo_models.MemoParams),
-]
-
-# All instruction params NamedTuples live in spl.token.instructions and are mirrored in spl.token.models.
-_PARITY_PAIRS += [
-    (getattr(token_instructions, name), getattr(token_models, name))
-    for name in dir(token_instructions)
-    if name.endswith("Params") and hasattr(token_models, name)
-]
-
-
-@pytest.mark.parametrize("deprecated_cls, model_cls", _PARITY_PAIRS, ids=lambda c: getattr(c, "__name__", c))
-def test_field_parity(deprecated_cls, model_cls):
-    """The new Pydantic model exposes the same field names, in order, as the deprecated NamedTuple."""
-    assert list(model_cls.model_fields) == list(deprecated_cls._fields)
+def test_field_order(model_cls, expected_fields):
+    """Critical model fields stay stable and ordered."""
+    assert list(model_cls.model_fields) == expected_fields
 
 
 def test_construction_and_attribute_access():
@@ -94,43 +89,3 @@ def test_validation_rejects_bad_types():
 def test_field_descriptions_carried_over():
     """Attribute docstrings become field descriptions."""
     assert token_models.TransferParams.model_fields["program_id"].description == "SPL Token program account."
-
-
-def test_from_namedtuple_converts_deprecated_instance():
-    """from_namedtuple builds a model from a deprecated NamedTuple instance."""
-    with pytest.deprecated_call():
-        deprecated = DeprecatedMemcmpOpts(offset=4, bytes="3Mc6vR")
-    model = rpc_models.MemcmpOpts.from_namedtuple(deprecated)
-    assert isinstance(model, rpc_models.MemcmpOpts)
-    assert model.offset == 4
-    assert model.bytes == "3Mc6vR"
-
-
-def test_from_namedtuple_preserves_defaults():
-    """Defaulted fields survive conversion from a deprecated NamedTuple."""
-    with pytest.deprecated_call():
-        deprecated = DeprecatedTxOpts(skip_confirmation=False)
-    model = rpc_models.TxOpts.from_namedtuple(deprecated)
-    assert model.skip_confirmation is False
-    assert model.preflight_commitment == Finalized
-    assert model.max_retries is None
-
-
-def test_from_namedtuple_is_idempotent():
-    """from_namedtuple returns an existing model instance unchanged."""
-    model = rpc_models.MemcmpOpts(offset=4, bytes="3Mc6vR")
-    assert rpc_models.MemcmpOpts.from_namedtuple(model) is model
-
-
-def test_from_namedtuple_converts_params_with_pubkeys():
-    """A token params NamedTuple with Pubkey fields and a list default converts cleanly."""
-    pubkey = Keypair().pubkey()
-    with pytest.deprecated_call():
-        deprecated = token_instructions.TransferParams(
-            program_id=pubkey, source=pubkey, dest=pubkey, owner=pubkey, amount=7
-        )
-    model = token_models.TransferParams.from_namedtuple(deprecated)
-    assert isinstance(model, token_models.TransferParams)
-    assert model.amount == 7
-    assert model.program_id == pubkey
-    assert model.signers == []

--- a/tests/unit/test_vote_program.py
+++ b/tests/unit/test_vote_program.py
@@ -2,7 +2,6 @@
 
 import base64
 
-import pytest
 from solders.hash import Hash
 from solders.keypair import Keypair
 from solders.message import MessageV0
@@ -11,11 +10,7 @@ import solana.vote_program as vp
 from solana import models
 
 
-@pytest.mark.parametrize(
-    "params_cls",
-    [vp.WithdrawFromVoteAccountParams, models.WithdrawFromVoteAccountParams],
-)
-def test_withdraw_from_vote_account(params_cls):
+def test_withdraw_from_vote_account():
     withdrawer_keypair = Keypair.from_bytes(
         [
             134,
@@ -87,21 +82,12 @@ def test_withdraw_from_vote_account(params_cls):
     vote_account_pubkey = Pubkey.from_string("CWqJy1JpmBcx7awpeANfrPk6AsQKkmego8ujjaYPGFEk")
     receiver_account_pubkey = Pubkey.from_string("A1V5gsis39WY42djdTKUFsgE5oamk4nrtg16WnKTuzZK")
     recent_blockhash = Hash.from_string("Add1tV7kJgNHhTtx3Dgs6dhC7kyXrGJQZ2tJGW15tLDH")
-    if params_cls is vp.WithdrawFromVoteAccountParams:
-        with pytest.deprecated_call():
-            params = params_cls(
-                vote_account_from_pubkey=vote_account_pubkey,
-                to_pubkey=receiver_account_pubkey,
-                withdrawer=withdrawer_keypair.pubkey(),
-                lamports=2_000_000_000,
-            )
-    else:
-        params = params_cls(
-            vote_account_from_pubkey=vote_account_pubkey,
-            to_pubkey=receiver_account_pubkey,
-            withdrawer=withdrawer_keypair.pubkey(),
-            lamports=2_000_000_000,
-        )
+    params = models.WithdrawFromVoteAccountParams(
+        vote_account_from_pubkey=vote_account_pubkey,
+        to_pubkey=receiver_account_pubkey,
+        withdrawer=withdrawer_keypair.pubkey(),
+        lamports=2_000_000_000,
+    )
 
     msg = MessageV0.try_compile(
         payer=withdrawer_keypair.pubkey(),

--- a/tests/unit/test_websocket_api.py
+++ b/tests/unit/test_websocket_api.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 import itertools
 
-import pytest
 from solders.account_decoder import UiAccountEncoding, UiDataSliceConfig
 from solders.commitment_config import CommitmentLevel
 from solders.pubkey import Pubkey
 from solders.rpc.config import RpcAccountInfoConfig, RpcProgramAccountsConfig
 from solders.rpc.filter import Memcmp
 
-from solana.rpc import types
 from solana.rpc.commitment import Processed
 from solana.rpc.models import DataSliceOpts, MemcmpOpts
 from solana.rpc.websocket_api import SolanaWsClientProtocol, connect
@@ -69,44 +67,6 @@ async def test_program_subscribe_with_config(monkeypatch):
         encoding="base64",
         data_slice=DataSliceOpts(offset=1, length=2),
         filters=[17, MemcmpOpts(offset=4, bytes="3Mc6vR")],
-    )
-
-    expected_config = RpcProgramAccountsConfig(
-        RpcAccountInfoConfig(
-            encoding=UiAccountEncoding.Base64,
-            commitment=CommitmentLevel.Processed,
-            data_slice=UiDataSliceConfig(offset=1, length=2),
-        ),
-        [17, Memcmp(offset=4, bytes_="3Mc6vR")],
-    )
-    assert request_id == 1
-    assert sent_messages[0].id == request_id
-    assert sent_messages[0].config == expected_config
-
-
-async def test_program_subscribe_with_config_from_deprecated_namedtuples(monkeypatch):
-    """program_subscribe should still accept the deprecated DataSliceOpts/MemcmpOpts NamedTuples."""
-    protocol = SolanaWsClientProtocol.__new__(SolanaWsClientProtocol)
-    protocol.request_counter = itertools.count()
-    sent_messages = []
-
-    async def fake_send_request(self, message):
-        sent_messages.append(message)
-
-    monkeypatch.setattr(SolanaWsClientProtocol, "send_request", fake_send_request)
-
-    program_id = Pubkey.default()
-    with pytest.deprecated_call():
-        deprecated_data_slice = types.DataSliceOpts(offset=1, length=2)
-    with pytest.deprecated_call():
-        deprecated_memcmp = types.MemcmpOpts(offset=4, bytes="3Mc6vR")
-
-    request_id = await protocol.program_subscribe(
-        program_id,
-        commitment=Processed,
-        encoding="base64",
-        data_slice=deprecated_data_slice,
-        filters=[17, deprecated_memcmp],
     )
 
     expected_config = RpcProgramAccountsConfig(


### PR DESCRIPTION
This pull request completes the removal of all deprecated `NamedTuple` compatibility types and related coercion logic from the codebase. It updates the API boundary to accept only the new Pydantic model types, simplifies model docstrings, and removes obsolete documentation and references to the old types. These changes are breaking and require all downstream code to use the Pydantic models directly.

### Breaking API changes

* Removed all deprecated `NamedTuple` compatibility types from `solana.rpc.types`, `solana.vote_program`, `spl.memo.instructions`, and `spl.token.instructions`. All RPC and instruction helpers now accept only Pydantic model types (e.g., `DataSliceOptsModel`, `MemcmpOptsModel`, `TokenAccountOptsModel`, `TxOptsModel`) at API boundaries. 
* Removed the `PydanticModel.from_namedtuple` method and all coercion paths that allowed passing `NamedTuple` types to APIs expecting models.
* Updated all core and async RPC methods in `src/solana/rpc/async_api.py` and `src/solana/rpc/core.py` to require Pydantic model types, removing support for the old types in all function signatures. 

### Documentation cleanup

* Removed the deprecated documentation page `docs/rpc/types.md` and all references to it in the navigation. 
* Simplified and clarified docstrings in `src/solana/models.py` and `src/solana/rpc/models.py` to reflect the removal of the old types.

### Code simplification

* Removed unnecessary imports and code related to the old `NamedTuple` types in `src/solana/rpc/types.py`. 
These changes complete the migration to Pydantic models and remove all support for the legacy `NamedTuple`-based types. Downstream code must use the new models directly at all API boundaries.