### PR TITLE
Cancel Generic Type on JsonRpcRequest

### DIFF
--- a/src/solana/_pydantic.py
+++ b/src/solana/_pydantic.py
@@ -20,7 +20,5 @@ class PydanticModel(BaseModel):
     """
 
     model_config = ConfigDict(
-        arbitrary_types_allowed=True,
-        frozen=True,
-        use_attribute_docstrings=True,
+        arbitrary_types_allowed=True, frozen=True, use_attribute_docstrings=True
     )

--- a/src/solana/_pydantic.py
+++ b/src/solana/_pydantic.py
@@ -19,6 +19,4 @@ class PydanticModel(BaseModel):
         - read field descriptions from attribute docstrings.
     """
 
-    model_config = ConfigDict(
-        arbitrary_types_allowed=True, frozen=True, use_attribute_docstrings=True
-    )
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True, use_attribute_docstrings=True)

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Sequence
 from time import time
-from typing import Any
 
 from solders.message import MessageV0
 from solders.pubkey import Pubkey
@@ -151,7 +150,7 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
 
     async def send_rpc_request(
         self,
-        request: JsonRpcRequest[Any],
+        request: JsonRpcRequest,
         result_model: type[TResult],
         *,
         error_parser: JsonRpcErrorParser | None = None,

--- a/src/solana/rpc/jsonrpc.py
+++ b/src/solana/rpc/jsonrpc.py
@@ -5,14 +5,12 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from enum import IntEnum
-from typing import Any, Generic, Literal, Protocol, TypeVar
+from typing import Any, Literal, Protocol, TypeVar
 
 from pydantic import BaseModel, model_validator
 from pydantic.main import IncEx
 
 from solana._pydantic import PydanticModel
-
-JsonRpcParamT = TypeVar("JsonRpcParamT", bound=BaseModel)
 
 
 class JsonRpcRequestSerializer(Protocol):
@@ -23,13 +21,13 @@ class JsonRpcRequestSerializer(Protocol):
         ...
 
 
-class JsonRpcRequest(PydanticModel, Generic[JsonRpcParamT]):
+class JsonRpcRequest(PydanticModel):
     """Base Pydantic JSON-RPC request model."""
 
     jsonrpc: Literal["2.0"] = "2.0"
     id: str | int = "1"
     method: str
-    params: list[JsonRpcParamT] | None = None
+    params: Any | None = None
 
     def to_json(
         self,

--- a/tests/unit/test_async_client.py
+++ b/tests/unit/test_async_client.py
@@ -53,6 +53,7 @@ class _TypedRpcRequest(JsonRpcRequest[_TypedRpcParams]):
     """Test JSON-RPC request with typed params."""
 
     method: str = "typedMethod"
+    params: list[_TypedRpcParams] | None = None
 
 
 class _LooseRpcRequest(BaseModel):
@@ -102,8 +103,20 @@ def test_jsonrpc_request_to_json_forwards_model_dump_json_kwargs():
     }
 
 
-def test_jsonrpc_request_supports_typed_params():
-    request = JsonRpcRequest[_TypedRpcParams].model_validate({"method": "typedMethod", "params": [{"value": 2}]})
+def test_jsonrpc_request_params_are_untyped_by_default():
+    request = JsonRpcRequest.model_validate({"method": "testMethod", "params": {"value": 2}})
+
+    assert request.params == {"value": 2}
+    assert json.loads(request.to_json()) == {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "testMethod",
+        "params": {"value": 2},
+    }
+
+
+def test_jsonrpc_request_subclasses_can_override_params():
+    request = _TypedRpcRequest.model_validate({"params": [{"value": 2}]})
 
     assert request.params == [_TypedRpcParams(value=2)]
     assert json.loads(request.to_json()) == {
@@ -116,7 +129,7 @@ def test_jsonrpc_request_supports_typed_params():
 
 def test_jsonrpc_request_typed_params_must_be_list():
     with pytest.raises(ValidationError):
-        JsonRpcRequest[_TypedRpcParams].model_validate({"method": "typedMethod", "params": {"value": 2}})
+        _TypedRpcRequest.model_validate({"params": {"value": 2}})
 
 
 def test_solana_jsonrpc_error_to_json():

--- a/tests/unit/test_async_client.py
+++ b/tests/unit/test_async_client.py
@@ -49,7 +49,7 @@ class _TypedRpcParams(PydanticModel):
     value: int
 
 
-class _TypedRpcRequest(JsonRpcRequest[_TypedRpcParams]):
+class _TypedRpcRequest(JsonRpcRequest):
     """Test JSON-RPC request with typed params."""
 
     method: str = "typedMethod"
@@ -79,13 +79,17 @@ class _ScalarRpcResult(RootModel[int]):
 class _CustomRpcError(SolanaJsonRpcError):
     """Test custom JSON-RPC error."""
 
-    def __init__(self, code: int, message: str, request_id: str | int, method: str | None) -> None:
+    def __init__(
+        self, code: int, message: str, request_id: str | int, method: str | None
+    ) -> None:
         """Initialize test custom JSON-RPC error."""
         super().__init__(code, message, request_id=request_id, method=method)
 
 
 def _mock_response(text: str) -> httpx2.Response:
-    return httpx2.Response(200, text=text, request=httpx2.Request("POST", "http://localhost:8899"))
+    return httpx2.Response(
+        200, text=text, request=httpx2.Request("POST", "http://localhost:8899")
+    )
 
 
 def test_jsonrpc_request_to_json_forwards_model_dump_json_kwargs():
@@ -104,7 +108,9 @@ def test_jsonrpc_request_to_json_forwards_model_dump_json_kwargs():
 
 
 def test_jsonrpc_request_params_are_untyped_by_default():
-    request = JsonRpcRequest.model_validate({"method": "testMethod", "params": {"value": 2}})
+    request = JsonRpcRequest.model_validate(
+        {"method": "testMethod", "params": {"value": 2}}
+    )
 
     assert request.params == {"value": 2}
     assert json.loads(request.to_json()) == {
@@ -218,7 +224,10 @@ async def test_async_client_http_exception(unit_test_http_client_async):
         with pytest.raises(SolanaRpcException) as exc_info:
             await unit_test_http_client_async.get_epoch_info()
         assert exc_info.type == SolanaRpcException
-        assert exc_info.value.error_msg == "<class 'httpx2.ReadTimeout'> raised in \"GetEpochInfo\" endpoint request"
+        assert (
+            exc_info.value.error_msg
+            == "<class 'httpx2.ReadTimeout'> raised in \"GetEpochInfo\" endpoint request"
+        )
 
 
 async def test_async_http_provider_retries_transport_error_once(
@@ -228,7 +237,9 @@ async def test_async_http_provider_retries_transport_error_once(
     raw = '{"jsonrpc":"2.0","id":1,"result":{"value":42}}'
     with patch("httpx2.AsyncClient.post") as post_mock:
         post_mock.side_effect = [ReadError("placeholder"), _mock_response(raw)]
-        result = await unit_test_http_client_async.send_rpc_request(_TestRpcRequest(), _TestRpcResult)
+        result = await unit_test_http_client_async.send_rpc_request(
+            _TestRpcRequest(), _TestRpcResult
+        )
     assert result == _TestRpcResult(value=42)
     assert post_mock.call_count == 2
 
@@ -245,9 +256,14 @@ async def test_async_http_provider_does_not_retry_http_status_error(
     with patch("httpx2.AsyncClient.post") as post_mock:
         post_mock.return_value = response
         with pytest.raises(SolanaRpcException) as exc_info:
-            await unit_test_http_client_async.send_rpc_request(_TestRpcRequest(), _TestRpcResult)
+            await unit_test_http_client_async.send_rpc_request(
+                _TestRpcRequest(), _TestRpcResult
+            )
     assert post_mock.call_count == 1
-    assert exc_info.value.error_msg == "<class 'httpx2.HTTPStatusError'> raised in \"_TestRpcRequest\" endpoint request"
+    assert (
+        exc_info.value.error_msg
+        == "<class 'httpx2.HTTPStatusError'> raised in \"_TestRpcRequest\" endpoint request"
+    )
 
 
 async def test_async_http_provider_can_disable_transport_retries():
@@ -268,14 +284,21 @@ async def test_send_rpc_request_success(unit_test_http_client_async):
     raw = '{"jsonrpc":"2.0","id":1,"result":{"value":42}}'
     with patch("httpx2.AsyncClient.post") as post_mock:
         post_mock.return_value = _mock_response(raw)
-        result = await unit_test_http_client_async.send_rpc_request(_TestRpcRequest(), _TestRpcResult)
+        result = await unit_test_http_client_async.send_rpc_request(
+            _TestRpcRequest(), _TestRpcResult
+        )
     assert result == _TestRpcResult(value=42)
-    assert post_mock.call_args.kwargs["content"] == '{"jsonrpc":"2.0","id":"1","method":"testMethod"}'
+    assert (
+        post_mock.call_args.kwargs["content"]
+        == '{"jsonrpc":"2.0","id":"1","method":"testMethod"}'
+    )
 
 
 async def test_send_rpc_request_requires_jsonrpc_request(unit_test_http_client_async):
     """Test send_rpc_request rejects loose serializers."""
-    with pytest.raises(TypeError, match="request must be an instance of JsonRpcRequest"):
+    with pytest.raises(
+        TypeError, match="request must be an instance of JsonRpcRequest"
+    ):
         await unit_test_http_client_async.send_rpc_request(_LooseRpcRequest(), _TestRpcResult)  # type: ignore[arg-type]
 
 
@@ -284,17 +307,23 @@ async def test_send_rpc_request_scalar_result(unit_test_http_client_async):
     raw = '{"jsonrpc":"2.0","id":1,"result":42}'
     with patch("httpx2.AsyncClient.post") as post_mock:
         post_mock.return_value = _mock_response(raw)
-        result = await unit_test_http_client_async.send_rpc_request(_TestRpcRequest(), _ScalarRpcResult)
+        result = await unit_test_http_client_async.send_rpc_request(
+            _TestRpcRequest(), _ScalarRpcResult
+        )
     assert result.root == 42
 
 
 async def test_send_rpc_request_jsonrpc_error(unit_test_http_client_async):
     """Test JSON-RPC error responses are raised before result parsing."""
-    raw = '{"jsonrpc":"2.0","id":"1","error":{"code":-32602,"message":"Invalid params"}}'
+    raw = (
+        '{"jsonrpc":"2.0","id":"1","error":{"code":-32602,"message":"Invalid params"}}'
+    )
     with patch("httpx2.AsyncClient.post") as post_mock:
         post_mock.return_value = _mock_response(raw)
         with pytest.raises(SolanaJsonRpcError) as exc_info:
-            await unit_test_http_client_async.send_rpc_request(_TestRpcRequest(), _TestRpcResult)
+            await unit_test_http_client_async.send_rpc_request(
+                _TestRpcRequest(), _TestRpcResult
+            )
     assert exc_info.value.code == -32602
     assert exc_info.value.message == "Invalid params"
     assert exc_info.value.data is None
@@ -341,7 +370,9 @@ async def test_send_rpc_request_malformed_envelope(unit_test_http_client_async):
     with patch("httpx2.AsyncClient.post") as post_mock:
         post_mock.return_value = _mock_response(raw)
         with pytest.raises(ValidationError):
-            await unit_test_http_client_async.send_rpc_request(_TestRpcRequest(), _TestRpcResult)
+            await unit_test_http_client_async.send_rpc_request(
+                _TestRpcRequest(), _TestRpcResult
+            )
 
 
 async def test_send_rpc_request_http_exception(unit_test_http_client_async):
@@ -349,8 +380,13 @@ async def test_send_rpc_request_http_exception(unit_test_http_client_async):
     with patch("httpx2.AsyncClient.post") as post_mock:
         post_mock.side_effect = ReadTimeout("placeholder")
         with pytest.raises(SolanaRpcException) as exc_info:
-            await unit_test_http_client_async.send_rpc_request(_TestRpcRequest(), _TestRpcResult)
-    assert exc_info.value.error_msg == "<class 'httpx2.ReadTimeout'> raised in \"_TestRpcRequest\" endpoint request"
+            await unit_test_http_client_async.send_rpc_request(
+                _TestRpcRequest(), _TestRpcResult
+            )
+    assert (
+        exc_info.value.error_msg
+        == "<class 'httpx2.ReadTimeout'> raised in \"_TestRpcRequest\" endpoint request"
+    )
 
 
 def test_client_address_sig_args_no_commitment(unit_test_http_client_async):

--- a/tests/unit/test_async_client.py
+++ b/tests/unit/test_async_client.py
@@ -79,17 +79,13 @@ class _ScalarRpcResult(RootModel[int]):
 class _CustomRpcError(SolanaJsonRpcError):
     """Test custom JSON-RPC error."""
 
-    def __init__(
-        self, code: int, message: str, request_id: str | int, method: str | None
-    ) -> None:
+    def __init__(self, code: int, message: str, request_id: str | int, method: str | None) -> None:
         """Initialize test custom JSON-RPC error."""
         super().__init__(code, message, request_id=request_id, method=method)
 
 
 def _mock_response(text: str) -> httpx2.Response:
-    return httpx2.Response(
-        200, text=text, request=httpx2.Request("POST", "http://localhost:8899")
-    )
+    return httpx2.Response(200, text=text, request=httpx2.Request("POST", "http://localhost:8899"))
 
 
 def test_jsonrpc_request_to_json_forwards_model_dump_json_kwargs():
@@ -108,9 +104,7 @@ def test_jsonrpc_request_to_json_forwards_model_dump_json_kwargs():
 
 
 def test_jsonrpc_request_params_are_untyped_by_default():
-    request = JsonRpcRequest.model_validate(
-        {"method": "testMethod", "params": {"value": 2}}
-    )
+    request = JsonRpcRequest.model_validate({"method": "testMethod", "params": {"value": 2}})
 
     assert request.params == {"value": 2}
     assert json.loads(request.to_json()) == {
@@ -224,10 +218,7 @@ async def test_async_client_http_exception(unit_test_http_client_async):
         with pytest.raises(SolanaRpcException) as exc_info:
             await unit_test_http_client_async.get_epoch_info()
         assert exc_info.type == SolanaRpcException
-        assert (
-            exc_info.value.error_msg
-            == "<class 'httpx2.ReadTimeout'> raised in \"GetEpochInfo\" endpoint request"
-        )
+        assert exc_info.value.error_msg == "<class 'httpx2.ReadTimeout'> raised in \"GetEpochInfo\" endpoint request"
 
 
 async def test_async_http_provider_retries_transport_error_once(
@@ -237,9 +228,7 @@ async def test_async_http_provider_retries_transport_error_once(
     raw = '{"jsonrpc":"2.0","id":1,"result":{"value":42}}'
     with patch("httpx2.AsyncClient.post") as post_mock:
         post_mock.side_effect = [ReadError("placeholder"), _mock_response(raw)]
-        result = await unit_test_http_client_async.send_rpc_request(
-            _TestRpcRequest(), _TestRpcResult
-        )
+        result = await unit_test_http_client_async.send_rpc_request(_TestRpcRequest(), _TestRpcResult)
     assert result == _TestRpcResult(value=42)
     assert post_mock.call_count == 2
 
@@ -256,14 +245,9 @@ async def test_async_http_provider_does_not_retry_http_status_error(
     with patch("httpx2.AsyncClient.post") as post_mock:
         post_mock.return_value = response
         with pytest.raises(SolanaRpcException) as exc_info:
-            await unit_test_http_client_async.send_rpc_request(
-                _TestRpcRequest(), _TestRpcResult
-            )
+            await unit_test_http_client_async.send_rpc_request(_TestRpcRequest(), _TestRpcResult)
     assert post_mock.call_count == 1
-    assert (
-        exc_info.value.error_msg
-        == "<class 'httpx2.HTTPStatusError'> raised in \"_TestRpcRequest\" endpoint request"
-    )
+    assert exc_info.value.error_msg == "<class 'httpx2.HTTPStatusError'> raised in \"_TestRpcRequest\" endpoint request"
 
 
 async def test_async_http_provider_can_disable_transport_retries():
@@ -284,21 +268,14 @@ async def test_send_rpc_request_success(unit_test_http_client_async):
     raw = '{"jsonrpc":"2.0","id":1,"result":{"value":42}}'
     with patch("httpx2.AsyncClient.post") as post_mock:
         post_mock.return_value = _mock_response(raw)
-        result = await unit_test_http_client_async.send_rpc_request(
-            _TestRpcRequest(), _TestRpcResult
-        )
+        result = await unit_test_http_client_async.send_rpc_request(_TestRpcRequest(), _TestRpcResult)
     assert result == _TestRpcResult(value=42)
-    assert (
-        post_mock.call_args.kwargs["content"]
-        == '{"jsonrpc":"2.0","id":"1","method":"testMethod"}'
-    )
+    assert post_mock.call_args.kwargs["content"] == '{"jsonrpc":"2.0","id":"1","method":"testMethod"}'
 
 
 async def test_send_rpc_request_requires_jsonrpc_request(unit_test_http_client_async):
     """Test send_rpc_request rejects loose serializers."""
-    with pytest.raises(
-        TypeError, match="request must be an instance of JsonRpcRequest"
-    ):
+    with pytest.raises(TypeError, match="request must be an instance of JsonRpcRequest"):
         await unit_test_http_client_async.send_rpc_request(_LooseRpcRequest(), _TestRpcResult)  # type: ignore[arg-type]
 
 
@@ -307,23 +284,17 @@ async def test_send_rpc_request_scalar_result(unit_test_http_client_async):
     raw = '{"jsonrpc":"2.0","id":1,"result":42}'
     with patch("httpx2.AsyncClient.post") as post_mock:
         post_mock.return_value = _mock_response(raw)
-        result = await unit_test_http_client_async.send_rpc_request(
-            _TestRpcRequest(), _ScalarRpcResult
-        )
+        result = await unit_test_http_client_async.send_rpc_request(_TestRpcRequest(), _ScalarRpcResult)
     assert result.root == 42
 
 
 async def test_send_rpc_request_jsonrpc_error(unit_test_http_client_async):
     """Test JSON-RPC error responses are raised before result parsing."""
-    raw = (
-        '{"jsonrpc":"2.0","id":"1","error":{"code":-32602,"message":"Invalid params"}}'
-    )
+    raw = '{"jsonrpc":"2.0","id":"1","error":{"code":-32602,"message":"Invalid params"}}'
     with patch("httpx2.AsyncClient.post") as post_mock:
         post_mock.return_value = _mock_response(raw)
         with pytest.raises(SolanaJsonRpcError) as exc_info:
-            await unit_test_http_client_async.send_rpc_request(
-                _TestRpcRequest(), _TestRpcResult
-            )
+            await unit_test_http_client_async.send_rpc_request(_TestRpcRequest(), _TestRpcResult)
     assert exc_info.value.code == -32602
     assert exc_info.value.message == "Invalid params"
     assert exc_info.value.data is None
@@ -370,9 +341,7 @@ async def test_send_rpc_request_malformed_envelope(unit_test_http_client_async):
     with patch("httpx2.AsyncClient.post") as post_mock:
         post_mock.return_value = _mock_response(raw)
         with pytest.raises(ValidationError):
-            await unit_test_http_client_async.send_rpc_request(
-                _TestRpcRequest(), _TestRpcResult
-            )
+            await unit_test_http_client_async.send_rpc_request(_TestRpcRequest(), _TestRpcResult)
 
 
 async def test_send_rpc_request_http_exception(unit_test_http_client_async):
@@ -380,13 +349,8 @@ async def test_send_rpc_request_http_exception(unit_test_http_client_async):
     with patch("httpx2.AsyncClient.post") as post_mock:
         post_mock.side_effect = ReadTimeout("placeholder")
         with pytest.raises(SolanaRpcException) as exc_info:
-            await unit_test_http_client_async.send_rpc_request(
-                _TestRpcRequest(), _TestRpcResult
-            )
-    assert (
-        exc_info.value.error_msg
-        == "<class 'httpx2.ReadTimeout'> raised in \"_TestRpcRequest\" endpoint request"
-    )
+            await unit_test_http_client_async.send_rpc_request(_TestRpcRequest(), _TestRpcResult)
+    assert exc_info.value.error_msg == "<class 'httpx2.ReadTimeout'> raised in \"_TestRpcRequest\" endpoint request"
 
 
 def test_client_address_sig_args_no_commitment(unit_test_http_client_async):


### PR DESCRIPTION
## Background

During recent test adjustments, there was an attempt to write `JsonRpcRequest` as `JsonRpcRequest[T]`.

Taking `GetBlockRequest` in [tmp/get_block.py](tmp/get_block.py) as an example (see [tmp/get_block.py](tmp/get_block.py#L52)), the request parameters are:

- `tuple[int]`
- or `tuple[int, GetBlockConfig]`

These parameters are clearly "heterogeneous positional params", not a list of a single element type.

## Conclusion

`JsonRpcRequest` should not have generic type parameters.

## Rationale

1. At the JSON-RPC specification level, `params` can be an array or an object, and array elements are allowed to be heterogeneous.

2. In the current implementation, `JsonRpcRequest.params` is defined as a wide type (`Any | None`), designed to carry any legitimate JSON-RPC parameter shape rather than being constrained to `list[T]`.

3. Making the base class generic (e.g., `JsonRpcRequest[T]`) would convey misleading semantics:
   - It would look like "params is a homogeneous container (list[T])";
   - But real-world scenarios commonly involve `tuple[int, Config]`, `dict[str, Any]`, `None`, and other polymorphic shapes;
   - It would force callers to do unnecessary wrapping, reducing API usability.

4. Type narrowing should be done in subclasses, not enforced at the base class:
   - The base class maintains the generality of the transport envelope (`jsonrpc/id/method/params`);
   - Specific method requests (such as `GetBlockRequest`) override the `params` field type in subclasses to achieve "per-method precise constraints".

## Recommended Pattern

Keep:

- `JsonRpcRequest` non-generic;
- Override the `params` type in concrete request subclasses.

Example:

```python
class GetBlockRequest(JsonRpcRequest):
    method: str = "getBlock"
    params: tuple[int] | tuple[int, GetBlockConfig] | None = None
```

This satisfies:

- The real parameter shapes of JSON-RPC;
- Strong type checking per RPC method;
- Stability and simplicity of the base class API.