### PR TITLE
Add third party packages section to docs and django-solana-payments library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,7 @@ stop-localnet:
 serve:
 	uv run mkdocs serve
 
+build-docs:
+	uv run mkdocs build --strict
+
 .PHONY: $(MAKECMDGOALS)

--- a/README.md
+++ b/README.md
@@ -139,3 +139,18 @@ make unit-tests
 # Integration tests only
 make int-tests
 ```
+
+
+### Documentation
+
+To build documentation from source files run:
+
+```sh
+make build-docs
+```
+
+To serve documentation locally run:
+
+```sh
+make serve
+```

--- a/docs/third-party-packages/django-solana-payments.md
+++ b/docs/third-party-packages/django-solana-payments.md
@@ -1,0 +1,21 @@
+# Django Solana Payments
+
+[`django-solana-payments`](https://django-solana-payments.readthedocs.io/) is a third-party Django application built on top of `solana-py`. It is useful when you need a self-hosted Solana payment flows inside a Django or Django REST Framework project and do not want to dive deep into Solana blockchain internals or low-level `solana-py` usage.
+
+## What It Provides
+
+- Transaction verification and automatic payment confirmation
+- Reusable frontend widget with QR code and crypto wallet connection
+- Support for SOL and SPL token payment flows
+- Customizable payment and token models
+- Django and Django REST Framework integration
+- Encryption support for one-time payment wallets
+
+## Related Use Cases
+
+This pattern allows you to integrate Solana payments into existing Django infrastructure as a reusable app.
+
+## Links
+
+- Documentation: [django-solana-payments.readthedocs.io](https://django-solana-payments.readthedocs.io/)
+- GitHub: [github.com/Artemooon/django-solana-payments](https://github.com/Artemooon/django-solana-payments)

--- a/docs/third-party-packages/index.md
+++ b/docs/third-party-packages/index.md
@@ -1,0 +1,7 @@
+# Third-Party Packages
+
+Examples of libraries and integrations built on top of `solana-py`.
+
+| Name | Description |
+| ---- | ----------- |
+| [Django Solana Payments](django-solana-payments.md) | Self-hosted Django payments with Solana verification and a reusable frontend widget |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,5 +103,9 @@ nav:
           - cookbook/wallet-management/verify-keypair.md
           - cookbook/wallet-management/validate-public-key.md
           - cookbook/wallet-management/sign-verify-message.md
+  - Third-Party Packages:
+      - third-party-packages/index.md
+      - Django Solana Payments:
+          - third-party-packages/django-solana-payments.md
 extra_css:
   - css/mkdocstrings.css


### PR DESCRIPTION
@michaelhly the idea of this PR is to add a new documentation section for third-party packages built on top of solana-py. I have added a library created by me that I personally use and it might be helpful for Django users who want to accept Solana payments without building the full integration on top of solana-py and dive into the solana blockchain internals

Also it can demonstrate the capabilities of solana-py and real example of its use in a production environment.

something similar to DRF packages - https://www.django-rest-framework.org/api-guide/authentication/#third-party-packages