### PR TITLE
Added the missing `params` to `get_block`.

### DIFF
--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -66,6 +66,7 @@ from solders.rpc.responses import (
 )
 from solders.signature import Signature
 from solders.transaction import VersionedTransaction
+from solders.transaction_status import TransactionDetails
 
 from solana.rpc.models import (
     DataSliceOpts as DataSliceOptsModel,
@@ -326,6 +327,9 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         slot: int,
         encoding: str = "json",
         max_supported_transaction_version: int | None = None,
+        transaction_details: TransactionDetails | None = None,
+        rewards: bool | None = None,
+        commitment: Commitment | None = None,
     ) -> GetBlockResp:
         """Returns identity and transaction information about a confirmed block in the ledger.
 
@@ -335,6 +339,9 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
                     "base58" (slow), or "base64". If parameter not provided, the default encoding is JSON.
             max_supported_transaction_version: (optional) The max transaction version to return in
                 responses. If the requested transaction is a higher version, an error will be returned
+            transaction_details: (optional) Level of transaction detail to return.
+            rewards: (optional) Whether to populate the rewards array.
+            commitment: Bank state to query. It can be either "finalized", "confirmed" or "processed".
 
         Example:
             >>> solana_client = AsyncClient("http://localhost:8899")
@@ -343,7 +350,14 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
                 EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG,
             )
         """
-        body = self._get_block_body(slot, encoding, max_supported_transaction_version)
+        body = self._get_block_body(
+            slot,
+            encoding,
+            max_supported_transaction_version,
+            transaction_details,
+            rewards,
+            commitment,
+        )
         return await self._provider.make_request(body, GetBlockResp)
 
     async def get_recent_performance_samples(self, limit: int | None = None) -> GetRecentPerformanceSamplesResp:

--- a/src/solana/rpc/async_api.py
+++ b/src/solana/rpc/async_api.py
@@ -906,18 +906,23 @@ class AsyncClient(_ClientCore):  # pylint: disable=too-many-public-methods
         body = self._get_slot_leaders_body(start, limit)
         return await self._provider.make_request(body, GetSlotLeadersResp)
 
-    async def get_supply(self, commitment: Commitment | None = None) -> GetSupplyResp:
+    async def get_supply(
+        self,
+        commitment: Commitment | None = None,
+        exclude_non_circulating_accounts_list: bool = False,
+    ) -> GetSupplyResp:
         """Returns information about the current supply.
 
         Args:
             commitment: Bank state to query. It can be either "finalized", "confirmed" or "processed".
+            exclude_non_circulating_accounts_list: If True, exclude non-circulating accounts from supply.
 
         Example:
             >>> solana_client = AsyncClient("http://localhost:8899")
             >>> (await solana_client.get_supply()).value.circulating # doctest: +SKIP
             683635192454157660
         """
