### PR TITLE
Type JSON-RPC Results by Result Shape

### DIFF
--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Sequence
 from time import time
+from typing import Any, overload
 
+from pydantic import TypeAdapter
 from solders.message import MessageV0
 from solders.pubkey import Pubkey
 from solders.rpc.requests import GetRecentPrioritizationFees
@@ -148,20 +150,38 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         """Use this when you are done with the client."""
         await self._provider.close()
 
+    @overload
     async def send_rpc_request(
         self,
         request: JsonRpcRequest,
-        result_model: type[TResult],
+        result_type: type[TResult],
         *,
         error_parser: JsonRpcErrorParser | None = None,
-    ) -> TResult:
-        """Send a raw JSON-RPC request and parse the result with a Pydantic model."""
+    ) -> TResult: ...
+
+    @overload
+    async def send_rpc_request(
+        self,
+        request: JsonRpcRequest,
+        result_type: Any,
+        *,
+        error_parser: JsonRpcErrorParser | None = None,
+    ) -> Any: ...
+
+    async def send_rpc_request(
+        self,
+        request: JsonRpcRequest,
+        result_type: Any,
+        *,
+        error_parser: JsonRpcErrorParser | None = None,
+    ) -> Any:
+        """Send a raw JSON-RPC request and parse the result with the provided type."""
         if not isinstance(request, JsonRpcRequest):
             raise TypeError("request must be an instance of JsonRpcRequest")
         raw = await self._provider.make_request_unparsed(request)
         envelope = JsonRpcResponseEnvelope.model_validate_json(raw)
         result = envelope.unwrap_result(error_parser, method=getattr(request, "method", None))
-        return result_model.model_validate(result)
+        return TypeAdapter(result_type).validate_python(result)
 
     async def is_connected(self) -> bool:
         """Health check.

--- a/src/solana/rpc/jsonrpc.py
+++ b/src/solana/rpc/jsonrpc.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from enum import IntEnum
 from typing import Any, Literal, Protocol, TypeVar
 
-from pydantic import BaseModel, model_validator
+from pydantic import model_validator
 from pydantic.main import IncEx
 
 from solana._pydantic import PydanticModel
@@ -225,7 +225,7 @@ class JsonRpcResponseEnvelope(PydanticModel):
         return self.result
 
 
-TResult = TypeVar("TResult", bound=BaseModel)
+TResult = TypeVar("TResult")
 
 
 def _get_error_name(code: int) -> str | None:

--- a/tests/unit/test_async_client.py
+++ b/tests/unit/test_async_client.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from httpx2 import ReadError, ReadTimeout
 import httpx2
 import pytest
-from pydantic import BaseModel, RootModel, ValidationError
+from pydantic import BaseModel, ValidationError
 from solders.account_decoder import UiAccountEncoding, UiDataSliceConfig
 from solders.commitment_config import CommitmentLevel
 from solders.pubkey import Pubkey
@@ -70,10 +70,6 @@ class _TestRpcResult(PydanticModel):
     """Test JSON-RPC result."""
 
     value: int
-
-
-class _ScalarRpcResult(RootModel[int]):
-    """Test scalar JSON-RPC result."""
 
 
 class _CustomRpcError(SolanaJsonRpcError):
@@ -280,12 +276,30 @@ async def test_send_rpc_request_requires_jsonrpc_request(unit_test_http_client_a
 
 
 async def test_send_rpc_request_scalar_result(unit_test_http_client_async):
-    """Test sending a JSON-RPC request with a scalar result model."""
+    """Test sending a JSON-RPC request with a scalar result type."""
     raw = '{"jsonrpc":"2.0","id":1,"result":42}'
     with patch("httpx2.AsyncClient.post") as post_mock:
         post_mock.return_value = _mock_response(raw)
-        result = await unit_test_http_client_async.send_rpc_request(_TestRpcRequest(), _ScalarRpcResult)
-    assert result.root == 42
+        result = await unit_test_http_client_async.send_rpc_request(_TestRpcRequest(), int)
+    assert result == 42
+
+
+async def test_send_rpc_request_string_result(unit_test_http_client_async):
+    """Test sending a JSON-RPC request with a string result type."""
+    raw = '{"jsonrpc":"2.0","id":1,"result":"testLeader"}'
+    with patch("httpx2.AsyncClient.post") as post_mock:
+        post_mock.return_value = _mock_response(raw)
+        result = await unit_test_http_client_async.send_rpc_request(_TestRpcRequest(), str)
+    assert result == "testLeader"
+
+
+async def test_send_rpc_request_object_result(unit_test_http_client_async):
+    """Test sending a JSON-RPC request with an object result type."""
+    raw = '{"jsonrpc":"2.0","id":1,"result":{"value":42}}'
+    with patch("httpx2.AsyncClient.post") as post_mock:
+        post_mock.return_value = _mock_response(raw)
+        result = await unit_test_http_client_async.send_rpc_request(_TestRpcRequest(), dict[str, int])
+    assert result == {"value": 42}
 
 
 async def test_send_rpc_request_jsonrpc_error(unit_test_http_client_async):


### PR DESCRIPTION
## What Changed

Refactor `send_rpc_request` so callers pass a `result_type` instead of a Pydantic-only `result_model`.

The response `result` is now validated with `pydantic.TypeAdapter`, which allows the same API to parse:

- Pydantic models for object results
- `RootModel[...]` when a wrapper is still useful
- primitive JSON values like `str`, `int`, and `bool`
- containers and unions like `dict[str, Any]`, `list[T]`, or `dict[str, Any] | None`

## Why

JSON-RPC does not require `result` to be an object. Solana RPC methods return many different shapes: some return objects, while others return scalars such as slot numbers, validator identities, signatures, or booleans.

The previous `result_model: type[TResult]` design implied that every result had to be represented as a `BaseModel`. That worked for object responses, but scalar responses needed artificial `RootModel[str]` or `RootModel[int]` wrappers just to satisfy the helper API.

Using `TypeAdapter` moves the type boundary to the actual response shape instead of forcing every response through a model class. This keeps object parsing fully supported while making scalar and container results natural:

```python
leader = await client.send_rpc_request(request, str)
slot = await client.send_rpc_request(request, int)
block = await client.send_rpc_request(request, dict[str, Any] | None)
```

## Design Note

The overloads are intentional type gymnastics: simple class types like `str`, `int`, or a Pydantic model can infer a precise return type, while complex runtime type expressions still flow through `TypeAdapter` as `Any` when static typing cannot express them cleanly.

This keeps the runtime behavior broad enough for JSON-RPC while preserving useful static typing for the common cases.