### PR TITLE
docs: Fix build errors and warnings

### DIFF
--- a/docs/rpc/providers.md
+++ b/docs/rpc/providers.md
@@ -1,3 +1,3 @@
 # RPC Providers
 
-:::solana.rpc.providers
+:::solana.rpc.async_http_provider

--- a/src/solana/rpc/commitment.py
+++ b/src/solana/rpc/commitment.py
@@ -79,8 +79,8 @@ def commitment_comparator(a: Commitment, b: Commitment) -> Literal[-1, 0, 1]:
 
     Returns:
         -1 if ``a`` is less finalized than ``b``,
-         0 if they are equal,
-         1 if ``a`` is more finalized than ``b``.
+            0 if they are equal,
+            1 if ``a`` is more finalized than ``b``.
 
     Example:
         >>> commitment_comparator(Commitment.FINALIZED, Commitment.PROCESSED)

--- a/src/solana/rpc/websocket_api.py
+++ b/src/solana/rpc/websocket_api.py
@@ -254,8 +254,8 @@ class SolanaWsClientProtocol(ClientConnection):
             program_id: The program ID.
             commitment: Commitment level to use.
             encoding: Encoding to use.
-            data_slice: (optional) Limit the returned account data using the provided `offset`: <usize> and
-            `   length`: <usize> fields; only available for "base58" or "base64" encoding.
+            data_slice: (optional) Limit the returned account data using the provided ``offset``: <usize> and
+                ``length``: <usize> fields; only available for "base58" or "base64" encoding.
             filters: (optional) Options to compare a provided series of bytes with program account data at a particular offset.
                 Note: an int entry is converted to a `dataSize` filter.
         """  # noqa: E501 # pylint: disable=line-too-long


### PR DESCRIPTION
## Summary

Fixes the following documentation build errors and warnings:

1. **ERROR**: `solana.rpc.providers` module not found
   - Changed `:::solana.rpc.providers` to `:::solana.rpc.async_http_provider` in `docs/rpc/providers.md`

2. **WARNING**: Confusing indentation in `src/solana/rpc/commitment.py:82-83`
   - Fixed the docstring indentation in the `commitment_comparator` function

3. **WARNING**: Malformed backticks in `src/solana/rpc/websocket_api.py:258`
   - Fixed the malformed backticks in the `program_subscribe` docstring

## Testing

The documentation now builds successfully with `mkdocs build`.

@michaelhly can click here to [continue refining the PR](https://app.all-hands.dev/conversations/17ee8ac3-2caf-44ea-ae32-8fb1a4f18a3e)