-        body = self._get_supply_body(commitment)
+        body = self._get_supply_body(commitment, exclude_non_circulating_accounts_list)
         return await self._provider.make_request(body, GetSupplyResp)
 
     async def get_token_account_balance(

--- a/src/solana/rpc/core.py
+++ b/src/solana/rpc/core.py
@@ -393,12 +393,16 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
         commitment_to_use = _COMMITMENT_TO_SOLDERS[commitment or self._commitment]
         return GetInflationReward(pubkeys, RpcEpochConfig(epoch, commitment_to_use))
 
-    def _get_supply_body(self, commitment: Optional[Commitment]) -> GetSupply:
+    def _get_supply_body(
+        self,
+        commitment: Optional[Commitment],
+        exclude_non_circulating_accounts_list: bool = False,
+    ) -> GetSupply:
         commitment_to_use = _COMMITMENT_TO_SOLDERS[commitment or self._commitment]
         return GetSupply(
             RpcSupplyConfig(
                 commitment=commitment_to_use,
-                exclude_non_circulating_accounts_list=False,
+                exclude_non_circulating_accounts_list=exclude_non_circulating_accounts_list,
             )
         )
 

--- a/src/solana/rpc/core.py
+++ b/src/solana/rpc/core.py
@@ -84,7 +84,7 @@ from solders.rpc.requests import (
 from solders.rpc.responses import GetLatestBlockhashResp, SendTransactionResp
 from solders.signature import Signature
 from solders.transaction import VersionedTransaction
-from solders.transaction_status import UiTransactionEncoding
+from solders.transaction_status import TransactionDetails, UiTransactionEncoding
 
 from solana.rpc.models import (
     DataSliceOpts,
@@ -201,11 +201,22 @@ class _ClientCore:  # pylint: disable=too-few-public-methods
     def _get_block_time_body(slot: int) -> GetBlockTime:
         return GetBlockTime(slot)
 
-    @staticmethod
-    def _get_block_body(slot: int, encoding: str, max_supported_transaction_version: Optional[int]) -> GetBlock:
+    def _get_block_body(
+        self,
+        slot: int,
+        encoding: str,
+        max_supported_transaction_version: Optional[int],
+        transaction_details: Optional[TransactionDetails],
+        rewards: Optional[bool],
+        commitment: Optional[Commitment],
+    ) -> GetBlock:
         encoding_to_use = _TX_ENCODING_TO_SOLDERS[encoding]
+        commitment_to_use = _COMMITMENT_TO_SOLDERS[commitment or self._commitment]
         config = RpcBlockConfig(
             encoding=encoding_to_use,
+            transaction_details=transaction_details,
+            rewards=rewards,
+            commitment=commitment_to_use,
             max_supported_transaction_version=max_supported_transaction_version,
         )
         return GetBlock(slot=slot, config=config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,16 +37,10 @@ def solana_test_validator(worker_id: str) -> Generator[ValidatorConfig, None, No
     validator as-is.
     """
     if os.environ.get("SOLANA_VALIDATOR_EXTERNAL") == "1":
-        rpc_url = os.environ.get(
-            "SOLANA_VALIDATOR_EXTERNAL_RPC_URL", "http://127.0.0.1:8899"
-        )
-        ws_url = os.environ.get(
-            "SOLANA_VALIDATOR_EXTERNAL_WS_URL", "ws://127.0.0.1:8900"
-        )
+        rpc_url = os.environ.get("SOLANA_VALIDATOR_EXTERNAL_RPC_URL", "http://127.0.0.1:8899")
+        ws_url = os.environ.get("SOLANA_VALIDATOR_EXTERNAL_WS_URL", "ws://127.0.0.1:8900")
         if not validator_is_healthy(rpc_url):
-            pytest.skip(
-                f"SOLANA_VALIDATOR_EXTERNAL=1 but no validator is reachable on {rpc_url}"
-            )
+            pytest.skip(f"SOLANA_VALIDATOR_EXTERNAL=1 but no validator is reachable on {rpc_url}")
         yield ValidatorConfig(
             rpc_url=rpc_url,
             ws_url=ws_url,
@@ -57,9 +51,7 @@ def solana_test_validator(worker_id: str) -> Generator[ValidatorConfig, None, No
         return
 
     if not shutil.which("solana-test-validator"):
-        pytest.skip(
-            "solana-test-validator not found in PATH; skipping integration tests"
-        )
+        pytest.skip("solana-test-validator not found in PATH; skipping integration tests")
         return
     config = acquire_shared_validator(worker_id)
     try:
@@ -93,9 +85,7 @@ async def test_http_client_async(
     validator_rpc_url: str,
 ) -> AsyncGenerator[AsyncClient, None]:
     """Async HTTP client pointed at the local test validator."""
-    http_client = AsyncClient(
-        endpoint=validator_rpc_url, commitment=Commitment.PROCESSED
-    )
+    http_client = AsyncClient(endpoint=validator_rpc_url, commitment=Commitment.PROCESSED)
     timeout_secs = env_int("SOLANA_TEST_BLOCK_READY_TIMEOUT", 120)
     deadline = time.time() + timeout_secs
     last_error: Exception | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import pytest
 from solders.keypair import Keypair
 
 from solana.rpc.async_api import AsyncClient
-from solana.rpc.commitment import Processed
+from solana.rpc.commitment import Commitment
 from tests.validator_runtime import (
     ValidatorConfig,
     acquire_shared_validator,
@@ -37,10 +37,16 @@ def solana_test_validator(worker_id: str) -> Generator[ValidatorConfig, None, No
     validator as-is.
     """
     if os.environ.get("SOLANA_VALIDATOR_EXTERNAL") == "1":
-        rpc_url = os.environ.get("SOLANA_VALIDATOR_EXTERNAL_RPC_URL", "http://127.0.0.1:8899")
-        ws_url = os.environ.get("SOLANA_VALIDATOR_EXTERNAL_WS_URL", "ws://127.0.0.1:8900")
+        rpc_url = os.environ.get(
+            "SOLANA_VALIDATOR_EXTERNAL_RPC_URL", "http://127.0.0.1:8899"
+        )
+        ws_url = os.environ.get(
+            "SOLANA_VALIDATOR_EXTERNAL_WS_URL", "ws://127.0.0.1:8900"
+        )
         if not validator_is_healthy(rpc_url):
-            pytest.skip(f"SOLANA_VALIDATOR_EXTERNAL=1 but no validator is reachable on {rpc_url}")
+            pytest.skip(
+                f"SOLANA_VALIDATOR_EXTERNAL=1 but no validator is reachable on {rpc_url}"
+            )
         yield ValidatorConfig(
             rpc_url=rpc_url,
             ws_url=ws_url,
@@ -51,7 +57,9 @@ def solana_test_validator(worker_id: str) -> Generator[ValidatorConfig, None, No
         return
 
     if not shutil.which("solana-test-validator"):
-        pytest.skip("solana-test-validator not found in PATH; skipping integration tests")
+        pytest.skip(
+            "solana-test-validator not found in PATH; skipping integration tests"
+        )
         return
     config = acquire_shared_validator(worker_id)
     try:
@@ -75,7 +83,7 @@ def validator_ws_url(solana_test_validator: ValidatorConfig) -> str:
 @pytest.fixture(scope="session")
 def unit_test_http_client_async() -> AsyncClient:
     """Async client to be used in unit tests."""
-    client = AsyncClient(commitment=Processed)
+    client = AsyncClient(commitment=Commitment.PROCESSED)
     return client
 
 
@@ -85,13 +93,15 @@ async def test_http_client_async(
     validator_rpc_url: str,
 ) -> AsyncGenerator[AsyncClient, None]:
     """Async HTTP client pointed at the local test validator."""
-    http_client = AsyncClient(endpoint=validator_rpc_url, commitment=Processed)
+    http_client = AsyncClient(
+        endpoint=validator_rpc_url, commitment=Commitment.PROCESSED
+    )
     timeout_secs = env_int("SOLANA_TEST_BLOCK_READY_TIMEOUT", 120)
     deadline = time.time() + timeout_secs
     last_error: Exception | None = None
     while time.time() < deadline:
         try:
-            await http_client.get_block(5)
+            await http_client.get_block(5, commitment=Commitment.CONFIRMED)
             break
         except Exception as exc:  # noqa: BLE001
             last_error = exc

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -23,9 +23,7 @@ from solana.rpc.models import DataSliceOpts, TxOpts
 from ..utils import AIRDROP_AMOUNT, assert_valid_response
 
 
-async def _ensure_minimum_balance(
-    client: AsyncClient, pubkey: Pubkey, minimum_balance: int
-) -> int:
+async def _ensure_minimum_balance(client: AsyncClient, pubkey: Pubkey, minimum_balance: int) -> int:
     """Top up an account when needed and return its current balance."""
     balance_resp = await client.get_balance(pubkey)
     assert_valid_response(balance_resp)
@@ -104,12 +102,8 @@ async def test_send_transaction_and_get_balance(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, sender.pubkey(), amount + 50_000
-    )
-    receiver_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, receiver, 1
-    )
+    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
+    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
     ixs = [
         sp.transfer(
             sp.TransferParams(
@@ -153,9 +147,7 @@ async def test_send_versioned_transaction_and_get_balance(
     sender_balance_before = await _ensure_minimum_balance(
         test_http_client_async, random_funded_keypair.pubkey(), amount + 50_000
     )
-    receiver_balance_before = await test_http_client_async.get_balance(
-        receiver.pubkey()
-    )
+    receiver_balance_before = await test_http_client_async.get_balance(receiver.pubkey())
     assert_valid_response(receiver_balance_before)
     transfer_ix = sp.transfer(
         sp.TransferParams(
@@ -164,9 +156,7 @@ async def test_send_versioned_transaction_and_get_balance(
             lamports=amount,
         )
     )
-    recent_blockhash = (
-        await test_http_client_async.get_latest_blockhash()
-    ).value.blockhash
+    recent_blockhash = (await test_http_client_async.get_latest_blockhash()).value.blockhash
     msg = MessageV0.try_compile(
         payer=random_funded_keypair.pubkey(),
         instructions=[transfer_ix],
@@ -184,9 +174,7 @@ async def test_send_versioned_transaction_and_get_balance(
     # Confirm transaction
     await test_http_client_async.confirm_transaction(resp.value)
     # Check balances
-    sender_balance_resp = await test_http_client_async.get_balance(
-        random_funded_keypair.pubkey()
-    )
+    sender_balance_resp = await test_http_client_async.get_balance(random_funded_keypair.pubkey())
     assert_valid_response(sender_balance_resp)
     assert sender_balance_resp.value == sender_balance_before - amount - fee_resp.value
     receiver_balance_resp = await test_http_client_async.get_balance(receiver.pubkey())
@@ -195,15 +183,11 @@ async def test_send_versioned_transaction_and_get_balance(
 
 
 @pytest.mark.integration
-async def test_send_bad_transaction(
-    stubbed_receiver: Pubkey, test_http_client_async: AsyncClient
-):
+async def test_send_bad_transaction(stubbed_receiver: Pubkey, test_http_client_async: AsyncClient):
     """Test sending a transaction that errors."""
     poor_account = Keypair()
     airdrop_amount = 1000000
-    airdrop_resp = await test_http_client_async.request_airdrop(
-        poor_account.pubkey(), airdrop_amount
-    )
+    airdrop_resp = await test_http_client_async.request_airdrop(poor_account.pubkey(), airdrop_amount)
     assert_valid_response(airdrop_resp)
     await test_http_client_async.confirm_transaction(airdrop_resp.value)
     balance = await test_http_client_async.get_balance(poor_account.pubkey())
@@ -242,12 +226,8 @@ async def test_send_transaction_prefetched_blockhash(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, sender.pubkey(), amount + 50_000
-    )
-    receiver_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, receiver, 1
-    )
+    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
+    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
     blockhash = (await test_http_client_async.get_latest_blockhash()).value.blockhash
     ixs = [
         sp.transfer(
@@ -290,12 +270,8 @@ async def test_send_raw_transaction_and_get_balance(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, sender.pubkey(), amount + 50_000
-    )
-    receiver_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, receiver, 1
-    )
+    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
+    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
     resp = await test_http_client_async.get_latest_blockhash(Finalized)
     assert_valid_response(resp)
     recent_blockhash = resp.value.blockhash
@@ -344,12 +320,8 @@ async def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, sender.pubkey(), amount + 50_000
-    )
-    receiver_balance_before = await _ensure_minimum_balance(
-        test_http_client_async, receiver, 1
-    )
+    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
+    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
     resp = await test_http_client_async.get_latest_blockhash(Finalized)
     assert_valid_response(resp)
     recent_blockhash = resp.value.blockhash
@@ -386,9 +358,7 @@ async def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
     )
     assert_valid_response(resp)
     # Confirm transaction
-    resp = await test_http_client_async.confirm_transaction(
-        resp.value, last_valid_block_height=last_valid_block_height
-    )
+    resp = await test_http_client_async.confirm_transaction(resp.value, last_valid_block_height=last_valid_block_height)
     # Check balances
     resp = await test_http_client_async.get_balance(sender.pubkey())
     assert_valid_response(resp)
@@ -399,9 +369,7 @@ async def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
 
 
 @pytest.mark.integration
-async def test_confirm_expired_transaction(
-    stubbed_sender, stubbed_receiver, test_http_client_async: AsyncClient
-):
+async def test_confirm_expired_transaction(stubbed_sender, stubbed_receiver, test_http_client_async: AsyncClient):
     """Test that RPCException is raised when trying to confirm a transaction that exceeded last valid block height."""
     # Get a recent blockhash
     resp = await test_http_client_async.get_latest_blockhash()
@@ -441,9 +409,7 @@ async def test_confirm_expired_transaction(
 
 
 @pytest.mark.integration
-async def test_get_fee_for_transaction_message(
-    stubbed_sender, stubbed_receiver, test_http_client_async: AsyncClient
-):
+async def test_get_fee_for_transaction_message(stubbed_sender, stubbed_receiver, test_http_client_async: AsyncClient):
     """Test that gets a fee for a transaction using get fee for message."""
     # Get latest blockhash
     resp = await test_http_client_async.get_latest_blockhash()
@@ -547,9 +513,7 @@ async def test_get_blocks(test_http_client_async: AsyncClient):
 @pytest.mark.integration
 async def test_get_signatures_for_address(test_http_client_async: AsyncClient):
     """Test get signatures for addresses."""
-    resp = await test_http_client_async.get_signatures_for_address(
-        VOTE_PROGRAM_ID, limit=1, commitment=Confirmed
-    )
+    resp = await test_http_client_async.get_signatures_for_address(VOTE_PROGRAM_ID, limit=1, commitment=Confirmed)
     assert_valid_response(resp)
 
 
@@ -619,17 +583,11 @@ async def test_get_inflation_rate(test_http_client_async: AsyncClient):
 
 
 # XXX: Block not available for slot on local cluster
-@pytest.mark.skip(
-    reason="Local test validator does not provide stable reward history for getInflationReward."
-)
+@pytest.mark.skip(reason="Local test validator does not provide stable reward history for getInflationReward.")
 @pytest.mark.integration
-async def test_get_inflation_reward(
-    stubbed_sender, test_http_client_async: AsyncClient
-):
+async def test_get_inflation_reward(stubbed_sender, test_http_client_async: AsyncClient):
     """Test get inflation reward."""
-    resp = await test_http_client_async.get_inflation_reward(
-        [stubbed_sender.pubkey()], commitment=Confirmed
-    )
+    resp = await test_http_client_async.get_inflation_reward([stubbed_sender.pubkey()], commitment=Confirmed)
     assert_valid_response(resp)
 
 
@@ -714,23 +672,17 @@ async def test_send_rpc_request_get_version(test_http_client_async: AsyncClient)
         feature_set: int = Field(alias="feature-set")
         solana_core: str = Field(alias="solana-core")
 
-    resp = await test_http_client_async.send_rpc_request(
-        GetVersionRequest(), GetVersionResult
-    )
+    resp = await test_http_client_async.send_rpc_request(GetVersionRequest(), GetVersionResult)
     assert resp.feature_set >= 0
     assert resp.solana_core
 
 
 @pytest.mark.integration
-async def test_get_account_info(
-    async_stubbed_sender, test_http_client_async: AsyncClient
-):
+async def test_get_account_info(async_stubbed_sender, test_http_client_async: AsyncClient):
     """Test get_account_info."""
     resp = await test_http_client_async.get_account_info(async_stubbed_sender.pubkey())
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_account_info(
-        async_stubbed_sender.pubkey(), encoding="jsonParsed"
-    )
+    resp = await test_http_client_async.get_account_info(async_stubbed_sender.pubkey(), encoding="jsonParsed")
     assert_valid_response(resp)
     resp = await test_http_client_async.get_account_info(
         async_stubbed_sender.pubkey(), data_slice=DataSliceOpts(offset=1, length=1)
@@ -739,20 +691,14 @@ async def test_get_account_info(
 
 
 @pytest.mark.integration
-async def test_get_multiple_accounts(
-    async_stubbed_sender, test_http_client_async: AsyncClient
-):
+async def test_get_multiple_accounts(async_stubbed_sender, test_http_client_async: AsyncClient):
     """Test get_multiple_accounts."""
     pubkeys = [async_stubbed_sender.pubkey()] * 2
     resp = await test_http_client_async.get_multiple_accounts(pubkeys)
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_multiple_accounts(
-        pubkeys, encoding="jsonParsed"
-    )
+    resp = await test_http_client_async.get_multiple_accounts(pubkeys, encoding="jsonParsed")
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_multiple_accounts(
-        pubkeys, data_slice=DataSliceOpts(offset=1, length=1)
-    )
+    resp = await test_http_client_async.get_multiple_accounts(pubkeys, data_slice=DataSliceOpts(offset=1, length=1))
     assert_valid_response(resp)
 
 
@@ -782,13 +728,9 @@ async def test_rate_limiter_throttles_requests(validator_rpc_url: str):
     n_requests = 500
     time_period = 1.0  # seconds (matches AsyncLimiter default)
 
-    async with AsyncClient(
-        endpoint=validator_rpc_url, commitment=Processed, rate_limit=rate_limit
-    ) as client:
+    async with AsyncClient(endpoint=validator_rpc_url, commitment=Processed, rate_limit=rate_limit) as client:
         start = monotonic()
-        responses = await asyncio.gather(
-            *[client.get_slot() for _ in range(n_requests)]
-        )
+        responses = await asyncio.gather(*[client.get_slot() for _ in range(n_requests)])
         elapsed = monotonic() - start
 
     for resp in responses:

--- a/tests/integration/test_async_http_client.py
+++ b/tests/integration/test_async_http_client.py
@@ -15,7 +15,7 @@ from spl.token.constants import WRAPPED_SOL_MINT
 
 from solana.constants import VOTE_PROGRAM_ID
 from solana.rpc.async_api import AsyncClient
-from solana.rpc.commitment import Confirmed, Finalized, Processed
+from solana.rpc.commitment import Commitment, Confirmed, Finalized, Processed
 from solana.rpc.core import RPCException, TransactionExpiredBlockheightExceededError
 from solana.rpc.jsonrpc import JsonRpcRequest
 from solana.rpc.models import DataSliceOpts, TxOpts
@@ -23,7 +23,9 @@ from solana.rpc.models import DataSliceOpts, TxOpts
 from ..utils import AIRDROP_AMOUNT, assert_valid_response
 
 
-async def _ensure_minimum_balance(client: AsyncClient, pubkey: Pubkey, minimum_balance: int) -> int:
+async def _ensure_minimum_balance(
+    client: AsyncClient, pubkey: Pubkey, minimum_balance: int
+) -> int:
     """Top up an account when needed and return its current balance."""
     balance_resp = await client.get_balance(pubkey)
     assert_valid_response(balance_resp)
@@ -102,8 +104,12 @@ async def test_send_transaction_and_get_balance(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
-    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
+    sender_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, sender.pubkey(), amount + 50_000
+    )
+    receiver_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, receiver, 1
+    )
     ixs = [
         sp.transfer(
             sp.TransferParams(
@@ -147,7 +153,9 @@ async def test_send_versioned_transaction_and_get_balance(
     sender_balance_before = await _ensure_minimum_balance(
         test_http_client_async, random_funded_keypair.pubkey(), amount + 50_000
     )
-    receiver_balance_before = await test_http_client_async.get_balance(receiver.pubkey())
+    receiver_balance_before = await test_http_client_async.get_balance(
+        receiver.pubkey()
+    )
     assert_valid_response(receiver_balance_before)
     transfer_ix = sp.transfer(
         sp.TransferParams(
@@ -156,7 +164,9 @@ async def test_send_versioned_transaction_and_get_balance(
             lamports=amount,
         )
     )
-    recent_blockhash = (await test_http_client_async.get_latest_blockhash()).value.blockhash
+    recent_blockhash = (
+        await test_http_client_async.get_latest_blockhash()
+    ).value.blockhash
     msg = MessageV0.try_compile(
         payer=random_funded_keypair.pubkey(),
         instructions=[transfer_ix],
@@ -174,7 +184,9 @@ async def test_send_versioned_transaction_and_get_balance(
     # Confirm transaction
     await test_http_client_async.confirm_transaction(resp.value)
     # Check balances
-    sender_balance_resp = await test_http_client_async.get_balance(random_funded_keypair.pubkey())
+    sender_balance_resp = await test_http_client_async.get_balance(
+        random_funded_keypair.pubkey()
+    )
     assert_valid_response(sender_balance_resp)
     assert sender_balance_resp.value == sender_balance_before - amount - fee_resp.value
     receiver_balance_resp = await test_http_client_async.get_balance(receiver.pubkey())
@@ -183,11 +195,15 @@ async def test_send_versioned_transaction_and_get_balance(
 
 
 @pytest.mark.integration
-async def test_send_bad_transaction(stubbed_receiver: Pubkey, test_http_client_async: AsyncClient):
+async def test_send_bad_transaction(
+    stubbed_receiver: Pubkey, test_http_client_async: AsyncClient
+):
     """Test sending a transaction that errors."""
     poor_account = Keypair()
     airdrop_amount = 1000000
-    airdrop_resp = await test_http_client_async.request_airdrop(poor_account.pubkey(), airdrop_amount)
+    airdrop_resp = await test_http_client_async.request_airdrop(
+        poor_account.pubkey(), airdrop_amount
+    )
     assert_valid_response(airdrop_resp)
     await test_http_client_async.confirm_transaction(airdrop_resp.value)
     balance = await test_http_client_async.get_balance(poor_account.pubkey())
@@ -226,8 +242,12 @@ async def test_send_transaction_prefetched_blockhash(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
-    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
+    sender_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, sender.pubkey(), amount + 50_000
+    )
+    receiver_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, receiver, 1
+    )
     blockhash = (await test_http_client_async.get_latest_blockhash()).value.blockhash
     ixs = [
         sp.transfer(
@@ -270,8 +290,12 @@ async def test_send_raw_transaction_and_get_balance(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
-    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
+    sender_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, sender.pubkey(), amount + 50_000
+    )
+    receiver_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, receiver, 1
+    )
     resp = await test_http_client_async.get_latest_blockhash(Finalized)
     assert_valid_response(resp)
     recent_blockhash = resp.value.blockhash
@@ -320,8 +344,12 @@ async def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
     sender = Keypair()
     receiver = Keypair().pubkey()
     amount = 1000
-    sender_balance_before = await _ensure_minimum_balance(test_http_client_async, sender.pubkey(), amount + 50_000)
-    receiver_balance_before = await _ensure_minimum_balance(test_http_client_async, receiver, 1)
+    sender_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, sender.pubkey(), amount + 50_000
+    )
+    receiver_balance_before = await _ensure_minimum_balance(
+        test_http_client_async, receiver, 1
+    )
     resp = await test_http_client_async.get_latest_blockhash(Finalized)
     assert_valid_response(resp)
     recent_blockhash = resp.value.blockhash
@@ -358,7 +386,9 @@ async def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
     )
     assert_valid_response(resp)
     # Confirm transaction
-    resp = await test_http_client_async.confirm_transaction(resp.value, last_valid_block_height=last_valid_block_height)
+    resp = await test_http_client_async.confirm_transaction(
+        resp.value, last_valid_block_height=last_valid_block_height
+    )
     # Check balances
     resp = await test_http_client_async.get_balance(sender.pubkey())
     assert_valid_response(resp)
@@ -369,7 +399,9 @@ async def test_send_raw_transaction_and_get_balance_using_latest_blockheight(
 
 
 @pytest.mark.integration
-async def test_confirm_expired_transaction(stubbed_sender, stubbed_receiver, test_http_client_async: AsyncClient):
+async def test_confirm_expired_transaction(
+    stubbed_sender, stubbed_receiver, test_http_client_async: AsyncClient
+):
     """Test that RPCException is raised when trying to confirm a transaction that exceeded last valid block height."""
     # Get a recent blockhash
     resp = await test_http_client_async.get_latest_blockhash()
@@ -409,7 +441,9 @@ async def test_confirm_expired_transaction(stubbed_sender, stubbed_receiver, tes
 
 
 @pytest.mark.integration
-async def test_get_fee_for_transaction_message(stubbed_sender, stubbed_receiver, test_http_client_async: AsyncClient):
+async def test_get_fee_for_transaction_message(
+    stubbed_sender, stubbed_receiver, test_http_client_async: AsyncClient
+):
     """Test that gets a fee for a transaction using get fee for message."""
     # Get latest blockhash
     resp = await test_http_client_async.get_latest_blockhash()
@@ -492,7 +526,7 @@ async def test_get_cluster_nodes(test_http_client_async: AsyncClient):
 @pytest.mark.integration
 async def test_get_block(test_http_client_async: AsyncClient):
     """Test get confirmed block."""
-    resp = await test_http_client_async.get_block(2)
+    resp = await test_http_client_async.get_block(2, commitment=Commitment.CONFIRMED)
     assert_valid_response(resp)
 
 
@@ -513,7 +547,9 @@ async def test_get_blocks(test_http_client_async: AsyncClient):
 @pytest.mark.integration
 async def test_get_signatures_for_address(test_http_client_async: AsyncClient):
     """Test get signatures for addresses."""
-    resp = await test_http_client_async.get_signatures_for_address(VOTE_PROGRAM_ID, limit=1, commitment=Confirmed)
+    resp = await test_http_client_async.get_signatures_for_address(
+        VOTE_PROGRAM_ID, limit=1, commitment=Confirmed
+    )
     assert_valid_response(resp)
 
 
@@ -583,11 +619,17 @@ async def test_get_inflation_rate(test_http_client_async: AsyncClient):
 
 
 # XXX: Block not available for slot on local cluster
-@pytest.mark.skip(reason="Local test validator does not provide stable reward history for getInflationReward.")
+@pytest.mark.skip(
+    reason="Local test validator does not provide stable reward history for getInflationReward."
+)
 @pytest.mark.integration
-async def test_get_inflation_reward(stubbed_sender, test_http_client_async: AsyncClient):
+async def test_get_inflation_reward(
+    stubbed_sender, test_http_client_async: AsyncClient
+):
     """Test get inflation reward."""
-    resp = await test_http_client_async.get_inflation_reward([stubbed_sender.pubkey()], commitment=Confirmed)
+    resp = await test_http_client_async.get_inflation_reward(
+        [stubbed_sender.pubkey()], commitment=Confirmed
+    )
     assert_valid_response(resp)
 
 
@@ -672,17 +714,23 @@ async def test_send_rpc_request_get_version(test_http_client_async: AsyncClient)
         feature_set: int = Field(alias="feature-set")
         solana_core: str = Field(alias="solana-core")
 
-    resp = await test_http_client_async.send_rpc_request(GetVersionRequest(), GetVersionResult)
+    resp = await test_http_client_async.send_rpc_request(
+        GetVersionRequest(), GetVersionResult
+    )
     assert resp.feature_set >= 0
     assert resp.solana_core
 
 
 @pytest.mark.integration
-async def test_get_account_info(async_stubbed_sender, test_http_client_async: AsyncClient):
+async def test_get_account_info(
+    async_stubbed_sender, test_http_client_async: AsyncClient
+):
     """Test get_account_info."""
     resp = await test_http_client_async.get_account_info(async_stubbed_sender.pubkey())
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_account_info(async_stubbed_sender.pubkey(), encoding="jsonParsed")
+    resp = await test_http_client_async.get_account_info(
+        async_stubbed_sender.pubkey(), encoding="jsonParsed"
+    )
     assert_valid_response(resp)
     resp = await test_http_client_async.get_account_info(
         async_stubbed_sender.pubkey(), data_slice=DataSliceOpts(offset=1, length=1)
@@ -691,14 +739,20 @@ async def test_get_account_info(async_stubbed_sender, test_http_client_async: As
 
 
 @pytest.mark.integration
-async def test_get_multiple_accounts(async_stubbed_sender, test_http_client_async: AsyncClient):
+async def test_get_multiple_accounts(
+    async_stubbed_sender, test_http_client_async: AsyncClient
+):
     """Test get_multiple_accounts."""
     pubkeys = [async_stubbed_sender.pubkey()] * 2
     resp = await test_http_client_async.get_multiple_accounts(pubkeys)
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_multiple_accounts(pubkeys, encoding="jsonParsed")
+    resp = await test_http_client_async.get_multiple_accounts(
+        pubkeys, encoding="jsonParsed"
+    )
     assert_valid_response(resp)
-    resp = await test_http_client_async.get_multiple_accounts(pubkeys, data_slice=DataSliceOpts(offset=1, length=1))
+    resp = await test_http_client_async.get_multiple_accounts(
+        pubkeys, data_slice=DataSliceOpts(offset=1, length=1)
+    )
     assert_valid_response(resp)
 
 
@@ -728,9 +782,13 @@ async def test_rate_limiter_throttles_requests(validator_rpc_url: str):
     n_requests = 500
     time_period = 1.0  # seconds (matches AsyncLimiter default)
 
-    async with AsyncClient(endpoint=validator_rpc_url, commitment=Processed, rate_limit=rate_limit) as client:
+    async with AsyncClient(
+        endpoint=validator_rpc_url, commitment=Processed, rate_limit=rate_limit
+    ) as client:
         start = monotonic()
-        responses = await asyncio.gather(*[client.get_slot() for _ in range(n_requests)])
+        responses = await asyncio.gather(
+            *[client.get_slot() for _ in range(n_requests)]
+        )
         elapsed = monotonic() - start
 
     for resp in responses:

--- a/tests/unit/test_async_client.py
+++ b/tests/unit/test_async_client.py
@@ -13,6 +13,7 @@ from solders.commitment_config import CommitmentLevel
 from solders.pubkey import Pubkey
 from solders.rpc.config import (
     RpcAccountInfoConfig,
+    RpcBlockConfig,
     RpcProgramAccountsConfig,
     RpcSignaturesForAddressConfig,
     RpcTokenAccountsFilterProgramId,
@@ -20,12 +21,14 @@ from solders.rpc.config import (
 from solders.rpc.filter import Memcmp
 from solders.rpc.requests import (
     GetAccountInfo,
+    GetBlock,
     GetMultipleAccounts,
     GetProgramAccounts,
     GetSignaturesForAddress,
     GetTokenAccountsByOwner,
 )
 from solders.signature import Signature
+from solders.transaction_status import TransactionDetails, UiTransactionEncoding
 
 from solana.constants import SYSTEM_PROGRAM_ID
 from solana._pydantic import PydanticModel
@@ -415,6 +418,29 @@ def test_get_account_info_body(unit_test_http_client_async):
         commitment=None,
         encoding="base64",
         data_slice=DataSliceOpts(offset=1, length=2),
+    )
+    assert expected == actual
+
+
+def test_get_block_body(unit_test_http_client_async):
+    """Test generating getBlock body with full block config."""
+    expected = GetBlock(
+        2,
+        RpcBlockConfig(
+            encoding=UiTransactionEncoding.Json,
+            transaction_details=TransactionDetails.Signatures,
+            rewards=False,
+            commitment=CommitmentLevel.Finalized,
+            max_supported_transaction_version=0,
+        ),
+    )
+    actual = unit_test_http_client_async._get_block_body(
+        slot=2,
+        encoding="json",
+        max_supported_transaction_version=0,
+        transaction_details=TransactionDetails.Signatures,
+        rewards=False,
+        commitment=Finalized,
     )
     assert expected == actual
 


### PR DESCRIPTION
This pull request enhances the Solana async RPC client by adding support for additional parameters to the `get_block` method, enabling more granular control over block queries. The changes update both the client implementation and its associated tests to handle new options such as transaction detail level, rewards inclusion, and commitment level.

**Enhancements to `get_block` API and configuration:**

* Added `transaction_details`, `rewards`, and `commitment` parameters to the `AsyncClient.get_block` method, allowing users to specify the level of transaction detail, whether to include rewards, and the bank state to query. 
* Updated the `_get_block_body` method in `core.py` to accept and correctly map these new parameters into the `RpcBlockConfig` used in the request.

**Dependency and import updates:**

* Imported `TransactionDetails` from `solders.transaction_status` in both `async_api.py` and `core.py` to support the new parameter. 

**Testing improvements:**

* Added a new unit test `test_get_block_body` to verify that the `get_block` request body is generated correctly when all new parameters are provided.
* Updated test imports to include new dependencies required for the enhanced block configuration.